### PR TITLE
Clear SR file cache when stopped

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/ScriptRunner.vue
@@ -1366,6 +1366,7 @@ export default {
       this.fatal = false
       this.scriptId = null
       this.currentFilename = null
+      this.files = {} // Clear the file cache
       // We may have changed the contents (if there were sub-scripts)
       // so don't let the undo manager think this is a chanage
       this.editor.session.getUndoManager().reset()
@@ -1460,10 +1461,10 @@ export default {
               this.files[data.filename] = null
             })
         } else {
+          this.currentFilename = data.filename
           this.editor.setValue(this.files[data.filename].content)
           this.restoreBreakpoints(data.filename)
           this.editor.clearSelection()
-          this.currentFilename = data.filename
         }
       }
       this.state = data.state


### PR DESCRIPTION
Definitely a bug when you run a script and then try to click the drop down and choose another file. This causes the editor to detect a change and the filename gets changed to the original with a *. At that point if you run or click save you will overwrite. But the process is pretty manual in that you have to select a file from that drop down.

I kind of liked the ability to see the files that we drilled into during the test but I couldn't figure out a way to disable the change callback during this change.