### PR TITLE
Small Patches to Help with the Local Workflow

### DIFF
--- a/openc3-cosmos-init/init.sh
+++ b/openc3-cosmos-init/init.sh
@@ -101,7 +101,9 @@ if [ "${OPENC3_CLOUD}" == "local" ]; then
     # Create a new user scriptrunner on MinIO use mc admin user.
     mc admin user add openc3minio ${OPENC3_SR_BUCKET_USERNAME} ${OPENC3_SR_BUCKET_PASSWORD} || exit 1
     # Once the user is successfully created you can now apply the getonly policy for this user.
-    mc admin policy attach openc3minio script --user=${OPENC3_SR_BUCKET_USERNAME} || exit 1
+    # "|| true" is required on subsequent startups due to the following error that is thrown:
+    # mc: <ERROR> Unable to make user/group policy association. The specified policy change is already in effect. (Specified policy update has no net effect).
+    mc admin policy attach openc3minio script --user=${OPENC3_SR_BUCKET_USERNAME} || true
 fi
 
 ruby /openc3/bin/openc3cli removeenterprise || exit 1

--- a/openc3/Rakefile
+++ b/openc3/Rakefile
@@ -84,7 +84,7 @@ task :build => [:devkit] do
   end
 end
 
-task :gems => [:build] do
+task :gems do
   _, platform, *_ = RUBY_PLATFORM.split("-")
   if platform == 'mswin32' or platform == 'mingw32'
     raise "Building gem is not supported on Windows because file permissions are lost"

--- a/openc3/Rakefile
+++ b/openc3/Rakefile
@@ -17,7 +17,7 @@
 # All changes Copyright 2022, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'open3'
@@ -84,7 +84,7 @@ task :build => [:devkit] do
   end
 end
 
-task :gems do
+task :gems => [:build] do
   _, platform, *_ = RUBY_PLATFORM.split("-")
   if platform == 'mswin32' or platform == 'mingw32'
     raise "Building gem is not supported on Windows because file permissions are lost"


### PR DESCRIPTION
This is a small commit to fix some issues that were encountered when running Cosmos locally.
* Fixes included:
  * The new updates to `minio/mc` have caused a different behavior when applying the policy so that it will fail if the specified policy is already in effect. The small patch just allows it to fail and move on.
  * I have made the `:build` task a prerequisite to the `:gems` tasks. Without the `:build` task the generated gem doesn't include all the necessary library files that are generated by `make`. If you set `OPENC3_DEVEL` or `OPENC3_PATH` to `/openc3` in the Dockerfile for both the `openc3-cosmos-cmd-tlm-api` and the `openc3-cosmos-script-runner-api` it will throw errors about not being able to find these library files.