### PR TITLE
Add optional flag to return object metadata

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/storage_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/storage_controller.rb
@@ -40,7 +40,9 @@ class StorageController < ApplicationController
     bucket_name = ENV[params[:bucket]] # Get the actual bucket name
     path = params[:path]
     path = '/' if path.nil? || path.empty?
-    results = bucket.list_files(bucket: bucket_name, path: path)
+    # if user wants metadata returned
+    include_head = params[:include_head].present? ? true : false
+    results = bucket.list_files(bucket: bucket_name, path: path, include_head: include_head)
     render :json => results, :status => 200
   rescue OpenC3::Bucket::NotFound => error
     render :json => { :status => 'error', :message => error.message }, :status => 404

--- a/openc3/lib/openc3/utilities/aws_bucket.rb
+++ b/openc3/lib/openc3/utilities/aws_bucket.rb
@@ -124,7 +124,7 @@ module OpenC3
     end
 
     # Lists the files under a specified path
-    def list_files(bucket:, path:, only_directories: false)
+    def list_files(bucket:, path:, only_directories: false, include_head: false)
       # Trailing slash is important in AWS S3 when listing files
       # See https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Types/ListObjectsV2Output.html#common_prefixes-instance_method
       if path[-1] != '/'
@@ -158,6 +158,9 @@ module OpenC3
             item['name'] = aws_item.key.split('/')[-1]
             item['modified'] = aws_item.last_modified
             item['size'] = aws_item.size
+            if include_head
+              item['head'] = head_object(bucket: bucket, key: aws_item.key)
+            end
             files << item
           end
           result = [dirs, files]
@@ -168,6 +171,14 @@ module OpenC3
       result
     rescue Aws::S3::Errors::NoSuchBucket => error
       raise NotFound, "Bucket '#{bucket}' does not exist."
+    end
+
+    # get metadata for a specific object
+    def head_object(bucket:, key:)
+      head = @client.head_object({
+        bucket: bucket,
+        key: key
+      })
     end
 
     # put_object fires off the request to store but does not confirm

--- a/openc3/lib/openc3/utilities/aws_bucket.rb
+++ b/openc3/lib/openc3/utilities/aws_bucket.rb
@@ -179,6 +179,8 @@ module OpenC3
         bucket: bucket,
         key: key
       })
+    rescue Aws::S3::Errors::NotFound => error
+      raise NotFound, "Object: #{bucket}/#{key}"
     end
 
     # put_object fires off the request to store but does not confirm


### PR DESCRIPTION
#496 Add an optional flag to `list_files`  to return metadata for an object.