### PR TITLE
Add environment variable for dynamic operator hostname

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/microservices_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/microservices_controller.rb
@@ -42,10 +42,14 @@ class MicroservicesController < ModelController
       if prefix and ports[0][0]
         port = ports[0][0].to_i
         prefix = '/' + prefix unless prefix[0] == '/'
-        if ENV['KUBERNETES_SERVICE_HOST']
-          url = "http://#{microservice_name.downcase.gsub('__', '-').gsub('_', '-')}-service:#{port}"
+        if ENV['OPENC3_OPERATOR_HOSTNAME']
+          url = "http://#{ENV['OPENC3_OPERATOR_HOSTNAME']}:#{port}"
         else
-          url = "http://openc3-operator:#{port}"
+          if ENV['KUBERNETES_SERVICE_HOST']
+            url = "http://#{microservice_name.downcase.gsub('__', '-').gsub('_', '-')}-service:#{port}"
+          else
+            url = "http://openc3-operator:#{port}"
+          end
         end
         service_name = microservice_name
         router_name = microservice_name


### PR DESCRIPTION
Will allow pointing to the correct service for a normal operator in Kubernetes