### PR TITLE
Add OPENC3_IMAGE_SUFFIX to the cli and cliroot Calls

### DIFF
--- a/openc3.sh
+++ b/openc3.sh
@@ -65,7 +65,7 @@ case $1 in
     args=`echo $@ | { read _ args; echo $args; }`
     # Make sure the network exists
     (docker network create openc3-cosmos-network || true) &> /dev/null
-    docker run -it --rm --env-file "$(dirname -- "$0")/.env" --user=$OPENC3_USER_ID:$OPENC3_GROUP_ID --network openc3-cosmos-network -v `pwd`:/openc3/local:z -w /openc3/local $OPENC3_REGISTRY/$OPENC3_NAMESPACE/openc3-operator:$OPENC3_TAG ruby /openc3/bin/openc3cli $args
+    docker run -it --rm --env-file "$(dirname -- "$0")/.env" --user=$OPENC3_USER_ID:$OPENC3_GROUP_ID --network openc3-cosmos-network -v `pwd`:/openc3/local:z -w /openc3/local $OPENC3_REGISTRY/$OPENC3_NAMESPACE/openc3-operator$OPENC3_IMAGE_SUFFIX:$OPENC3_TAG ruby /openc3/bin/openc3cli $args
     set +a
     ;;
   cliroot )
@@ -73,7 +73,7 @@ case $1 in
     . "$(dirname -- "$0")/.env"
     args=`echo $@ | { read _ args; echo $args; }`
     (docker network create openc3-cosmos-network || true) &> /dev/null
-    docker run -it --rm --env-file "$(dirname -- "$0")/.env" --user=root --network openc3-cosmos-network -v `pwd`:/openc3/local:z -w /openc3/local $OPENC3_REGISTRY/$OPENC3_NAMESPACE/openc3-operator:$OPENC3_TAG ruby /openc3/bin/openc3cli $args
+    docker run -it --rm --env-file "$(dirname -- "$0")/.env" --user=root --network openc3-cosmos-network -v `pwd`:/openc3/local:z -w /openc3/local $OPENC3_REGISTRY/$OPENC3_NAMESPACE/openc3-operator$OPENC3_IMAGE_SUFFIX:$OPENC3_TAG ruby /openc3/bin/openc3cli $args
     set +a
     ;;
   start )


### PR DESCRIPTION
If building and running with `build-ubi` and `start-ubi` the images are subject to the `OPENC3_IMAGE_SUFFIX`. This adds the suffix to the `cli` and `cliroot` calls that will point it to the correct image.