### PR TITLE
prevent 0 max params registering as no-maximum

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/components/widgets/Widget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/components/widgets/Widget.js
@@ -153,7 +153,7 @@ export default {
         }
       }
       // If they pass null for max_params we don't check for a maximum number
-      if (max_num_params && this.parameters[max_num_params] !== undefined) {
+      if (max_num_params !== null && this.parameters[max_num_params] !== undefined) {
         throw new ConfigParserError(
           parser,
           `Too many parameters for ${keyword}.`,

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/components/widgets/Widget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/components/widgets/Widget.js
@@ -153,7 +153,7 @@ export default {
         }
       }
       // If they pass null for max_params we don't check for a maximum number
-      if (max_num_params !== null && this.parameters[max_num_params] !== undefined) {
+      if (max_num_params !== null && this.parameters.length > max_num_params) {
         throw new ConfigParserError(
           parser,
           `Too many parameters for ${keyword}.`,


### PR DESCRIPTION
Desired effect is disabling max param check if max_params is null.

Current logic also disables max param check if max_params (and min params) are set to 0.

I hit this in a custom widget that didn't need any parameters.