### PR TITLE
Generator requires language

### DIFF
--- a/.env
+++ b/.env
@@ -55,6 +55,7 @@ PYPI_URL=https://pypi.org
 NPM_URL=https://registry.npmjs.org
 SECRET_KEY_BASE=bdb4300d46c9d4f116ce3dbbd54cac6b20802d8be1c2333cf5f6f90b1627799ac5d043e8460744077bc0bd6aacdd5c4bf53f499a68303c6752e7f327b874b96a
 OPENC3_CLOUD=local
+OPENC3_LANGUAGE=ruby
 # Change to arn:aws-us-gov for deploying to AWS Gov Cloud
 OPENC3_AWS_ARN_PREFIX=arn:aws
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -67,6 +67,7 @@ jobs:
           docker image ls | grep localhost:12345/openc3/openc3-traefik | grep mine
       - name: openc3.sh util generate
         shell: 'script -q -e -c "bash {0}"'
+        env: OPENC3_LANGUAGE: ruby
         run: |
           set -e
           ### PLUGIN ###

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -67,7 +67,8 @@ jobs:
           docker image ls | grep localhost:12345/openc3/openc3-traefik | grep mine
       - name: openc3.sh util generate
         shell: 'script -q -e -c "bash {0}"'
-        env: OPENC3_LANGUAGE: ruby
+        env:
+          OPENC3_LANGUAGE: ruby
         run: |
           set -e
           ### PLUGIN ###

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -67,8 +67,6 @@ jobs:
           docker image ls | grep localhost:12345/openc3/openc3-traefik | grep mine
       - name: openc3.sh util generate
         shell: 'script -q -e -c "bash {0}"'
-        env:
-          OPENC3_LANGUAGE: ruby
         run: |
           set -e
           ### PLUGIN ###

--- a/openc3/bin/openc3cli
+++ b/openc3/bin/openc3cli
@@ -68,7 +68,7 @@ def print_usage
   puts "  cli load /PATH/FILENAME.gem SCOPE variables.txt     # Loads a COSMOS plugin gem file"
   puts "  cli list <SCOPE>                  # Lists installed plugins, SCOPE is DEFAULT if not given"
   puts "  cli generate TYPE OPTIONS         # Generate various COSMOS entities"
-  puts "    OPTIONS: --ruby or --python to specify the language in the generated code"
+  puts "    OPTIONS: --ruby or --python is required to specify the language in the generated code"
   puts "  #{MIGRATE_PARSER}"
   puts "  cli bridge CONFIG_FILENAME        # Run COSMOS host bridge"
   puts "  cli bridgegem gem_name variable1=value1 variable2=value2 # Runs bridge using gem bridge.txt"

--- a/openc3/bin/openc3cli
+++ b/openc3/bin/openc3cli
@@ -68,7 +68,7 @@ def print_usage
   puts "  cli load /PATH/FILENAME.gem SCOPE variables.txt     # Loads a COSMOS plugin gem file"
   puts "  cli list <SCOPE>                  # Lists installed plugins, SCOPE is DEFAULT if not given"
   puts "  cli generate TYPE OPTIONS         # Generate various COSMOS entities"
-  puts "    OPTIONS: --ruby or --python is required to specify the language in the generated code"
+  puts "    OPTIONS: --ruby or --python is required to specify the language in the generated code unless OPENC3_LANGUAGE is set"
   puts "  #{MIGRATE_PARSER}"
   puts "  cli bridge CONFIG_FILENAME        # Run COSMOS host bridge"
   puts "  cli bridgegem gem_name variable1=value1 variable2=value2 # Runs bridge using gem bridge.txt"

--- a/openc3/lib/openc3/utilities/cli_generator.rb
+++ b/openc3/lib/openc3/utilities/cli_generator.rb
@@ -41,13 +41,17 @@ module OpenC3
         abort("No gemspec file detected. #{args[0].to_s.downcase} generator should be run within an existing plugin.")
       end
 
-      case args[-1]
-        when '--python'
-          @@language = 'py'
-        when '--ruby'
-          @@language = 'rb'
-        else
-          abort("One of --python or --ruby is required.")
+      gen_lang = ENV['OPENC3_LANGUAGE']
+      if (args[-1] == '--python' || args[-1] == '--ruby')
+        gen_lang = args[-1][2, 6]
+      end
+      case gen_lang
+      when 'python'
+        @@language = 'py'
+      when 'ruby'
+        @@language = 'rb'
+      else
+        abort("One of --python or --ruby is required unless OPENC3_LANGUAGE is set.")
       end
     end
 

--- a/openc3/lib/openc3/utilities/cli_generator.rb
+++ b/openc3/lib/openc3/utilities/cli_generator.rb
@@ -79,8 +79,8 @@ module OpenC3
     end
 
     def self.generate_plugin(args)
-      if args.length != 2
-        abort("Usage: cli generate #{args[0]} <NAME>")
+      if args.length < 2 or args.length > 3
+        abort("Usage: cli generate #{args[0]} <NAME> (--ruby or --python)")
       end
 
       # Create the local variables
@@ -203,8 +203,8 @@ module OpenC3
     end
 
     def self.generate_widget(args)
-      if args.length != 2
-        abort("Usage: cli generate #{args[0]} <SuperdataWidget>")
+      if args.length < 2 or args.length > 3
+        abort("Usage: cli generate #{args[0]} <SuperdataWidget> (--ruby or --python)")
       end
       # Per https://stackoverflow.com/a/47591707/453280
       if args[1] !~ /.*Widget$/ or args[1][0...-6] != args[1][0...-6].capitalize
@@ -249,8 +249,8 @@ module OpenC3
     end
 
     def self.generate_tool(args)
-      if args.length != 2
-        abort("Usage: cli generate #{args[0]} 'Tool Name'")
+      if args.length < 2 or args.length > 3
+        abort("Usage: cli generate #{args[0]} 'Tool Name' (--ruby or --python)")
       end
 
       # Create the local variables

--- a/openc3/lib/openc3/utilities/cli_generator.rb
+++ b/openc3/lib/openc3/utilities/cli_generator.rb
@@ -41,10 +41,13 @@ module OpenC3
         abort("No gemspec file detected. #{args[0].to_s.downcase} generator should be run within an existing plugin.")
       end
 
-      if args[-1] == '--python'
-        @@language = 'py'
-      else
-        @@language = 'rb'
+      case args[-1]
+        when '--python'
+          @@language = 'py'
+        when '--ruby'
+          @@language = 'rb'
+        else
+          abort("One of --python or --ruby is required.")
       end
     end
 

--- a/playwright/playwright.sh
+++ b/playwright/playwright.sh
@@ -29,9 +29,9 @@ case $1 in
 
     build-plugin )
         rm -rf openc3-cosmos-pw-test
-        ../openc3.sh cli generate plugin PW_TEST
+        ../openc3.sh cli generate plugin PW_TEST --ruby
         cd openc3-cosmos-pw-test
-        ../../openc3.sh cli generate target PW_TEST
+        ../../openc3.sh cli generate target PW_TEST --ruby
         ../../openc3.sh cli rake build VERSION=1.0.0
         cp openc3-cosmos-pw-test-1.0.0.gem openc3-cosmos-pw-test-1.0.1.gem
         ../../openc3.sh cli validate openc3-cosmos-pw-test-1.0.0.gem


### PR DESCRIPTION
There is no longer a default language for the generators.

If OPENC3_LANGUAGE is not set, the final argument to _bundle exec ruby bin/openc3cli generate_ must be **--ruby** or -**-python**.

If OPENC3_LANGUAGE is set, it must be exactly **ruby** or **python**.

If OPENC3_LANGUAGE is set, the final argument can be (missing or) anything other than **--ruby** or **--python**, then OPENC3_LANGUAGE will be used.

If both are set but only one is correct, the correct one will be used.

If neither are set or both are incorrect the script will abort with a descriptive message.

NOTE: the command line arguments must have the leading dashes, but the ENV var must not.