### PR TITLE
Removed version tag from compose.yaml, compose-dev.yaml, and compose-…

### DIFF
--- a/compose-build.yaml
+++ b/compose-build.yaml
@@ -20,8 +20,6 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
-version: "3.5"
-
 services:
   openc3-ruby:
     build:

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -20,8 +20,6 @@
 # This file may also be used under the terms of a commercial license 
 # if purchased from OpenC3, Inc.
 
-version: "3.5"
-
 services:
   openc3-redis:
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,8 +20,6 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
-version: "3.5"
-
 networks:
   default:
     name: openc3-cosmos-network


### PR DESCRIPTION
Docker Compose obsoleted the version tag. As a result, containers using the tag began to throw warnings at the user that it became obsolete. 

I removed the version tags from `compose.yaml`, `compose-dev.yaml`, and `compose-build.yaml` to comply with this new Docker Compose standard. Interacting with COSMOS Docker containers no longer warns the user about deprecated tags.

Closes issue [#1159](https://github.com/OpenC3/cosmos/issues/1159)