### PR TITLE
Support item names with brackets

### DIFF
--- a/openc3/lib/openc3/packets/json_packet.rb
+++ b/openc3/lib/openc3/packets/json_packet.rb
@@ -67,7 +67,9 @@ module OpenC3
     def read(name, value_type = :CONVERTED, reduced_type = nil)
       value = nil
       array_index = nil
-      if name[-1] == ']'
+      # Check for array index to handle array items but also make sure there
+      # isn't a REAL item that has brackets in the name
+      if name[-1] == ']' and !@json_hash.include?(name)
         open_bracket_index = name.index('[')
         if open_bracket_index
           array_index = name[(open_bracket_index + 1)..-2].to_i
@@ -212,12 +214,12 @@ module OpenC3
         else
           postfix = nil if value_type == :RAW
         end
-        @json_hash.each do |key, value|
+        @json_hash.each do |key, _value|
           key_split = key.split("__")
           result[key_split[0]] = true if key_split[1] == postfix
         end
       else
-        @json_hash.each { |key, value| result[key.split("__")[0]] = true }
+        @json_hash.each { |key, _value| result[key.split("__")[0]] = true }
       end
       return result.keys
     end

--- a/openc3/spec/install/config/targets/INST/cmd_tlm/inst_tlm.txt
+++ b/openc3/spec/install/config/targets/INST/cmd_tlm/inst_tlm.txt
@@ -231,3 +231,4 @@ TELEMETRY INST HIDDEN BIG_ENDIAN "Hidden"
   ITEM TIMEUS            80 32 UINT     "Microseconds of second"
   ID_ITEM PKTID         112 16 UINT   1 "Packet id (The combination of CCSDS_APID and PACKET_ID identify the packet)"
   APPEND_ITEM COUNT 16 UINT
+  APPEND_ITEM BRACKET[0] 16 UINT

--- a/openc3/spec/packets/json_packet_spec.rb
+++ b/openc3/spec/packets/json_packet_spec.rb
@@ -51,8 +51,8 @@ module OpenC3
         time = Time.now
         p = JsonPacket.new(:TLM, "INST", "HEALTH_STATUS", time.to_nsec_from_epoch, false, json_data)
         expect(p.read("TEMP1", :RAW)).to eql 0
-        expect(p.read("TEMP1", :CONVERTED)).to eql -100.0
-        expect(p.read("TEMP1")).to eql -100.0
+        expect(p.read("TEMP1", :CONVERTED)).to eql(-100.0)
+        expect(p.read("TEMP1")).to eql(-100.0)
         expect(p.read("TEMP1", :FORMATTED)).to eql '-100.000'
         expect(p.read("TEMP1", :WITH_UNITS)).to eql '-100.000 C'
       end
@@ -79,7 +79,7 @@ module OpenC3
         expect(p.read("TEMP1", :RAW, :MAX)).to eql 65535
         expect(p.read("TEMP1", :CONVERTED, :AVG)).to eql 0
         expect(p.read("TEMP1", :CONVERTED, :STDDEV)).to eql 0.1
-        expect(p.read("TEMP1", :CONVERTED, :MIN)).to eql -100.0
+        expect(p.read("TEMP1", :CONVERTED, :MIN)).to eql(-100.0)
         expect(p.read("TEMP1", :CONVERTED, :MAX)).to eql 100.0
         expect { p.read("TEMP1", :FORMATTED, :AVG) }.to raise_error(/Reduced types only support RAW or CONVERTED/)
         expect { p.read("TEMP1", :WITH_UNITS, :AVG) }.to raise_error(/Reduced types only support RAW or CONVERTED/)
@@ -124,6 +124,17 @@ module OpenC3
           expect(p.read("ARY[#{i}]", :FORMATTED)).to eql i.to_s
           expect(p.read("ARY[#{i}]", :WITH_UNITS)).to eql "#{i} V"
         end
+      end
+
+      it "reads items with brackets in the name" do
+        pkt = System.telemetry.packet("INST", "HIDDEN")
+        pkt.write("BRACKET[0]", 0xABCD)
+        json_hash = CvtModel.build_json_from_packet(pkt)
+        json_data = JSON.generate(json_hash.as_json(:allow_nan => true))
+        time = Time.now
+        p = JsonPacket.new(:TLM, "INST", "HIDDEN", time.to_nsec_from_epoch, false, json_data)
+        expect(p.read("BRACKET[0]", :RAW)).to eql 0xABCD
+        expect(p.read("BRACKET[0]", :CONVERTED)).to eql 0xABCD
       end
 
       it "returns nil if the value does not exist" do


### PR DESCRIPTION
#933 added support for graphing telemetry items. This relied on syntax which used brackets '[]' to determine that an array item was requested. This broke normal items with brackets from working, e.g. 'MYTLM[1]'.