### PR TITLE
fix "FromAsCasing" buildkit check

### DIFF
--- a/openc3-cosmos-init/Dockerfile
+++ b/openc3-cosmos-init/Dockerfile
@@ -106,7 +106,7 @@ RUN ["/openc3/plugins/docker-package-build.sh", "openc3-cosmos-tool-scriptrunner
 COPY ./plugins/packages/openc3-cosmos-demo/ packages/openc3-cosmos-demo/
 RUN ["/openc3/plugins/docker-package-build.sh", "openc3-cosmos-demo"]
 
-FROM ${OPENC3_REGISTRY}/${OPENC3_NAMESPACE}/${OPENC3_BASE_IMAGE}:${OPENC3_TAG} as base
+FROM ${OPENC3_REGISTRY}/${OPENC3_NAMESPACE}/${OPENC3_BASE_IMAGE}:${OPENC3_TAG} AS base
 FROM openc3-frontend-tmp AS openc3-tmp5
 
 # Build docs tool


### PR DESCRIPTION
We recently encountered this error when running with buildkit on docker version is 27.0.1, through WSL2. More recent docker versions seem to be failing builds based on Dockerfile best-practice checks. This was a `./openc3.sh build-ubi` build- not docker compose.
https://docs.docker.com/reference/build-checks/from-as-casing/