### PR TITLE
Map fatal to critical

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/components/icons/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/components/icons/index.js
@@ -63,8 +63,8 @@ const AstroIconLibrary = [
 ]
 
 const UnknownToAstroStatus = {
-  fatal: 'fatal',
-  FATAL: 'fatal',
+  fatal: 'critical',
+  FATAL: 'critical',
   error: 'critical',
   ERROR: 'critical',
   warn: 'caution',


### PR DESCRIPTION
Since we're using the rux-status web component we must map to known astro status values.

closes #1014 