### PR TITLE
Map targets to multiple interfaces and Migrations

### DIFF
--- a/openc3-cosmos-init/init.sh
+++ b/openc3-cosmos-init/init.sh
@@ -69,6 +69,10 @@ fi
 # Fail on errors
 set -e
 
+if [ -z "${OPENC3_NO_MIGRATE}" ]; then
+    ruby /openc3/bin/openc3cli runmigrations || exit 1
+fi
+
 if [ "${OPENC3_CLOUD}" == "local" ]; then
     ruby /openc3/bin/openc3cli initbuckets || exit 1
     mc alias set openc3minio "${OPENC3_BUCKET_URL}" ${OPENC3_BUCKET_USERNAME} ${OPENC3_BUCKET_PASSWORD} || exit 1

--- a/openc3/bin/openc3cli
+++ b/openc3/bin/openc3cli
@@ -29,6 +29,8 @@ require 'openc3/utilities/bucket'
 require 'openc3/models/scope_model'
 require 'openc3/models/plugin_model'
 require 'openc3/models/gem_model'
+require 'openc3/models/migration_model'
+require 'openc3/models/tool_model'
 require 'openc3/packets/packet_config'
 require 'openc3/bridge/bridge'
 require 'ostruct'
@@ -481,6 +483,40 @@ def get_redis_keys
   puts "Packets Defs: #{keys.select { |item| item[/^tlm__/] }}"
 end
 
+def run_migrations(folder)
+  # Determine if this is a brand new installation (no tools installed)
+  # We don't run migrations on new installations
+  tools = OpenC3::ToolModel.names(scope: 'DEFAULT')
+  if tools.length <= 0
+    puts "Brand new installation detected"
+    brand_new = true
+  else
+    puts "Checking for needed migrations..."
+    brand_new = false
+  end
+
+  # Run each newly discovered migration unless brand_new
+  folder = "/openc3/lib/openc3/migrations" unless folder
+  migrations = OpenC3::MigrationModel.all
+  entries = Dir.entries(folder).sort # run in alphabetical order
+  entries.each do |entry|
+    name = File.basename(entry)
+    extension = File.extname(name)
+    if extension == '.rb' and not migrations[name]
+      unless brand_new
+        puts "Running Migration: #{name}"
+        require File.join(folder, entry)
+      end
+      OpenC3::MigrationModel.new(name: name).create
+    end
+  end
+  if brand_new
+    puts "All migrations skipped"
+  else
+    puts "Migrations complete"
+  end
+end
+
 if __FILE__ == $0
   if not ARGV[0].nil? # argument(s) given
 
@@ -593,6 +629,9 @@ if __FILE__ == $0
       client.create(ENV['OPENC3_LOGS_BUCKET'])
       client.create(ENV['OPENC3_TOOLS_BUCKET'])
       client.ensure_public(ENV['OPENC3_TOOLS_BUCKET'])
+
+    when 'runmigrations'
+      run_migrations(ARGV[1])
 
     else # Unknown task
       print_usage()

--- a/openc3/data/config/interface_modifiers.yaml
+++ b/openc3/data/config/interface_modifiers.yaml
@@ -6,6 +6,20 @@ MAP_TARGET:
       required: true
       description: Target name to map to this interface
       values: .+
+MAP_CMD_TARGET:
+  summary: Maps a target name to an interface for commands only
+  parameters:
+    - name: Target Name
+      required: true
+      description: Command target name to map to this interface
+      values: .+
+MAP_TLM_TARGET:
+  summary: Maps a target name to an interface for telemetry only
+  parameters:
+    - name: Target Name
+      required: true
+      description: Telemetry target name to map to this interface
+      values: .+
 DONT_CONNECT:
   summary: Server will not automatically try to connect to the interface at startup
 DONT_RECONNECT:

--- a/openc3/lib/openc3/api/interface_api.rb
+++ b/openc3/lib/openc3/api/interface_api.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/models/interface_model'
@@ -125,7 +125,7 @@ module OpenC3
     #
     # @param target_name [String/Array] The name of the target(s)
     # @param interface_name (see #connect_interface)
-    def map_target_to_interface(target_name, interface_name, scope: $openc3_scope, token: $openc3_token)
+    def map_target_to_interface(target_name, interface_name, cmd_only: false, tlm_only: false, unmap_old: true, scope: $openc3_scope, token: $openc3_token)
       authorize(permission: 'system_set', interface_name: interface_name, scope: scope, token: token)
       new_interface = InterfaceModel.get_model(name: interface_name, scope: scope)
       if Array === target_name
@@ -134,7 +134,7 @@ module OpenC3
         target_names = [target_name]
       end
       target_names.each do |name|
-        new_interface.map_target(name)
+        new_interface.map_target(name, cmd_only: cmd_only, tlm_only: tlm_only, unmap_old: unmap_old)
         Logger.info("Target #{name} mapped to Interface #{interface_name}", scope: scope)
       end
       nil

--- a/openc3/lib/openc3/api/target_api.rb
+++ b/openc3/lib/openc3/api/target_api.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/models/target_model'
@@ -66,14 +66,13 @@ module OpenC3
         packets.each do |packet|
           tlm_cnt += Topic.get_cnt("#{scope}__TELEMETRY__{#{target_name}}__#{packet['packet_name']}")
         end
-        interface_name = ''
+        interface_names = []
         InterfaceModel.all(scope: scope).each do |name, interface|
           if interface['target_names'].include? target_name
-            interface_name = interface['name']
-            break
+            interface_names << interface['name']
           end
         end
-        info << [target_name, interface_name, cmd_cnt, tlm_cnt]
+        info << [target_name, interface_names.join(","), cmd_cnt, tlm_cnt]
       end
       info
     end

--- a/openc3/lib/openc3/interfaces/interface.rb
+++ b/openc3/lib/openc3/interfaces/interface.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/api/api'
@@ -37,6 +37,12 @@ module OpenC3
 
     # @return [Array<String>] Array of target names associated with this interface
     attr_accessor :target_names
+
+    # @return [Array<String>] Array of cmd target names associated with this interface
+    attr_accessor :cmd_target_names
+
+    # @return [Array<String>] Array of tlm target names associated with this interface
+    attr_accessor :tlm_target_names
 
     # @return [Boolean] Flag indicating if the interface should be connected
     #   to on startup
@@ -133,6 +139,8 @@ module OpenC3
       @name = self.class.to_s.split("::")[-1] # Remove namespacing if present
       @state = 'DISCONNECTED'
       @target_names = []
+      @cmd_target_names = []
+      @tlm_target_names = []
       @connect_on_startup = true
       @auto_reconnect = true
       @reconnect_delay = 5.0
@@ -381,6 +389,8 @@ module OpenC3
     def copy_to(other_interface)
       other_interface.name = self.name.clone
       other_interface.target_names = self.target_names.clone
+      other_interface.cmd_target_names = self.cmd_target_names.clone
+      other_interface.tlm_target_names = self.tlm_target_names.clone
       other_interface.connect_on_startup = self.connect_on_startup
       other_interface.auto_reconnect = self.auto_reconnect
       other_interface.reconnect_delay = self.reconnect_delay

--- a/openc3/lib/openc3/interfaces/protocols/fixed_protocol.rb
+++ b/openc3/lib/openc3/interfaces/protocols/fixed_protocol.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/config/config_parser'
@@ -77,7 +77,13 @@ module OpenC3
       packet_data = nil
       identified_packet = nil
 
-      @interface.target_names.each do |target_name|
+      if @telemetry
+        target_names = @interface.tlm_target_names
+      else
+        target_names = @interface.cmd_target_names
+      end
+
+      target_names.each do |target_name|
         target_packets = nil
         unique_id_mode = false
         begin

--- a/openc3/lib/openc3/interfaces/protocols/ignore_packet_protocol.rb
+++ b/openc3/lib/openc3/interfaces/protocols/ignore_packet_protocol.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/config/config_parser'
@@ -40,7 +40,7 @@ module OpenC3
     def read_packet(packet)
       # Need to make sure packet is identified and defined
       target_names = nil
-      target_names = @interface.target_names if @interface
+      target_names = @interface.tlm_target_names if @interface
       identified_packet = System.telemetry.identify_and_define_packet(packet, target_names)
       if identified_packet
         if identified_packet.target_name == @target_name && identified_packet.packet_name == @packet_name

--- a/openc3/lib/openc3/interfaces/protocols/override_protocol.rb
+++ b/openc3/lib/openc3/interfaces/protocols/override_protocol.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/interfaces/protocols/protocol'
@@ -41,7 +41,7 @@ module OpenC3
       if @interface.override_tlm && !@interface.override_tlm.empty?
         # Need to make sure packet is identified and defined
         target_names = nil
-        target_names = @interface.target_names if @interface
+        target_names = @interface.tlm_target_names if @interface
         identified_packet = System.telemetry.identify_and_define_packet(packet, target_names)
         if identified_packet
           packet = identified_packet

--- a/openc3/lib/openc3/interfaces/tcpip_server_interface.rb
+++ b/openc3/lib/openc3/interfaces/tcpip_server_interface.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'socket'
@@ -398,6 +398,8 @@ module OpenC3
 
       interface = StreamInterface.new
       interface.target_names = @target_names
+      interface.cmd_target_names = @cmd_target_names
+      interface.tlm_target_names = @tlm_target_names
       if @raw_logger_pair
         interface.raw_logger_pair = @raw_logger_pair.clone
         interface.raw_logger_pair.start if @raw_logging_enabled

--- a/openc3/lib/openc3/microservices/router_microservice.rb
+++ b/openc3/lib/openc3/microservices/router_microservice.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/microservices/interface_microservice'
@@ -29,12 +29,12 @@ module OpenC3
       RouterStatusModel.set(@interface.as_json(:allow_nan => true), scope: @scope)
       if !packet.identified?
         # Need to identify so we can find the target
-        identified_packet = System.commands.identify(packet.buffer(false), @target_names)
+        identified_packet = System.commands.identify(packet.buffer(false), @cmd_target_names)
         packet = identified_packet if identified_packet
       end
 
       begin
-        RouterTopic.route_command(packet, @target_names, scope: @scope)
+        RouterTopic.route_command(packet, @cmd_target_names, scope: @scope)
         @count += 1
       rescue Exception => err
         @error = err

--- a/openc3/lib/openc3/migrations/20221202214600_add_target_names.rb
+++ b/openc3/lib/openc3/migrations/20221202214600_add_target_names.rb
@@ -1,0 +1,29 @@
+require 'openc3/utilities/migration'
+
+module OpenC3
+  class AddTargetNames < Migration
+    def self.run
+      ScopeModel.names.each do |scope|
+        # Get all existing InterfaceModels and add cmd_target_names / tlm_target_names if necessary
+        interface_models = InterfaceModel.all(scope: scope)
+        interface_models.each do |key, model_hash|
+          target_names = model_hash['target_names']
+          model_hash['cmd_target_names'] = target_names unless model_hash['cmd_target_names']
+          model_hash['tlm_target_names'] = target_names unless model_hash['tlm_target_names']
+          InterfaceModel.from_json(model_hash, scope: scope).update
+        end
+        router_models = RouterModel.all(scope: scope)
+        router_models.each do |key, model_hash|
+          target_names = model_hash['target_names']
+          model_hash['cmd_target_names'] = target_names unless model_hash['cmd_target_names']
+          model_hash['tlm_target_names'] = target_names unless model_hash['tlm_target_names']
+          RouterModel.from_json(model_hash, scope: scope).update
+        end
+      end
+    end
+  end
+end
+
+unless ENV['OPENC3_NO_MIGRATE']
+  OpenC3::AddTargetNames.run
+end

--- a/openc3/lib/openc3/models/microservice_model.rb
+++ b/openc3/lib/openc3/models/microservice_model.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/top_level'
@@ -134,29 +134,6 @@ module OpenC3
         'plugin' => @plugin,
         'needs_dependencies' => @needs_dependencies,
       }
-    end
-
-    def as_config
-      result = "MICROSERVICE #{@folder_name ? @folder_name : 'nil'} #{@name.split("__")[-1]}\n"
-      result << "  CMD #{@cmd.join(' ')}\n"
-      result << "  WORK_DIR \"#{@work_dir}\"\n"
-      @ports.each do |port|
-        result << "  PORT #{port}\n"
-      end
-      @topics.each do |topic_name|
-        result << "  TOPIC #{topic_name}\n"
-      end
-      @target_names.each do |target_name|
-        result << "  TARGET_NAME #{target_name}\n"
-      end
-      @env.each do |key, value|
-        result << "  ENV #{key} \"#{value}\"\n"
-      end
-      @options.each do |option|
-        result << "  OPTION #{option.join(" ")}\n"
-      end
-      result << "  CONTAINER #{@container}\n" if @container != 'openc3-base'
-      result
     end
 
     def handle_config(parser, keyword, parameters)

--- a/openc3/lib/openc3/models/migration_model.rb
+++ b/openc3/lib/openc3/models/migration_model.rb
@@ -1,0 +1,52 @@
+# encoding: ascii-8bit
+
+# Copyright 2022 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require 'openc3/models/model'
+
+module OpenC3
+  class MigrationModel < Model
+    PRIMARY_KEY = 'openc3__migrations'
+
+    # NOTE: The following three class methods are used by the ModelController
+    # and are reimplemented to enable various Model class methods to work
+    def self.get(name:, scope: nil)
+      super(PRIMARY_KEY, name: name)
+    end
+
+    def self.names(scope: nil)
+      super(PRIMARY_KEY)
+    end
+
+    def self.all(scope: nil)
+      super(PRIMARY_KEY)
+    end
+    # END NOTE
+
+    def initialize(name:)
+      super(PRIMARY_KEY, name: name)
+    end
+
+    # @return [Hash] JSON encoding of this model
+    def as_json(*a)
+      {
+        'name' => @name,
+        'updated_at' => @updated_at
+      }
+    end
+  end
+end

--- a/openc3/lib/openc3/models/model.rb
+++ b/openc3/lib/openc3/models/model.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/utilities/store'
@@ -191,11 +191,6 @@ module OpenC3
         'updated_at' => @updated_at,
         'plugin' => @plugin,
         'scope' => @scope }
-    end
-
-    # TODO: Not currently used but may be used by a XTCE or other format to OpenC3 conversion
-    def as_config
-      ""
     end
   end
 

--- a/openc3/lib/openc3/models/target_model.rb
+++ b/openc3/lib/openc3/models/target_model.rb
@@ -385,10 +385,6 @@ module OpenC3
       }
     end
 
-    def as_config
-      "TARGET #{@folder_name} #{@name}\n"
-    end
-
     # Handles Target specific configuration keywords
     def handle_config(parser, keyword, parameters)
       case keyword

--- a/openc3/lib/openc3/models/tool_model.rb
+++ b/openc3/lib/openc3/models/tool_model.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/models/model'
@@ -173,17 +173,6 @@ module OpenC3
         'plugin' => @plugin,
         'needs_dependencies' => @needs_dependencies,
       }
-    end
-
-    def as_config
-      result = "TOOL #{@folder_name ? @folder_name : 'nil'} \"#{@name}\"\n"
-      result << "  URL #{@url}\n" if @url
-      result << "  INLINE_URL #{@inline_url}\n" if @inline_url
-      result << "  ICON #{@icon}\n" if @icon
-      result << "  WINDOW #{@window}\n" unless @window == 'INLINE'
-      result << "  CATEGORY #{@category}\n" if @category
-      result << "  SHOWN false\n" unless @shown
-      result
     end
 
     def handle_config(parser, keyword, parameters)

--- a/openc3/lib/openc3/models/widget_model.rb
+++ b/openc3/lib/openc3/models/widget_model.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/top_level'
@@ -101,11 +101,6 @@ module OpenC3
         'plugin' => @plugin,
         'needs_dependencies' => @needs_dependencies,
       }
-    end
-
-    def as_config
-      result = "WIDGET \"#{@name}\"\n"
-      result
     end
 
     def handle_config(parser, keyword, parameters)

--- a/openc3/lib/openc3/tools/cmd_tlm_server/interface_thread.rb
+++ b/openc3/lib/openc3/tools/cmd_tlm_server/interface_thread.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 module OpenC3
@@ -153,7 +153,7 @@ module OpenC3
     def handle_packet(packet)
       if packet.stored
         # Stored telemetry does not update the current value table
-        identified_packet = System.telemetry.identify_and_define_packet(packet, @interface.target_names)
+        identified_packet = System.telemetry.identify_and_define_packet(packet, @interface.tlm_target_names)
       else
         # Identify and update packet
         if packet.identified?
@@ -169,12 +169,12 @@ module OpenC3
             packet.target_name = nil
             packet.packet_name = nil
             identified_packet = System.telemetry.identify!(packet.buffer,
-                                                           @interface.target_names)
+                                                           @interface.tlm_target_names)
           end
         else
           # Packet needs to be identified
           identified_packet = System.telemetry.identify!(packet.buffer,
-                                                         @interface.target_names)
+                                                         @interface.tlm_target_names)
         end
       end
 

--- a/openc3/lib/openc3/topics/interface_topic.rb
+++ b/openc3/lib/openc3/topics/interface_topic.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'openc3/topics/topic'
@@ -29,7 +29,7 @@ module OpenC3
     def self.topics(interface, scope:)
       topics = []
       topics << "{#{scope}__CMD}INTERFACE__#{interface.name}"
-      interface.target_names.each do |target_name|
+      interface.cmd_target_names.each do |target_name|
         topics << "{#{scope}__CMD}TARGET__#{target_name}"
       end
       topics

--- a/openc3/lib/openc3/topics/router_topic.rb
+++ b/openc3/lib/openc3/topics/router_topic.rb
@@ -29,7 +29,7 @@ module OpenC3
     def self.topics(router, scope:)
       topics = []
       topics << "{#{scope}__CMD}ROUTER__#{router.name}"
-      router.target_names.each do |target_name|
+      router.tlm_target_names.each do |target_name|
         System.telemetry.packets(target_name).each do |packet_name, packet|
           topics << "#{scope}__TELEMETRY__{#{packet.target_name}}__#{packet.packet_name}"
         end

--- a/openc3/lib/openc3/utilities/migration.rb
+++ b/openc3/lib/openc3/utilities/migration.rb
@@ -1,0 +1,22 @@
+# encoding: ascii-8bit
+
+# Copyright 2022 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+module OpenC3
+  class Migration
+  end
+end

--- a/openc3/spec/api/cmd_api_spec.rb
+++ b/openc3/spec/api/cmd_api_spec.rb
@@ -42,7 +42,7 @@ module OpenC3
       model = TargetModel.new(folder_name: 'INST', name: 'INST', scope: "DEFAULT")
       model.create
       model.update_store(System.new(['INST'], File.join(SPEC_DIR, 'install', 'config', 'targets')))
-      model = InterfaceModel.new(name: "INST_INT", scope: "DEFAULT", target_names: ["INST"], config_params: ["interface.rb"])
+      model = InterfaceModel.new(name: "INST_INT", scope: "DEFAULT", target_names: ["INST"], cmd_target_names: ["INST"], tlm_target_names: ["INST"], config_params: ["interface.rb"])
       model.create
       model = InterfaceStatusModel.new(name: "INST_INT", scope: "DEFAULT", state: "ACTIVE")
       model.create
@@ -53,6 +53,9 @@ module OpenC3
       @interface = Interface.new
       @interface.name = "INST_INT"
       @interface.target_names = %w[INST]
+      @interface.cmd_target_names = %w[INST]
+      @interface.tlm_target_names = %w[INST]
+
       # Stub to make the InterfaceCmdHandlerThread happy
       @interface_data = ''
       allow(@interface).to receive(:connected?).and_return(true)

--- a/openc3/spec/interfaces/protocols/fixed_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/fixed_protocol_spec.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
@@ -72,6 +72,8 @@ module OpenC3
         @interface.add_protocol(FixedProtocol, [1], :READ)
         @interface.instance_variable_set(:@stream, FixedStream.new)
         @interface.target_names = ['SYSTEM']
+        @interface.cmd_target_names = ['SYSTEM']
+        @interface.tlm_target_names = ['SYSTEM']
         # Initialize the read with a packet identified as SYSTEM META
         $index = 1
         packet = @interface.read
@@ -92,6 +94,8 @@ module OpenC3
         @interface.add_protocol(FixedProtocol, [1, 0, nil, true, false, true], :READ)
         @interface.instance_variable_set(:@stream, FixedStream.new)
         @interface.target_names = ['SYSTEM']
+        @interface.cmd_target_names = ['SYSTEM']
+        @interface.tlm_target_names = ['SYSTEM']
         expect { @interface.read }.to raise_error(/Unknown data/)
       end
 
@@ -99,6 +103,8 @@ module OpenC3
         @interface.add_protocol(FixedProtocol, [1], :READ)
         @interface.instance_variable_set(:@stream, FixedStream.new)
         @interface.target_names = ['EMPTY']
+        @interface.cmd_target_names = ['EMPTY']
+        @interface.tlm_target_names = ['EMPTY']
         $index = 1
         packet = @interface.read
         expect(packet.received_time.to_f).to eql 0.0
@@ -112,6 +118,8 @@ module OpenC3
         @interface.add_protocol(FixedProtocol, [1], :READ_WRITE)
         @interface.instance_variable_set(:@stream, FixedStream.new)
         @interface.target_names = ['SYSTEM']
+        @interface.cmd_target_names = ['SYSTEM']
+        @interface.tlm_target_names = ['SYSTEM']
         $index = 1
         packet = @interface.read
         expect(packet.received_time.to_f).to be_within(0.1).of(Time.now.to_f)
@@ -155,6 +163,8 @@ module OpenC3
         @interface.add_protocol(FixedProtocol, [8, 6, '0x1ACFFC1D', false], :READ_WRITE)
         @interface.instance_variable_set(:@stream, FixedStream2.new)
         @interface.target_names = ['SYSTEM']
+        @interface.cmd_target_names = ['SYSTEM']
+        @interface.tlm_target_names = ['SYSTEM']
         target.cmd_unique_id_mode = false
         packet = @interface.read
         expect(packet.received_time.to_f).to be_within(0.01).of(Time.now.to_f)

--- a/openc3/spec/interfaces/protocols/ignore_packet_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/ignore_packet_protocol_spec.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
@@ -35,6 +35,8 @@ module OpenC3
       $buffer = nil
       @interface = StreamInterface.new
       @interface.target_names = ['SYSTEM', 'INST']
+      @interface.cmd_target_names = ['SYSTEM', 'INST']
+      @interface.tlm_target_names = ['SYSTEM', 'INST']
       allow(@interface).to receive(:connected?) { true }
     end
 

--- a/openc3/spec/microservices/interface_microservice_spec.rb
+++ b/openc3/spec/microservices/interface_microservice_spec.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
@@ -81,7 +81,7 @@ module OpenC3
       allow(@interface).to receive(:connected?).and_return(true)
       allow(System).to receive(:targets).and_return({ "INST" => @interface })
 
-      model = InterfaceModel.new(name: "INST_INT", scope: "DEFAULT", target_names: ["INST"], config_params: ["TestInterface"])
+      model = InterfaceModel.new(name: "INST_INT", scope: "DEFAULT", target_names: ["INST"], cmd_target_names: ["INST"], tlm_target_names: ["INST"], config_params: ["TestInterface"])
       model.create
       model = MicroserviceModel.new(folder_name: "INST", name: "DEFAULT__INTERFACE__INST_INT", scope: "DEFAULT", target_names: ["INST"])
       model.create
@@ -121,6 +121,8 @@ module OpenC3
         expect(interface.name).to eql "INST_INT"
         expect(interface.state).to eql "ATTEMPTING"
         expect(interface.target_names).to eql ["INST"]
+        expect(interface.cmd_target_names).to eql ["INST"]
+        expect(interface.tlm_target_names).to eql ["INST"]
         all = InterfaceStatusModel.all(scope: "DEFAULT")
         expect(all["INST_INT"]["name"]).to eql "INST_INT"
         expect(all["INST_INT"]["state"]).to eql "ATTEMPTING"

--- a/openc3/spec/microservices/router_microservice_spec.rb
+++ b/openc3/spec/microservices/router_microservice_spec.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
@@ -83,7 +83,7 @@ module OpenC3
       allow(interface).to receive(:connected?).and_return(true)
       allow(System).to receive(:targets).and_return({ "TEST" => interface })
       allow(System).to receive_message_chain("telemetry.packets") { [["PKT", Packet.new("TEST", "PKT")]] }
-      model = RouterModel.new(name: "TEST_INT", scope: "DEFAULT", target_names: ["TEST"], config_params: ["TestInterface"])
+      model = RouterModel.new(name: "TEST_INT", scope: "DEFAULT", target_names: ["TEST"], cmd_target_names: ["TEST"], tlm_target_names: ["TEST"], config_params: ["TestInterface"])
       model.create
       model = MicroserviceModel.new(folder_name: "TEST", name: "DEFAULT__ROUTER__TEST_INT", scope: "DEFAULT", target_names: ["TEST"])
       model.create
@@ -107,6 +107,8 @@ module OpenC3
         expect(interface.name).to eql "TEST_INT"
         expect(interface.state).to eql "ATTEMPTING"
         expect(interface.target_names).to eql ["TEST"]
+        expect(interface.cmd_target_names).to eql ["TEST"]
+        expect(interface.tlm_target_names).to eql ["TEST"]
         all = RouterStatusModel.all(scope: "DEFAULT")
         expect(all["TEST_INT"]["name"]).to eql "TEST_INT"
         expect(all["TEST_INT"]["state"]).to eql "ATTEMPTING"

--- a/openc3/spec/models/microservice_model_spec.rb
+++ b/openc3/spec/models/microservice_model_spec.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
@@ -134,13 +134,6 @@ module OpenC3
 
           expect(json.key?(name.to_s)).to be true
         end
-      end
-    end
-
-    describe "as_config" do
-      it "exports model as OpenC3 configuration" do
-        model = MicroserviceModel.new(folder_name: "TEST", name: "DEFAULT__TYPE__NAME", scope: "DEFAULT")
-        expect(model.as_config).to match(/MICROSERVICE TEST NAME/)
       end
     end
 

--- a/openc3/spec/models/target_model_spec.rb
+++ b/openc3/spec/models/target_model_spec.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
@@ -369,15 +369,6 @@ module OpenC3
 
           expect(json.key?(name.to_s)).to be true
         end
-      end
-    end
-
-    describe "as_config" do
-      it "exports model as OpenC3 configuration" do
-        model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
-        expect(model.as_config).to match(/TARGET TEST/)
-        model = TargetModel.new(folder_name: "TEST", name: "TEST2", scope: "DEFAULT")
-        expect(model.as_config).to match(/TARGET TEST TEST2/)
       end
     end
 

--- a/openc3/spec/models/tool_model_spec.rb
+++ b/openc3/spec/models/tool_model_spec.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
@@ -126,15 +126,6 @@ module OpenC3
 
           expect(json.key?(name.to_s)).to be true
         end
-      end
-    end
-
-    describe "as_config" do
-      it "exports tool as OpenC3 configuration" do
-        model = ToolModel.new(folder_name: "FOLDER", name: "TEST", scope: "DEFAULT")
-        expect(model.as_config).to match(/TOOL FOLDER "TEST"/)
-        model = ToolModel.new(name: "TEST2", scope: "DEFAULT")
-        expect(model.as_config).to match(/TOOL nil "TEST2"/)
       end
     end
 

--- a/openc3/spec/script/commands_spec.rb
+++ b/openc3/spec/script/commands_spec.rb
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
@@ -62,7 +62,7 @@ module OpenC3
         model = TargetModel.new(folder_name: 'INST', name: 'INST', scope: "DEFAULT")
         model.create
         model.update_store(System.new(['INST'], File.join(SPEC_DIR, 'install', 'config', 'targets')))
-        model = InterfaceModel.new(name: "INST_INT", scope: "DEFAULT", target_names: ["INST"], config_params: ["interface.rb"])
+        model = InterfaceModel.new(name: "INST_INT", scope: "DEFAULT", target_names: ["INST"], cmd_target_names: ["INST"], tlm_target_names: ["INST"],config_params: ["interface.rb"])
         model.create
         model = InterfaceStatusModel.new(name: "INST_INT", scope: "DEFAULT", state: "ACTIVE")
         model.create
@@ -73,6 +73,8 @@ module OpenC3
         @interface = Interface.new
         @interface.name = "INST_INT"
         @interface.target_names = %w[INST]
+        @interface.cmd_target_names = %w[INST]
+        @interface.tlm_target_names = %w[INST]
         # Stub to make the InterfaceCmdHandlerThread happy
         @interface_data = ''
         allow(@interface).to receive(:connected?).and_return(true)


### PR DESCRIPTION
Map targets to multiple interfaces
Migrations. 
Sync Control Code support. 
Remove as_config from models.