### PR TITLE
Change get_target_names permission to 'system'

### DIFF
--- a/openc3/python/openc3/api/target_api.py
+++ b/openc3/python/openc3/api/target_api.py
@@ -33,7 +33,7 @@ WHITELIST.extend(
 #
 # @return [Array<String>] All target names
 def get_target_names(scope=OPENC3_SCOPE):
-    authorize(permission="tlm", scope=scope)
+    authorize(permission="system", scope=scope)
     return TargetModel.names(scope=scope)
 
 


### PR DESCRIPTION
closes #1410 

Ruby API already had `get_target_names` with `system` permission