### PR TITLE
Prevent ScriptRunner Ctrl-S Save from Saving Old Buffers

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/model_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/model_controller.rb
@@ -58,5 +58,6 @@ class ModelController < ApplicationController
     return unless authorization('admin')
     @model_class.new(name: params[:id], scope: params[:scope]).destroy
     OpenC3::Logger.info("#{@model_class.name} destroyed: #{params[:id]}", scope: params[:scope], user: username())
+    head :ok
   end
 end

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/ScriptRunner.vue
@@ -993,8 +993,9 @@ export default {
       this.updateBreakpoints($event, session)
     })
 
-    window.addEventListener('resize', this.doResize)
-    window.addEventListener('keydown', this.keydown)
+    this.editor.container.addEventListener('resize', this.doResize)
+    this.editor.container.addEventListener('keydown', this.keydown)
+
     this.doResize()
     this.cable = new Cable('/script-api/cable')
 


### PR DESCRIPTION
ScriptRunner was attaching the keydown event to window rather than the current editor.  This causes a new hook to be attached everytime a user leaves scriptrunner and came back.  Old hooks remained bound to old editors, so a ctrl-s would cause multiple saves with a random last save being the winner and ending up being committed.

Fix is to attach to the editor, not window.