### PR TITLE
Allow execute selection while paused

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/ScriptRunner.vue
@@ -249,7 +249,6 @@
               v-for="item in executeSelectionMenuItems"
               link
               :key="item.label"
-              :disabled="scriptId"
             >
               <v-list-item-title @click="item.command">
                 {{ item.label }}
@@ -887,20 +886,34 @@ export default {
       ]
     },
     executeSelectionMenuItems: function () {
-      return [
-        {
-          label: 'Execute selection',
-          command: this.executeSelection,
-        },
-        {
-          label: 'Run from here',
-          command: this.runFromCursor,
-        },
-        {
-          label: 'Clear local breakpoints',
-          command: this.clearBreakpoints,
-        },
-      ]
+      if (this.scriptId) {
+        return [
+          {
+            label: 'Execute selection',
+            command: this.executeSelection,
+          },
+          {
+            label: 'Run from here',
+            command: this.runFromCursor,
+          },
+          // Can't clear local breakpoints in a running script
+        ]
+      } else {
+        return [
+          {
+            label: 'Execute selection',
+            command: this.executeSelection,
+          },
+          {
+            label: 'Run from here',
+            command: this.runFromCursor,
+          },
+          {
+            label: 'Clear local breakpoints',
+            command: this.clearBreakpoints,
+          },
+        ]
+      }
     },
   },
   watch: {


### PR DESCRIPTION
closes #555 

All I did was allow the Execute Selection and Run from here while paused. All the other limitations apply which is you don't have any variables defined, etc and it's basically a new script. I think the real solution would be to run the selected text against the script binding context but not even sure that's possible with Python?