### PR TITLE
Fix markdown issue in documentation issue reporting note

### DIFF
--- a/docs.openc3.com/docs/getting-started/installation.md
+++ b/docs.openc3.com/docs/getting-started/installation.md
@@ -113,7 +113,7 @@ Continue to [Getting Started](gettingstarted.md).
 
 :::note Find a problem in the documentation?
 
-    Please [create an issue](https://github.com/OpenC3/cosmos/issues/new/choose">create an issue) on
-    GitHub describing what we can do to make it better.
+Please [create an issue](https://github.com/OpenC3/cosmos/issues/new/choose) on
+GitHub describing what we can do to make it better.
 
 :::


### PR DESCRIPTION
Somewhat amusingly, the documentation's note regarding reporting an issue was broken, thus making it impossible to report the issue itself. For convenience, here is the live page which has the bad link: https://docs.openc3.com/docs/getting-started/installation

The link syntax was broken and was generating a bad URL with a `">` included, which leads to a GitHub 404 page. I've removed the extra parts, and I believe the link now works as-expected, giving the option of which type of New Issue to create (although it may be nice if the issue types included "Documentation changes" or similar).

Additionally, this was the only `:::note` block which was tabbed-in across all the docs, so I made the choice to un-tab that. Not sure if that was meant to be tabbed in but my guess is that it should match all the others - my Markdown viewer was misbehaving since the tab in was causing it to render as code rather than parsing the Markdown link syntax.

Thanks for a nice SmallSat talk :)