### PR TITLE
Validate built gem

### DIFF
--- a/openc3/templates/plugin/Rakefile
+++ b/openc3/templates/plugin/Rakefile
@@ -9,4 +9,10 @@ end
 
 task :build => [:require_version] do
   system("gem build #{PLUGIN_NAME}")
+  _, platform, *_ = RUBY_PLATFORM.split("-")
+  if platform == 'mswin32' or platform == 'mingw32'
+    system("openc3.bat cli validate *.gem")
+  else
+    system("openc3.sh cli validate *.gem")
+  end
 end


### PR DESCRIPTION
Not sure if this is the best way to do this but seems like we can call validate using the cli in the Rakefile. This worked when I ran it on a regular project but obviously you'd have to have those scripts in your path. I tried it in the demo project and got this: `Error: You don't have write permissions for the /usr/lib/ruby/gems/3.1.0 directory.`
