### PR TITLE
Handle 404 errors in Script Runner

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/components/FileOpenSaveDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/components/FileOpenSaveDialog.vue
@@ -306,6 +306,7 @@ export default {
           return Api.delete('/script-api/scripts/temp_files')
         })
         .then((response) => {
+          this.$emit('clear-temp')
           this.loadFiles()
         })
         .catch((error) => {

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/services/axios.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/services/axios.js
@@ -41,19 +41,21 @@ axiosInstance.interceptors.response.use(
             if (refreshed) {
               OpenC3Auth.setTokens()
             }
-          }
+          },
         )
       }
       // Individual tools can set 'Ignore-Errors' to an error code
       // they potentially expect, e.g. '500', in which case we ignore it
       // For example in CommandSender.vue:
       // obs = this.api.cmd(targetName, commandName, paramList, {
-      //   'Ignore-Errors': '500',
+      //   headers: {
+      //     'Ignore-Errors': '404',
+      //   },
       // })
       if (
-        error.response.headers['ignore-errors'] &&
-        error.response.headers['ignore-errors'].includes(
-          error.response.status.toString()
+        error.response.config.headers['Ignore-Errors'] &&
+        error.response.config.headers['Ignore-Errors'].includes(
+          error.response.status.toString(),
         )
       ) {
         return Promise.reject(error)
@@ -87,7 +89,7 @@ axiosInstance.interceptors.response.use(
     } else {
       throw error
     }
-  }
+  },
 )
 
 export default axiosInstance


### PR DESCRIPTION
This handles a file being deleted out from under you silently rather than popping a 404 error. I'm also cleaning up the recently used which I wasn't even handling before. If you access the file from the recently used it still pops up a warning but then removes the file from the recents.