### PR TITLE
Fix python web socket in Enterprise

### DIFF
--- a/openc3/lib/openc3/utilities/authentication.rb
+++ b/openc3/lib/openc3/utilities/authentication.rb
@@ -21,6 +21,7 @@
 # if purchased from OpenC3, Inc.
 
 require 'openc3/version'
+require 'openc3/io/json_drb'
 require 'faraday'
 
 module OpenC3
@@ -145,7 +146,7 @@ module OpenC3
     def _make_request(headers, data)
       realm = ENV['OPENC3_KEYCLOAK_REALM'] || 'openc3'
       uri = URI("#{@url}/realms/#{realm}/protocol/openid-connect/token")
-      @log[0] = "request uri: #{uri.to_s} header: #{headers.to_s} body: #{data.to_s}"
+      @log[0] = "request uri: #{uri} header: #{headers} body: #{data}"
       STDOUT.puts @log[0] if JsonDRb.debug?
       saved_verbose = $VERBOSE; $VERBOSE = nil
       begin

--- a/openc3/python/examples/cosmos_web_socket_example.py
+++ b/openc3/python/examples/cosmos_web_socket_example.py
@@ -10,6 +10,10 @@ os.environ["OPENC3_API_HOSTNAME"] = "127.0.0.1"
 os.environ["OPENC3_API_PORT"] = "2900"
 os.environ["OPENC3_SCRIPT_API_HOSTNAME"] = "127.0.0.1"
 os.environ["OPENC3_SCRIPT_API_PORT"] = "2900"
+# Define these for Enterprise
+# os.environ["OPENC3_KEYCLOAK_URL"] = "http://localhost:2900/auth"
+# os.environ["OPENC3_API_USER"] = "operator"
+# Change this password for Enterprise
 os.environ["OPENC3_API_PASSWORD"] = "password"
 # END OUTSIDE OF DOCKER ONLY
 

--- a/openc3/python/openc3/script/web_socket_api.py
+++ b/openc3/python/openc3/script/web_socket_api.py
@@ -126,11 +126,17 @@ class WebSocketApi:
     # Connect to the websocket with authorization in query params
     def connect(self):
         self.disconnect()
-        final_url = self.url + f"?scope={self.scope}&authorization={self.authentication.token()}"
+        # Add the token directly in the URL since adding it to the header doesn't seem to work
+        # Note in the this case we remove the "Bearer " string which is part of the token
+        final_url = self.url + f"?scope={self.scope}&authorization={self.authentication.token()[7:]}"
         self.stream = WebSocketClientStream(final_url, self.write_timeout, self.read_timeout, self.connect_timeout)
         self.stream.headers = {
             "Sec-WebSocket-Protocol": "actioncable-v1-json, actioncable-unsupported",
             "User-Agent": WebSocketApi.USER_AGENT,
+            # Adding the authorization token to the header is supposed to work
+            # We add it directly with "Bearer <token>"
+            # But for some reason it doesn't so we add it directly to the URL above
+            # "Authorization": self.authentication.token(),
         }
         return self.stream.connect()
 


### PR DESCRIPTION
closes #1417 

This is a bit of a hack because the "right way" as described here: https://websockets.readthedocs.io/en/stable/topics/authentication.html#machine-to-machine-authentication doesn't seem to work. I get alternating results of `RuntimeError: Unauthorized` followed by `websockets.exceptions.ConnectionClosedOK: received 1000 (OK); then sent 1000 (OK)`.