### PR TITLE
CvtModel get_tlm_values return consistent results

### DIFF
--- a/openc3/lib/openc3/models/cvt_model.rb
+++ b/openc3/lib/openc3/models/cvt_model.rb
@@ -156,7 +156,13 @@ module OpenC3
               item_result[1] = item_result[1].intern if item_result[1] # Convert to symbol
             end
           else
-            raise "Item '#{target_name} #{packet_name} #{value_keys[-1]}' does not exist" unless hash.key?(value_keys[-1])
+            # We didn't find a value but the packet hash contains the key so the item exists
+            # Thus set the result to nil so it comes back like a normal item
+            if hash.key?(value_keys[-1])
+              item_result[1] = nil
+            else
+              raise "Item '#{target_name} #{packet_name} #{value_keys[-1]}' does not exist"
+            end
           end
         end
         results << item_result

--- a/openc3/spec/models/cvt_model_spec.rb
+++ b/openc3/spec/models/cvt_model_spec.rb
@@ -189,6 +189,18 @@ module OpenC3
         expect { CvtModel.get_tlm_values([["INST","HEALTH_STATUS","TEMP1","NOPE"]]) }.to raise_error("Unknown value type 'NOPE'")
       end
 
+      it "returns [nil, nil] from an unset item" do
+        json_hash = {}
+        json_hash["TEMP2"] = nil
+        CvtModel.set(json_hash, target_name: "INST", packet_name: "HEALTH_STATUS", scope: "DEFAULT")
+        values = [["INST","HEALTH_STATUS","TEMP2","RAW"]]
+        result = CvtModel.get_tlm_values(values)
+        expect(result.length).to eql 1
+        expect(result[0].length).to eql 2
+        expect(result[0][0]).to eql nil
+        expect(result[0][1]).to eql nil
+      end
+
       it "gets different value types from the CVT" do
         update_temp1()
         values = [["INST","HEALTH_STATUS","TEMP1","RAW"],["INST","HEALTH_STATUS","TEMP1","CONVERTED"], ["INST","HEALTH_STATUS","TEMP1","FORMATTED"], ["INST","HEALTH_STATUS","TEMP1","WITH_UNITS"]]


### PR DESCRIPTION
closes #1606 

Didn't expect this to be a backend change but it was returning a single [nil] for an item that exists but hasn't been populated which is inconsistent with all the other items which return a [value, limits_state].