### PR TITLE
Fixing Issues when Utilizing Gemfile.lock Files

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/Dockerfile
+++ b/openc3-cosmos-cmd-tlm-api/Dockerfile
@@ -12,9 +12,6 @@ USER root
 
 RUN bundle config set --local without 'development' \
   && bundle install --quiet \
-  # Temporary until grpc updated
-  && gem uninstall google-protobuf -v "!= 3.24.0" --all \
-  && rm Gemfile.lock \
   && rm -rf /usr/lib/ruby/gems/*/cache/* \
   /var/cache/apk/* \
   /tmp/* \

--- a/openc3-cosmos-cmd-tlm-api/Gemfile
+++ b/openc3-cosmos-cmd-tlm-api/Gemfile
@@ -23,6 +23,9 @@ gem 'bootsnap', '>= 1.9.3', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors', '~> 2.0'
 
+# Temporary until grpc updated
+gem 'google-protobuf', '3.24.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/openc3-cosmos-script-runner-api/Dockerfile
+++ b/openc3-cosmos-script-runner-api/Dockerfile
@@ -12,9 +12,6 @@ USER root
 
 RUN bundle config set --local without 'development' \
   && bundle install --quiet \
-  # Temporary until grpc updated
-  && gem uninstall google-protobuf -v "!= 3.24.0" --all \
-  && rm Gemfile.lock \
   && rm -rf /usr/lib/ruby/gems/*/cache/* \
   /var/cache/apk/* \
   /tmp/* \

--- a/openc3-cosmos-script-runner-api/Gemfile
+++ b/openc3-cosmos-script-runner-api/Gemfile
@@ -23,6 +23,9 @@ gem 'bootsnap', '>= 1.9.3', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors', '~> 2.0'
 
+# Temporary until grpc updated
+gem 'google-protobuf', '3.24.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/openc3/Dockerfile
+++ b/openc3/Dockerfile
@@ -23,10 +23,6 @@ RUN mkdir -p lib/openc3/ext \
   && ln -s $openc3_gem/openc3 $openc3_gem/cosmos \
   && mkdir -p gems \
   && mv *.gem gems/. \
-  # TODO: Remove google-protobuf / grpc manually install once grpc fixed
-  && gem install google-protobuf -v 3.24.0 --platform ruby \
-  && gem install grpc -v 1.59.2 \
-  && gem uninstall google-protobuf -v "!= 3.24.0" --all \
   && gem cleanup \
   && rm -rf /usr/lib/ruby/gems/*/cache/* /var/cache/apk/* /tmp/* /var/tmp/*
 

--- a/openc3/Gemfile
+++ b/openc3/Gemfile
@@ -6,6 +6,10 @@ gem 'ruby-termios', '>= 0.9' if RbConfig::CONFIG['target_os'] !~ /mswin|mingw|cy
 
 gemspec :name => 'openc3'
 
+# Temporary until grpc updated
+gem 'google-protobuf', '3.24.0'
+gem 'grpc', '1.59.2'
+
 # Include the rails gems for the convenience of custom microservice plugins
 gem 'bootsnap', '>= 1.9.3', require: false
 gem 'mock_redis', '0.44'


### PR DESCRIPTION
This PR fixes issues when I use `Gemfile.lock` files. I have been committing the generated `Gemfile.lock` in my repo and due to the way `google-protobuf` and `grpc` are pinned to a version these version never get reflected in `Gemfile.lock`. This causes problems when starting the application because it is looking for versions that don't exist anymore since they were manually deleted. I just added these two as dependencies in `Gemfile` and pin them to their required versions and removed the problematic code.