### PR TITLE
Cleanup controllers and change delete 204 to 200

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ Style:
 # Style/GlobalVars:
 #   Enabled: false # We need globals in several places
 # Style/MissingRespondToMissing:
-#   Enabled: false # TODO: We don't implement respond_to_missing? Should we?
+#   Enabled: false # We don't implement respond_to_missing?
 # Style/TrailingUnderscoreVariable:
 #   Enabled: false # I prefer "result, _ = method()" to result, = method()"
 

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/activity_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/activity_controller.rb
@@ -52,13 +52,13 @@ class ActivityController < ApplicationController
         limit = ((stop - start) / 60).to_i # 1 event every minute ... shouldn't ever be more than this!
       end
       model = @model_class.get(name: params[:name], scope: params[:scope], start: start, stop: stop, limit: limit)
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue ArgumentError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => 'Invalid date provided. Recommend ISO format' }, :status => 400
+      render json: { status: 'error', message: 'Invalid date provided. Recommend ISO format' }, status: 400
     rescue StandardError => e # includes ActivityInputError
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     end
   end
 
@@ -105,19 +105,19 @@ class ActivityController < ApplicationController
         scope: params[:scope],
         user: hash['data']['username']
       )
-      render :json => model.as_json(:allow_nan => true), :status => 201
+      render json: model.as_json(:allow_nan => true), status: 201
     rescue ArgumentError, TypeError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => "Invalid input: #{hash}", :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: "Invalid input: #{hash}", type: e.class, e: e.to_s }, status: 400
     rescue StandardError => e # includes ActivityInputError
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 400
     rescue OpenC3::ActivityOverlapError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 409
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 409
     rescue OpenC3::ActivityError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 418
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 418
     end
   end
 
@@ -137,10 +137,10 @@ class ActivityController < ApplicationController
     return unless authorization('system')
     begin
       count = @model_class.count(name: params[:name], scope: params[:scope])
-      render :json => { :name => params[:name], :count => count }, :status => 200
+      render json: { name: params[:name], count: count }
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 400
     end
   end
 
@@ -162,13 +162,13 @@ class ActivityController < ApplicationController
     begin
       model = @model_class.score(name: params[:name], score: params[:id].to_i, scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
       else
-        render :json => model.as_json(:allow_nan => true), :status => 200
+        render json: model.as_json(:allow_nan => true)
       end
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 400
     end
   end
 
@@ -197,7 +197,7 @@ class ActivityController < ApplicationController
     return unless authorization('script_run')
     model = @model_class.score(name: params[:name], score: params[:id].to_i, scope: params[:scope])
     if model.nil?
-      render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+      render json: { status: 'error', message: NOT_FOUND }, status: 404
       return
     end
     begin
@@ -208,13 +208,13 @@ class ActivityController < ApplicationController
         scope: params[:scope],
         user: username()
       )
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue OpenC3::ActivityError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 418
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 418
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 400
     end
   end
 
@@ -245,7 +245,7 @@ class ActivityController < ApplicationController
     return unless authorization('script_run')
     model = @model_class.score(name: params[:name], score: params[:id].to_i, scope: params[:scope])
     if model.nil?
-      render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+      render json: { status: 'error', message: NOT_FOUND }, status: 404
       return
     end
     begin
@@ -260,19 +260,19 @@ class ActivityController < ApplicationController
         scope: params[:scope],
         user: hash['data']['username']
       )
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue ArgumentError, TypeError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => "Invalid input: #{hash}", :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: "Invalid input: #{hash}", type: e.class, e: e.to_s }, status: 400
     rescue OpenC3::ActivityOverlapError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 409
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 409
     rescue OpenC3::ActivityError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 418
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 418
     rescue StandardError => e # includes OpenC3::ActivityInputError
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 400
     end
   end
 
@@ -281,7 +281,7 @@ class ActivityController < ApplicationController
   # name [String] the timeline name, `system42`
   # scope [String] the scope of the timeline, `TEST`
   # id [String] the score or id of the activity, `1620248449`
-  # @return [String] object/hash converted into json format but with a 204 no-content status code
+  # @return [String] object/hash converted into json format but with a 200 status code
   # Request Headers
   # ```json
   #  {
@@ -294,18 +294,18 @@ class ActivityController < ApplicationController
     begin
       ret = @model_class.destroy(name: params[:name], scope: params[:scope], score: params[:id].to_i, uuid: params[:uuid], recurring: params[:recurring])
       if ret == 0
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
       else
         OpenC3::Logger.info(
           "Activity destroyed name: #{params[:name]} id:#{params[:id]} recurring:#{params[:recurring]}",
           scope: params[:scope],
           user: username()
         )
-        render :json => { "status" => ret }, :status => 204
+        render json: { status: ret }
       end
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 400
     end
   end
 
@@ -339,7 +339,8 @@ class ActivityController < ApplicationController
     return unless authorization('script_run')
     input_activities = params.to_unsafe_h.slice(:multi).to_h['multi']
     unless input_activities.is_a?(Array)
-      render(:json => { :status => 'error', :message => 'invalid input, must be json list/array' }, :status => 400) and return
+      render json: { status: 'error', message: 'invalid input, must be json list/array' }, status: 400
+      return
     end
 
     ret = Array.new
@@ -363,19 +364,19 @@ class ActivityController < ApplicationController
         ret << model.as_json(:allow_nan => true)
       rescue ArgumentError, TypeError => e
         logger.error(e.formatted)
-        ret << { :status => 'error', :message => "Invalid input, #{e.message}", 'input' => input, 'type' => e.class, status => 400 }
+        ret << { status: 'error', message: "Invalid input, #{e.message}", input: input, type: e.class, err: 400 }
       rescue OpenC3::ActivityOverlapError => e
         logger.error(e.formatted)
-        ret << { :status => 'error', :message => e.message, :input => input, :type => e.class, :err => 409 }
+        ret << { status: 'error', message: e.message, input: input, type: e.class, err: 409 }
       rescue OpenC3::ActivityError => e
         logger.error(e.formatted)
-        ret << { :status => 'error', :message => e.message, :input => input, :type => e.class, :err => 418 }
+        ret << { status: 'error', message: e.message, input: input, type: e.class, err: 418 }
       rescue StandardError => e # includes OpenC3::ActivityInputError
         logger.error(e.formatted)
-        ret << { :status => 'error', :message => e.message, :input => input, :type => e.class, :err => 400 }
+        ret << { status: 'error', message: e.message, input: input, type: e.class, err: 400 }
       end
     end
-    render :json => ret, :status => 200
+    render json: ret
   end
 
   # Removes multiple activities by score/start/id.
@@ -405,7 +406,8 @@ class ActivityController < ApplicationController
     return unless authorization('script_run')
     input_activities = params.to_unsafe_h.slice(:multi).to_h['multi']
     unless input_activities.is_a?(Array)
-      render(:json => { :status => 'error', :message => 'invalid input' }, :status => 400) and return
+      render json: { status: 'error', message: 'invalid input' }, status: 400
+      return
     end
 
     ret = Array.new
@@ -415,12 +417,12 @@ class ActivityController < ApplicationController
       begin
         result = @model_class.destroy(name: input[:name], score: input[:id].to_i, uuid: input[:uuid], scope: params[:scope])
         OpenC3::Logger.info("Activity destroyed: #{input['name']}", scope: params[:scope], user: username())
-        ret << { 'status' => 'removed', 'removed' => result, 'input' => input, 'type' => e.class }
+        ret << { status: 'removed', removed: result, input: input, type: e.class }
       rescue StandardError => e # includes OpenC3::ActivityInputError
         logger.error(e.formatted)
-        ret << { :status => 'error', :message => e.message, :input => input, :type => e.class, :err => 400 }
+        ret << { status: 'error', message: e.message, input: input, type: e.class, err: 400 }
       end
     end
-    render :json => ret, :status => 200
+    render json: ret
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/application_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -49,10 +49,10 @@ class ApplicationController < ActionController::API
         token: request.headers['HTTP_AUTHORIZATION'],
       )
     rescue OpenC3::AuthError => e
-      render(json: { status: 'error', message: e.message }, status: 401) if perform_render
+      render json: { status: 'error', message: e.message }, status: 401 if perform_render
       return false
     rescue OpenC3::ForbiddenError => e
-      render(json: { status: 'error', message: e.message }, status: 403) if perform_render
+      render json: { status: 'error', message: e.message }, status: 403 if perform_render
       return false
     end
   end
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::API
           value = arg.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.tr("\u{202E}%$|:;/\t\r\n\\", "-")
         end
         if value != arg
-          render(json: { status: 'error', message: "Invalid #{param_list[index]}: #{arg}" }, status: 400)
+          render json: { status: 'error', message: "Invalid #{param_list[index]}: #{arg}" }, status: 400
           return false
         end
       end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/auth_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/auth_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -26,7 +26,7 @@ require 'openc3/models/auth_model'
 class AuthController < ApplicationController
   def token_exists
     result = OpenC3::AuthModel.set?
-    render :json => {
+    render json: {
       result: result
     }
   end
@@ -40,7 +40,7 @@ class AuthController < ApplicationController
       end
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class }, status: 500
     end
   end
 
@@ -52,7 +52,7 @@ class AuthController < ApplicationController
       render :plain => OpenC3::AuthModel.generate_session()
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/environment_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/environment_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -35,7 +35,7 @@ class EnvironmentController < ApplicationController
   def index
     return unless authorization('system')
     values = @model_class.all(scope: params[:scope]).values
-    render :json => values, :status => 200
+    render json: values
   end
 
   # Create a new environment returns object/hash of the environment in json.
@@ -60,10 +60,10 @@ class EnvironmentController < ApplicationController
   def create
     return unless authorization('script_run')
     if params['key'].nil? || params['value'].nil?
-      render :json => {
-        'status' => 'error',
-        'message' => "Parameter '#{params['key'].nil? ? 'key' : 'value'}' is required",
-      }, :status => 400
+      render json: {
+        status: 'error',
+        message: "Parameter '#{params['key'].nil? ? 'key' : 'value'}' is required",
+      }, status: 400
       return
     end
     begin
@@ -75,41 +75,41 @@ class EnvironmentController < ApplicationController
       model = @model_class.new(name: name, key: params['key'], value: params['value'], scope: params[:scope])
       model.create()
       OpenC3::Logger.info("Environment variable created: #{name} #{params['key']} #{params['value']}", scope: params[:scope], user: username())
-      render :json => model.as_json(:allow_nan => true), :status => 201
+      render json: model.as_json(:allow_nan => true), status: 201
     rescue RuntimeError, JSON::ParserError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue TypeError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => 'Invalid json object', 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: 'Invalid json object', type: e.class }, status: 400
     rescue OpenC3::EnvironmentError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 409
+      render json: { status: 'error', message: e.message, type: e.class }, status: 409
     end
   end
 
-  # Returns hash/object of environment name in json with a 204 no-content status code.
+  # Returns hash/object of environment name in json with a 200 status code.
   #
   # name [String] the environment name, `bffcdb71ce38b7604db3c53000adef1ed851606d`
   # scope [String] the scope of the environment, `TEST`
-  # @return [String] hash/object of environment name in json with a 204 no-content status code
+  # @return [String] hash/object of environment name in json with a 200 status code
   def destroy
     return unless authorization('script_run')
     model = @model_class.get(name: params[:name], scope: params[:scope])
     if model.nil?
-      render :json => {
-        'status' => 'error',
-        'message' => "failed to find environment: #{params[:name]}",
-      }, :status => 404
+      render json: {
+        status: 'error',
+        message: "failed to find environment: #{params[:name]}",
+      }, status: 404
       return
     end
     begin
       ret = @model_class.destroy(name: params[:name], scope: params[:scope])
       OpenC3::Logger.info("Environment variable destroyed: #{params[:name]}", scope: params[:scope], user: username())
-      render :json => { 'name' => params[:name] }, :status => 204
+      render json: { name: params[:name] }
     rescue OpenC3::EnvironmentError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/info_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/info_controller.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -22,7 +22,7 @@ begin
 rescue LoadError
   class InfoController < ApplicationController
     def info
-      render :json => { :version => OPENC3_VERSION, :license => 'AGPLv3', :enterprise => false }, :status => 200
+      render json: { version: OPENC3_VERSION, license: 'AGPLv3', enterprise: false }
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/internal_health_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/internal_health_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -29,10 +29,10 @@ class InternalHealthController < ApplicationController
   def health
     return unless authorization('system')
     begin
-      render :json => { :redis => OpenC3::InfoModel.get() }, :status => 200
+      render json: { redis: OpenC3::InfoModel.get() }
     rescue => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/internal_metrics_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/internal_metrics_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -43,7 +43,7 @@ class InternalMetricsController < ApplicationController
     rescue RuntimeError => e
       logger.error(e.formatted)
       OpenC3::Logger.error("failed to connect to redis to pull scopes")
-      render plain: "failed to access datastore", :status => 500
+      render plain: "failed to access datastore", status: 500
     end
     OpenC3::Logger.debug("ScopeModels: #{scopes}")
     data_hash = {}
@@ -54,7 +54,7 @@ class InternalMetricsController < ApplicationController
       rescue RuntimeError => e
         logger.error(e.formatted)
         OpenC3::Logger.error("failed to connect to redis to pull metrics")
-        render plain: "failed to access datastore", :status => 500
+        render plain: "failed to access datastore", status: 500
       end
       OpenC3::Logger.debug("metrics search for scope: #{scope}, returned: #{scope_resp}")
       scope_resp.each do |_key, label_json|

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/internal_status_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/internal_status_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -29,10 +29,10 @@ require 'openc3/models/ping_model'
 class InternalStatusController < ApplicationController
   def status
     begin
-      render :json => { :status => OpenC3::PingModel.get() }, :status => 200
+      render json: { status: OpenC3::PingModel.get() }
     rescue => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/metadata_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/metadata_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -49,7 +49,7 @@ class MetadataController < ApplicationController
       else
         json = @model_class.all(limit: limit, scope: params[:scope])
       end
-      render json: json, status: 200
+      render json: json
     end
   end
 
@@ -110,7 +110,7 @@ class MetadataController < ApplicationController
     action do
       model_hash = @model_class.get(start: params[:id].to_i, scope: params[:scope])
       if model_hash
-        render json: model_hash, status: 200
+        render json: model_hash
       else
         render json: { status: 'error', message: NOT_FOUND }, status: 404
       end
@@ -160,7 +160,7 @@ class MetadataController < ApplicationController
         scope: params[:scope],
         user: username()
       )
-      render json: model.as_json(:allow_nan => true), status: 200
+      render json: model.as_json(:allow_nan => true)
     end
   end
 
@@ -168,7 +168,7 @@ class MetadataController < ApplicationController
   #
   # scope [String] the scope of the timeline, `TEST`
   # id [String] the score or id of the activity, `1620248449`
-  # @return [String] object/hash converted into json format but with a 204 no-content status code
+  # @return [Integer] number of items deleted
   # Request Headers
   # ```json
   #  {
@@ -189,7 +189,7 @@ class MetadataController < ApplicationController
         scope: params[:scope],
         user: username()
       )
-      render json: { 'status' => count }, status: 204
+      render json: { status: count }
     end
   end
 
@@ -202,14 +202,10 @@ class MetadataController < ApplicationController
     action do
       json = @model_class.get_current_value(scope: params[:scope])
       if json.nil?
-        render json: {
-                 status: 'error',
-                 message: 'no metadata entries',
-               },
-               status: 204
+        render json: { status: 'error', message: 'no metadata entries'}
         return
       end
-      render json: json, status: 200
+      render json: json
     end
   end
 
@@ -237,7 +233,7 @@ class MetadataController < ApplicationController
   #     key, value = [hash['key'], hash['value']]
   #     raise OpenC3::SortedInputError "Must include key, value in metadata search" if key.nil? || value.nil?
   #     selected_array = json_array.select { | json_model | json_model['metadata'][key] == value }
-  #     render :json => selected_array, :status => 200
+  #     render json: selected_array
   #   end
   # end
 
@@ -253,24 +249,21 @@ class MetadataController < ApplicationController
                status: 'error',
                message: "Invalid input: #{e.message}",
                type: e.class,
-             },
-             status: 400
+             }, status: 400
     rescue OpenC3::SortedOverlapError => e
       logger.error(e.formatted)
       render json: {
                 status: 'error',
                 message: e.message,
                 type: e.class,
-              },
-              status: 409 # Conflict
+              }, status: 409 # Conflict
     rescue OpenC3::SortedError => e
       logger.error(e.formatted)
       render json: {
                status: 'error',
                message: e.message,
                type: e.class,
-             },
-             status: 400
+             }, status: 400
     rescue StandardError => e
       logger.error(e.formatted)
       render json: {
@@ -278,8 +271,7 @@ class MetadataController < ApplicationController
                message: e.message,
                type: e.class,
                backtrace: e.backtrace,
-             },
-             status: 400
+             }, status: 400
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/microservices_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/microservices_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -64,6 +64,6 @@ class MicroservicesController < ModelController
         routers[router_name]['priority'] = 20
       end
     end
-    render :json => result
+    render json: result
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/model_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/model_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -25,7 +25,7 @@ require 'openc3/models/gem_model'
 class ModelController < ApplicationController
   def index
     return unless authorization('system')
-    render :json => @model_class.names(scope: params[:scope])
+    render json: @model_class.names(scope: params[:scope])
   end
 
   def create(update_model = false)
@@ -44,9 +44,9 @@ class ModelController < ApplicationController
   def show
     return unless authorization('system')
     if params[:id].downcase == 'all'
-      render :json => @model_class.all(scope: params[:scope])
+      render json: @model_class.all(scope: params[:scope])
     else
-      render :json => @model_class.get(name: params[:id], scope: params[:scope])
+      render json: @model_class.get(name: params[:id], scope: params[:scope])
     end
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/notes_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/notes_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -49,7 +49,7 @@ class NotesController < ApplicationController
       else
         json = @model_class.all(scope: params[:scope])
       end
-      render json: json, status: 200
+      render json: json
     end
   end
 
@@ -112,7 +112,7 @@ class NotesController < ApplicationController
     action do
       model_hash = @model_class.get(start: params[:id].to_i, scope: params[:scope])
       if model_hash
-        render json: model_hash, status: 200
+        render json: model_hash
       else
         render json: { status: 'error', message: NOT_FOUND }, status: 404
       end
@@ -165,7 +165,7 @@ class NotesController < ApplicationController
         scope: params[:scope],
         user: username(),
       )
-      render json: model.as_json(:allow_nan => true), status: 200
+      render json: model.as_json(:allow_nan => true)
     end
   end
 
@@ -173,7 +173,7 @@ class NotesController < ApplicationController
   #
   # scope [String] the scope of the timeline, `TEST`
   # id [String] the score or id of the activity, `1620248449`
-  # @return [String] object/hash converted into json format but with a 204 no-content status code
+  # @return [String] object/hash converted into json format but with a 200 status code
   # Request Headers
   # ```json
   #  {
@@ -194,7 +194,7 @@ class NotesController < ApplicationController
         scope: params[:scope],
         user: username(),
       )
-      render json: { 'status' => count }, status: 204
+      render json: { status: count }
     end
   end
 
@@ -213,7 +213,7 @@ class NotesController < ApplicationController
   #     raise SortedInputError "Must include description value" if description.nil?
   #     model_array = @model_class.range(scope: params[:scope], start: start, stop: stop)
   #     model_array.find { |model| model.description.include? description }
-  #     render :json => model_array, :status => 200
+  #     render json: model_array
   #   end
   # end
 

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/packages_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/packages_controller.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -25,7 +25,7 @@ class PackagesController < ApplicationController
     return unless authorization('system')
     gems = OpenC3::GemModel.names
     packages = OpenC3::PythonPackageModel.names
-    render :json => {"ruby" => gems, "python" => packages}
+    render json: { ruby: gems, python: packages }
   end
 
   # Add a new package
@@ -44,16 +44,16 @@ class PackagesController < ApplicationController
           process_name = OpenC3::PythonPackageModel.put(package_file_path, package_install: true, scope: params[:scope])
         end
         OpenC3::Logger.info("Package created: #{params[:package]}", scope: params[:scope], user: username())
-        render :json => process_name
+        render json: process_name
       rescue => e
         OpenC3::Logger.error("Error installing package: #{file.original_filename}:#{e.formatted}", scope: params[:scope], user: username())
-        render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+        render json: { status: 'error', message: e.message, type: e.class }, status: 400
       ensure
         FileUtils.remove_entry(temp_dir) if temp_dir and File.exist?(temp_dir)
       end
     else
       OpenC3::Logger.error("Error installing package: Package file as params[:package] is required", scope: params[:scope], user: username())
-      render :json => { :status => 'error', :message => "Package file as params[:package] is required" }, :status => 400
+      render json: { status: 'error', message: "Package file as params[:package] is required" }, status: 400
     end
   end
 
@@ -71,11 +71,11 @@ class PackagesController < ApplicationController
         head :ok
       rescue => e
         OpenC3::Logger.error("Error destroying package: #{params[:id]}:#{e.formatted}", scope: params[:scope], user: username())
-        render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+        render json: { status: 'error', message: e.message, type: e.class }, status: 400
       end
     else
       OpenC3::Logger.error("Error destroying package: Package name as params[:id] is required", scope: params[:scope], user: username())
-      render :json => { :status => 'error', :message => "Package name as params[:id] is required" }, :status => 400
+      render json: { status: 'error', message: "Package name as params[:id] is required" }, status: 400
     end
   end
 
@@ -89,10 +89,10 @@ class PackagesController < ApplicationController
         package_file_path = OpenC3::PythonPackageModel.get(package_name)
       end
       file = File.read(package_file_path, mode: 'rb')
-      render :json => { filename: package_name, contents: Base64.encode64(file) }
+      render json: { filename: package_name, contents: Base64.encode64(file) }
     rescue Exception => e
       OpenC3::Logger.info("Package '#{params[:id]}' download failed: #{e.message}", user: username())
-      render :json => { status: 'error', message: e.message }, status: 500
+      render json: { status: 'error', message: e.message }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/plugins_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/plugins_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -47,16 +47,16 @@ class PluginsController < ModelController
         else
           result = OpenC3::PluginModel.install_phase1(gem_file_path, scope: scope)
         end
-        render :json => result
+        render json: result
       rescue Exception => error
-        render(:json => { :status => 'error', :message => error.message }, :status => 500)
+        render json: { status: 'error', message: error.message }, status: 500
         logger.error(error.formatted)
       ensure
         FileUtils.remove_entry(temp_dir) if temp_dir and File.exist?(temp_dir)
       end
     else
       logger.error("No file received")
-      render(:json => { :status => 'error', :message => "No file received" }, :status => 500)
+      render json: { status: 'error', message: "No file received" }, status: 500
     end
   end
 
@@ -87,10 +87,10 @@ class PluginsController < ModelController
         ["ruby", "/openc3/bin/openc3cli", "load", gem_name, scope, plugin_hash_file_path, "force"], # force install
         "plugin_install", params[:id], Time.now + 1.hour, temp_dir: temp_dir, scope: scope
       )
-      render :json => result.name
+      render json: result.name
     rescue Exception => error
       logger.error(error.formatted)
-      render(:json => { :status => 'error', :message => error.message }, :status => 500) and return
+      render json: { status: 'error', message: error.message }, status: 500
     end
   end
 
@@ -100,10 +100,10 @@ class PluginsController < ModelController
       id, scope = sanitize_params([:id, :scope])
       return unless id and scope
       result = OpenC3::ProcessManager.instance.spawn(["ruby", "/openc3/bin/openc3cli", "unload", id, scope], "plugin_uninstall", id, Time.now + 1.hour, scope: scope)
-      render :json => result.name
+      render json: result.name
     rescue Exception => error
       logger.error(error.formatted)
-      render(:json => { :status => 'error', :message => error.message }, :status => 500) and return
+      render json: { status: 'error', message: error.message }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/process_status_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/process_status_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -30,11 +30,11 @@ class ProcessStatusController < ModelController
   def show
     return unless authorization('system')
     if params[:id].downcase == 'all'
-      render :json => @model_class.all(scope: params[:scope])
+      render json: @model_class.all(scope: params[:scope])
     elsif params[:id].split('__').length > 1
-      render :json => @model_class.get(name: params[:id], scope: params[:scope])
+      render json: @model_class.get(name: params[:id], scope: params[:scope])
     else
-      render :json => @model_class.filter("process_type", params[:id], scope: params[:scope], substr: params[:substr])
+      render json: @model_class.filter("process_type", params[:id], scope: params[:scope], substr: params[:substr])
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/reaction_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/reaction_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -43,10 +43,10 @@ class ReactionController < ApplicationController
       triggers.each do |_, trigger|
         ret << trigger
       end
-      render :json => ret, :status => 200
+      render json: ret
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -59,16 +59,16 @@ class ReactionController < ApplicationController
     return unless authorization('system')
     begin
       model = @model_class.get(name: params[:name], scope: params[:scope])
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue OpenC3::ReactionInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 404
+      render json: { status: 'error', message: e.message, type: e.class }, status: 404
     rescue OpenC3::ReactionError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -113,16 +113,16 @@ class ReactionController < ApplicationController
       model = @model_class.from_json(hash.symbolize_keys, name: name, scope: params[:scope])
       model.create()
       model.deploy()
-      render :json => model.as_json(:allow_nan => true), :status => 201
+      render json: model.as_json(:allow_nan => true), status: 201
     rescue OpenC3::ReactionInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue OpenC3::ReactionError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 418
+      render json: { status: 'error', message: e.message, type: e.class }, status: 418
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -149,7 +149,7 @@ class ReactionController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
       hash = params.to_unsafe_h.slice(:snooze, :triggers, :triggerLevel, :actions).to_h
@@ -161,16 +161,16 @@ class ReactionController < ApplicationController
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user updating the reaction
       model.notify(kind: 'updated')
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue OpenC3::ReactionInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue OpenC3::ReactionError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 418
+      render json: { status: 'error', message: e.message, type: e.class }, status: 418
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -195,17 +195,17 @@ class ReactionController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
       # Notify the ReactionMicroservice to enable the ReactionModel
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user enabling the reaction
       model.notify_enable
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -230,17 +230,17 @@ class ReactionController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
       # Notify the ReactionMicroservice to disable the ReactionModel
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user disabling the reaction
       model.notify_disable
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -250,17 +250,17 @@ class ReactionController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
       # Notify the ReactionMicroservice to execute the ReactionModel
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user executing the reaction
       model.notify_execute
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -268,7 +268,7 @@ class ReactionController < ApplicationController
   #
   # name [String] the reaction name, `REACT1`
   # scope [String] the scope of the reaction, `TEST`
-  # @return [String] object/hash converted into json format but with a 204 no-content status code
+  # @return [String] object/hash converted into json format but with a 200 status code
   # Request Headers
   #```json
   #  {
@@ -281,23 +281,23 @@ class ReactionController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
       # Notify the ReactionMicroservice to delete the ReactionModel
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user deleting the reaction
       model.notify(kind: 'deleted')
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue OpenC3::ReactionInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 404
+      render json: { status: 'error', message: e.message, type: e.class }, status: 404
     rescue OpenC3::ReactionError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/redis_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/redis_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -33,7 +33,8 @@ class RedisController < ApplicationController
     # Check that we allow this command
     command = args[0].upcase
     if DISALLOWED_COMMANDS.include? command
-      render(:json => { :status => 'error', :message => "The #{command} command is not allowed." }, :status => 422) and return
+      render json: { status: 'error', message: "The #{command} command is not allowed." }, status: 422
+      return
     end
 
     if params[:ephemeral]
@@ -42,6 +43,6 @@ class RedisController < ApplicationController
       result = OpenC3::Store.method_missing(command, args[1..-1])
     end
     OpenC3::Logger.info("Redis command executed: #{args} - with result #{result}", user: username())
-    render :json => { :result => result }, :status => 201
+    render json: { :result => result }, status: 201
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/scopes_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/scopes_controller.rb
@@ -30,7 +30,7 @@ class ScopesController < ModelController
 
   def index
     # No authorization required
-    render :json => @model_class.names()
+    render json: @model_class.names()
   end
 
   def create(update_model = false)
@@ -49,16 +49,16 @@ class ScopesController < ModelController
     head :ok
   rescue Exception => e
     logger.error(e.formatted)
-    render(:json => { :status => 'error', :message => e.message }, :status => 500) and return
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def destroy
     return unless authorization('superadmin')
     # Scopes are global so the scope is always 'DEFAULT'
     result = OpenC3::ProcessManager.instance.spawn(["ruby", "/openc3/bin/openc3cli", "destroyscope", params[:id]], "scope_uninstall", params[:id], Time.now + 2.hours, scope: 'DEFAULT')
-    render :json => result
+    render json: result
   rescue Exception => e
     logger.error(e.formatted)
-    render(:json => { :status => 'error', :message => e.message }, :status => 500) and return
+    render json: { status: 'error', message: e.message }, status: 500
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/screens_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/screens_controller.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -22,7 +22,7 @@ class ScreensController < ApplicationController
     scope = sanitize_params([:scope])
     return unless scope
     scope = scope[0]
-    render :json => Screen.all(scope)
+    render json: Screen.all(scope)
   end
 
   def show
@@ -31,7 +31,7 @@ class ScreensController < ApplicationController
     return unless result
     screen = Screen.find(*result)
     if screen
-      render :json => screen
+      render json: screen
     else
       head :not_found
     end
@@ -45,10 +45,10 @@ class ScreensController < ApplicationController
     result << text
     screen = Screen.create(*result)
     OpenC3::Logger.info("Screen saved: #{params[:target]} #{params[:screen]}", scope: params[:scope], user: username())
-    render :json => screen
+    render json: screen
   rescue => e
     logger.error(e.formatted)
-    render(json: { status: 'error', message: e.message }, status: 500)
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def destroy
@@ -60,6 +60,6 @@ class ScreensController < ApplicationController
     head :ok
   rescue => e
     logger.error(e.formatted)
-    render(json: { status: 'error', message: e.message }, status: 500)
+    render json: { status: 'error', message: e.message }, status: 500
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/script_autocomplete_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/script_autocomplete_controller.rb
@@ -31,7 +31,7 @@ class ScriptAutocompleteController < ApplicationController
                     check check_tolerance wait wait_tolerance wait_check wait_check_tolerance)
 
   def reserved_item_names
-    render :json => OpenC3::Packet::RESERVED_ITEM_NAMES, :status => 200
+    render json: OpenC3::Packet::RESERVED_ITEM_NAMES
   end
 
   def keywords
@@ -45,14 +45,14 @@ class ScriptAutocompleteController < ApplicationController
     else
       []
     end
-    render :json => keywords, :status => 200
+    render json: keywords
   end
 
   def ace_autocomplete_data
     return unless authorization('system')
     autocomplete_data = build_autocomplete_data(params[:type], params[:scope])
     response.headers['Cache-Control'] = 'must-revalidate' # TODO: Browser is ignoring this and not caching anything for some reason. Future enhancement
-    render :json => autocomplete_data, :status => 200
+    render json: autocomplete_data
   end
 
   # private

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/secrets_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/secrets_controller.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -21,7 +21,7 @@ require 'openc3/utilities/secrets'
 class SecretsController < ApplicationController
   def index
     return unless authorization('admin')
-    render :json => OpenC3::Secrets.getClient.keys(scope: params[:scope])
+    render json: OpenC3::Secrets.getClient.keys(scope: params[:scope])
   end
 
   def create
@@ -39,7 +39,7 @@ class SecretsController < ApplicationController
     head :ok
   rescue => e
     logger.error(e.formatted)
-    render(json: { status: 'error', message: e.message }, status: 500)
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def destroy
@@ -49,6 +49,6 @@ class SecretsController < ApplicationController
     head :ok
   rescue => e
     logger.error(e.formatted)
-    render(json: { status: 'error', message: e.message }, status: 500)
+    render json: { status: 'error', message: e.message }, status: 500
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/storage_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/storage_controller.rb
@@ -32,7 +32,7 @@ class StorageController < ApplicationController
     # MatchData [0] is the full text, [1] is the captured group
     # downcase to make it look nicer, BucketExplorer.vue calls toUpperCase on the API requests
     buckets = matches.map { |match| match[1].downcase }.sort
-    render :json => buckets, :status => 200
+    render json: buckets
   end
 
   def volumes
@@ -45,7 +45,7 @@ class StorageController < ApplicationController
     volumes = matches.map { |match| match[1].downcase }.sort
     # Add a slash prefix to identify volumes separately from buckets
     volumes.map! {|volume| "/#{volume}" }
-    render :json => volumes, :status => 200
+    render json: volumes
   end
 
   def files
@@ -78,14 +78,14 @@ class StorageController < ApplicationController
     else
       raise "Unknown root #{params[:root]}"
     end
-    render :json => results, :status => 200
+    render json: results
   rescue OpenC3::Bucket::NotFound => e
     logger.error(e.formatted)
-    render :json => { :status => 'error', :message => e.message }, :status => 404
+    render json: { status: 'error', message: e.message }, status: 404
   rescue Exception => e
     logger.error(e.formatted)
     OpenC3::Logger.error("File listing failed: #{e.message}", user: username())
-    render :json => { status: 'error', message: e.message }, status: 500
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def exists
@@ -99,14 +99,14 @@ class StorageController < ApplicationController
                                  key: path,
                                  retries: false)
     if result
-      render :json => result, :status => 200
+      render json: result
     else
-      render :json => result, :status => 404
+      render json: result, status: 404
     end
   rescue Exception => e
     logger.error(e.formatted)
     OpenC3::Logger.error("File exists request failed: #{e.message}", user: username())
-    render :json => { status: 'error', message: e.message }, status: 500
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def download_file
@@ -116,11 +116,11 @@ class StorageController < ApplicationController
     filename = "/#{volume}/#{params[:object_id]}"
     filename = sanitize_path(filename)
     file = File.read(filename, mode: 'rb')
-    render :json => { filename: params[:object_id], contents: Base64.encode64(file) }
+    render json: { filename: params[:object_id], contents: Base64.encode64(file) }
   rescue Exception => e
     logger.error(e.formatted)
     OpenC3::Logger.error("Download failed: #{e.message}", user: username())
-    render :json => { status: 'error', message: e.message }, status: 500
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def get_download_presigned_request
@@ -133,11 +133,11 @@ class StorageController < ApplicationController
                                       key: path,
                                       method: :get_object,
                                       internal: params[:internal])
-    render :json => result, :status => 201
+    render json: result, status: 201
   rescue Exception => e
     logger.error(e.formatted)
     OpenC3::Logger.error("Download request failed: #{e.message}", user: username())
-    render :json => { status: 'error', message: e.message }, status: 500
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def get_upload_presigned_request
@@ -158,11 +158,11 @@ class StorageController < ApplicationController
                                       internal: params[:internal])
     OpenC3::Logger.info("S3 upload presigned request generated: #{bucket_name}/#{path}",
         scope: params[:scope], user: username())
-    render :json => result, :status => 201
+    render json: result, status: 201
   rescue Exception => e
     logger.error(e.formatted)
     OpenC3::Logger.error("Upload request failed: #{e.message}", user: username())
-    render :json => { status: 'error', message: e.message }, status: 500
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def delete
@@ -178,7 +178,7 @@ class StorageController < ApplicationController
   rescue Exception => e
     logger.error(e.formatted)
     OpenC3::Logger.error("Delete failed: #{e.message}", user: username())
-    render :json => { status: 'error', message: e.message }, status: 500
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   private

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/tables_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/tables_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -37,12 +37,11 @@ class TablesController < ApplicationController
     return unless scope
     begin
       file = Table.binary(scope, binary, definition, table)
-      results = { 'filename' => file.filename, 'contents' => Base64.encode64(file.contents) }
+      results = { filename: file.filename, contents: Base64.encode64(file.contents) }
       render json: results
     rescue Table::NotFound => e
       logger.error(e.formatted)
-      render(json: { status: 'error', message: e.message }, status: 404) and
-        return
+      render json: { status: 'error', message: e.message }, status: 404
     end
   end
 
@@ -52,11 +51,10 @@ class TablesController < ApplicationController
     return unless scope
     begin
       file = Table.definition(scope, definition, table)
-      render json: { 'filename' => file.filename, 'contents' => file.contents }
+      render json: { filename: file.filename, contents: file.contents }
     rescue Table::NotFound => e
       logger.error(e.formatted)
-      render(json: { status: 'error', message: e.message }, status: 404) and
-        return
+      render json: { status: 'error', message: e.message }, status: 404
     end
   end
 
@@ -66,11 +64,10 @@ class TablesController < ApplicationController
     return unless scope
     begin
       file = Table.report(scope, binary, definition, table)
-      render json: { 'filename' => file.filename, 'contents' => file.contents }
+      render json: { filename: file.filename, contents: file.contents }
     rescue Table::NotFound => e
       logger.error(e.formatted)
-      render(json: { status: 'error', message: e.message }, status: 404) and
-        return
+      render json: { status: 'error', message: e.message }, status: 404
     end
   end
 
@@ -84,13 +81,13 @@ class TablesController < ApplicationController
       results = {}
 
       if File.extname(name) == '.txt'
-        results = { 'contents' => file }
+        results = { contents: file }
       else
         locked = Table.locked?(scope, name)
         unless locked
           Table.lock(scope, name, username())
         end
-        results = { 'contents' => Base64.encode64(file), 'locked' => locked }
+        results = { contents: Base64.encode64(file), locked: locked }
       end
       render json: results
     else
@@ -109,8 +106,7 @@ class TablesController < ApplicationController
       render json: Table.load(scope, binary, definition)
     rescue Table::NotFound => e
       logger.error(e.formatted)
-      render(json: { status: 'error', message: e.message }, status: 404) and
-        return
+      render json: { status: 'error', message: e.message }, status: 404
     end
   end
 
@@ -123,8 +119,7 @@ class TablesController < ApplicationController
       head :ok
     rescue Table::NotFound => e
       logger.error(e.formatted)
-      render(json: { status: 'error', message: e.message }, status: 404) and
-        return
+      render json: { status: 'error', message: e.message }, status: 404
     end
   end
 
@@ -137,8 +132,7 @@ class TablesController < ApplicationController
       head :ok
     rescue Table::NotFound => e
       logger.error(e.formatted)
-      render(json: { status: 'error', message: e.message }, status: 404) and
-        return
+      render json: { status: 'error', message: e.message }, status: 404
     end
   end
 
@@ -148,11 +142,10 @@ class TablesController < ApplicationController
     return unless scope
     begin
       filename = Table.generate(scope, definition)
-      render json: { 'filename' => filename }
+      render json: { filename: filename }
     rescue Table::NotFound => e
       logger.error(e.formatted)
-      render(json: { status: 'error', message: e.message }, status: 404) and
-        return
+      render json: { status: 'error', message: e.message }, status: 404
     end
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/targets_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/targets_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -33,7 +33,7 @@ class TargetsController < ModelController
     scope = sanitize_params([:scope], require_params: true)
     return unless scope
     scope = scope[0]
-    render :json => @model_class.all_modified(scope: scope)
+    render json: @model_class.all_modified(scope: scope)
   end
 
   def modified_files
@@ -41,7 +41,7 @@ class TargetsController < ModelController
     scope, id = sanitize_params([:scope, :id], require_params: true)
     return unless scope
     begin
-      render :json => @model_class.modified_files(id, scope: scope)
+      render json: @model_class.modified_files(id, scope: scope)
     rescue Exception => e
       logger.error(e.formatted)
       OpenC3::Logger.info("Target '#{id} modified_files failed: #{e.message}", user: username())
@@ -70,7 +70,7 @@ class TargetsController < ModelController
     begin
       file = @model_class.download(id, scope: scope)
       if file
-        results = { 'filename' => file.filename, 'contents' => Base64.encode64(file.contents) }
+        results = { filename: file.filename, contents: Base64.encode64(file.contents) }
         render json: results
       else
         head :not_found
@@ -78,7 +78,7 @@ class TargetsController < ModelController
     rescue Exception => e
       logger.error(e.formatted)
       OpenC3::Logger.info("Target '#{id} download failed: #{e.message}", user: username())
-      render(json: { status: 'error', message: e.message }, status: 500) and return
+      render json: { status: 'error', message: e.message }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/time_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/time_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -24,7 +24,7 @@ class TimeController < ApplicationController
   def get_current
     response.headers["Cache-Control"] = "no-store"
     now = Time.now.to_nsec_from_epoch
-    render :json => {
+    render json: {
       now_nsec: now
     }
   end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/timeline_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/timeline_controller.rb
@@ -41,7 +41,7 @@ class TimelineController < ApplicationController
         ret << value
       end
     end
-    render :json => ret, :status => 200
+    render json: ret
   end
 
   # Create a new timeline returns object/hash of the timeline in json.
@@ -70,16 +70,16 @@ class TimelineController < ApplicationController
       model.create()
       model.deploy()
       OpenC3::Logger.info("Timeline created: #{params['name']}", scope: params[:scope], user: username())
-      render :json => model.as_json(:allow_nan => true), :status => 201
+      render json: model.as_json(:allow_nan => true), status: 201
     rescue RuntimeError, JSON::ParserError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue TypeError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => 'Invalid json object', 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: 'Invalid json object', type: e.class }, status: 400
     rescue OpenC3::TimelineInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     end
   end
 
@@ -93,13 +93,13 @@ class TimelineController < ApplicationController
     begin
       model = @model_class.get(name: params['name'], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => 'not found' }, :status => 404
+        render json: { status: 'error', message: 'not found' }, status: 404
       else
-        render :json => model.as_json(:allow_nan => true), :status => 200
+        render json: model.as_json(:allow_nan => true)
       end
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, :type => e.class, :e => e.to_s }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class, e: e.to_s }, status: 400
     end
   end
 
@@ -126,26 +126,26 @@ class TimelineController < ApplicationController
     return unless authorization('script_run')
     model = @model_class.get(name: params[:name], scope: params[:scope])
     if model.nil?
-      render :json => {
-        'status' => 'error',
-        'message' => "failed to find timeline: #{params[:name]}",
-      }, :status => 404
+      render json: {
+        status: 'error',
+        message: "failed to find timeline: #{params[:name]}",
+      }, status: 404
       return
     end
     begin
       model.update_color(color: params['color'])
       model.update()
       model.notify(kind: 'updated')
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue RuntimeError, JSON::ParserError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue TypeError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => 'Invalid json object', 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: 'Invalid json object', type: e.class }, status: 400
     rescue OpenC3::TimelineInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     end
   end
 
@@ -153,15 +153,12 @@ class TimelineController < ApplicationController
   #
   # name [String] the timeline name, `system42`
   # scope [String] the scope of the timeline, `TEST`
-  # @return [String] hash/object of timeline name in json with a 204 no-content status code
+  # @return [String] hash/object of timeline name in json with a 200 status code
   def destroy
     return unless authorization('script_run')
     model = @model_class.get(name: params[:name], scope: params[:scope])
     if model.nil?
-      render :json => {
-        'status' => 'error',
-        'message' => "failed to find timeline: #{params[:name]}",
-      }, :status => 404
+      render json: { status: 'error', message: "failed to find timeline: #{params[:name]}" }, status: 404
     else
       begin
         use_force = params[:force].nil? == false && params[:force] == 'true'
@@ -169,10 +166,10 @@ class TimelineController < ApplicationController
         model.undeploy()
         model.notify(kind: 'deleted')
         OpenC3::Logger.info("Timeline destroyed: #{params[:name]}", scope: params[:scope], user: username())
-        render :json => { 'name' => params[:name]}, :status => 204
+        render json: { name: params[:name]}
       rescue OpenC3::TimelineError => e
         logger.error(e.formatted)
-        render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+        render json: { status: 'error', message: e.message, type: e.class }, status: 400
       end
     end
   end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/tools_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/tools_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -30,9 +30,9 @@ class ToolsController < ModelController
   def show
     # No authorization required
     if params[:id].downcase == 'all'
-      render :json => @model_class.all(scope: params[:scope])
+      render json: @model_class.all(scope: params[:scope])
     else
-      render :json => @model_class.get(name: params[:id], scope: params[:scope])
+      render json: @model_class.get(name: params[:id], scope: params[:scope])
     end
   end
 
@@ -56,7 +56,7 @@ class ToolsController < ModelController
     inline_tools.each do |key, tool|
       result["imports"]["@openc3/tool-#{tool['folder_name']}"] = "/tools/#{tool['folder_name']}/#{tool['inline_url']}"
     end
-    render :json => result
+    render json: result
   end
 
   def auth
@@ -70,6 +70,6 @@ class ToolsController < ModelController
     end
     realm = ENV['OPENC3_KEYCLOAK_REALM']
     realm = "openc3" unless realm
-    render :js => "var openc3_keycloak_url = \"#{url}\"; var openc3_keycloak_realm = \"#{realm}\"; var openc3_keycloak_client_id = \"#{ENV['OPENC3_API_CLIENT']}\""
+    render js: "var openc3_keycloak_url = \"#{url}\"; var openc3_keycloak_realm = \"#{realm}\"; var openc3_keycloak_client_id = \"#{ENV['OPENC3_API_CLIENT']}\""
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/trigger_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/trigger_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -43,10 +43,10 @@ class TriggerController < ApplicationController
       triggers.each do |_, trigger|
         ret << trigger
       end
-      render :json => ret, :status => 200
+      render json: ret
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -61,16 +61,16 @@ class TriggerController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], group: params[:group], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue OpenC3::TriggerInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -111,16 +111,16 @@ class TriggerController < ApplicationController
       name = @model_class.create_unique_name(group: hash['group'], scope: params[:scope])
       model = @model_class.from_json(hash.symbolize_keys, name: name, scope: params[:scope])
       model.create() # Create sends a notification
-      render :json => model.as_json(:allow_nan => true), :status => 201
+      render json: model.as_json(:allow_nan => true), status: 201
     rescue OpenC3::TriggerInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue OpenC3::TriggerError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 418
+      render json: { status: 'error', message: e.message, type: e.class }, status: 418
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -170,16 +170,16 @@ class TriggerController < ApplicationController
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user updating the trigger
       model.notify(kind: 'updated')
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue OpenC3::TriggerInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue OpenC3::TriggerError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 418
+      render json: { status: 'error', message: e.message, type: e.class }, status: 418
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -205,17 +205,17 @@ class TriggerController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], group: params[:group], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
       # Notify the TriggerGroupMicroservice to enable the TriggerModel
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user enabling the trigger
       model.notify_enable()
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -241,24 +241,24 @@ class TriggerController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], group: params[:group], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
       # Notify the TriggerGroupMicroservice to disable the TriggerModel
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user disabling the trigger
       model.notify_disable()
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
   # group [String] the group name, `DEFAULT`
   # name [String] the trigger name, `TRIG0`
   # scope [String] the scope of the trigger, `DEFAULT`
-  # @return [String] object/hash converted into json format but with a 204 no-content status code
+  # @return [String] object/hash converted into json format but with a 200 status code
   # Request Headers
   #```json
   #  {
@@ -271,21 +271,21 @@ class TriggerController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], group: params[:group], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => NOT_FOUND }, :status => 404
+        render json: { status: 'error', message: NOT_FOUND }, status: 404
         return
       end
       unless model.dependents.empty?
-        render :json => { :status => 'error', :message => "#{model.group}:#{model.name} has dependents: #{model.dependents}", 'type' => 'TriggerError' }, :status => 404
+        render json: { status: 'error', message: "#{model.group}:#{model.name} has dependents: #{model.dependents}", type: 'TriggerError' }, status: 404
         return
       end
       # Notify the TriggerGroupMicroservice to delete the TriggerModel
       # We don't update directly here to avoid a race condition between the microservice
       # updating state and an asynchronous user deleting the trigger
       model.notify(kind: 'deleted')
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/trigger_group_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/trigger_group_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -42,10 +42,10 @@ class TriggerGroupController < ApplicationController
       trigger_groups.each do |_, trigger_group|
         ret << trigger_group
       end
-      render :json => ret, :status => 200
+      render json: ret
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -59,16 +59,16 @@ class TriggerGroupController < ApplicationController
     begin
       model = @model_class.get(name: params[:name], scope: params[:scope])
       if model.nil?
-        render :json => { :status => 'error', :message => 'not found' }, :status => 404
+        render json: { status: 'error', message: 'not found' }, status: 404
         return
       end
-      render :json => model.as_json(:allow_nan => true), :status => 200
+      render json: model.as_json(:allow_nan => true)
     rescue OpenC3::TriggerGroupInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -96,16 +96,16 @@ class TriggerGroupController < ApplicationController
       model = @model_class.new(name: params[:name], scope: params[:scope])
       model.create()
       model.deploy()
-      render :json => model.as_json(:allow_nan => true), :status => 201
+      render json: model.as_json(:allow_nan => true), status: 201
     rescue OpenC3::TriggerGroupInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue OpenC3::TriggerGroupError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 418
+      render json: { status: 'error', message: e.message, type: e.class }, status: 418
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 
@@ -114,7 +114,7 @@ class TriggerGroupController < ApplicationController
   # group [String] the trigger group name, `systemGroup`
   # scope [String] the scope of the trigger, `TEST`
   # id [String] the score or id of the trigger, `1620248449`
-  # @return [String] object/hash converted into json format but with a 204 no-content status code
+  # @return [String] object/hash converted into json format but with a 200 status code
   # Request Headers
   #```json
   #  {
@@ -126,16 +126,16 @@ class TriggerGroupController < ApplicationController
     return unless authorization('script_run')
     begin
       @model_class.delete(name: params[:group], scope: params[:scope])
-      render :json => { :delete => true, :group => params[:group] }, :status => 204
+      render json: { delete: true, group: params[:group] }
     rescue OpenC3::TriggerGroupInputError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 404
+      render json: { status: 'error', message: e.message, type: e.class }, status: 404
     rescue OpenC3::TriggerGroupError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class }, :status => 400
+      render json: { status: 'error', message: e.message, type: e.class }, status: 400
     rescue StandardError => e
       logger.error(e.formatted)
-      render :json => { :status => 'error', :message => e.message, 'type' => e.class, 'backtrace' => e.backtrace }, :status => 500
+      render json: { status: 'error', message: e.message, type: e.class, backtrace: e.backtrace }, status: 500
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/users_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ begin
 rescue LoadError
   class UsersController < ApplicationController
     def active()
-      render :json => [], :status => 200
+      render json: []
     end
 
     def logout()

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/activity_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/activity_controller_spec.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -249,14 +249,14 @@ RSpec.describe ActivityController, :type => :controller do
   end
 
   describe "DELETE destroy" do
-    it "returns a status code 204" do
+    it "returns a status code 200" do
       hash = generate_activity_hash(1.0)
       post :create, params: hash.merge({ 'scope'=>'DEFAULT', 'name'=>'test' })
       expect(response).to have_http_status(:created)
       created = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
       expect(created['start']).not_to be_nil
       delete :destroy, params: {'scope'=>'DEFAULT', 'name'=>'test', 'id'=>created['start'], 'uuid'=>created['uuid']}
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:success)
     end
 
     it "deletes items without uuids if uuid is not given" do
@@ -270,7 +270,7 @@ RSpec.describe ActivityController, :type => :controller do
       # Now add it back to the store and write over the existing activity
       OpenC3::Store.zadd('DEFAULT__openc3_timelines__test', created['start'], JSON.generate(created))
       delete :destroy, params: {'scope'=>'DEFAULT', 'name'=>'test', 'id'=>created['start']}
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:success)
     end
 
     it "returns a status code 404" do

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/environment_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/environment_controller_spec.rb
@@ -14,10 +14,10 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'rails_helper'
@@ -126,7 +126,7 @@ RSpec.describe EnvironmentController, :type => :controller do
       expect(response).to have_http_status(:created)
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
       delete :destroy, params: { 'scope' => 'DEFAULT', 'name' => json['name'] }
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:success)
       get :index, params: { 'scope' => 'DEFAULT', 'name' => json['name'] }
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/metadata_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/metadata_controller_spec.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -105,7 +105,7 @@ RSpec.describe MetadataController, :type => :controller do
 
     it "returns error and status 204 if no metadata" do
       get :latest,  params: { scope: 'DEFAULT' }
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:success)
       ret = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
       expect(ret['status']).to eql("error")
       expect(ret['message']).to match("no metadata entries")
@@ -293,7 +293,7 @@ RSpec.describe MetadataController, :type => :controller do
     it "successfully updates a metadata object with status code 204" do
       start = create_metadata()
       delete :destroy, params: { scope: 'DEFAULT', id: start.to_i }
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/notes_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/notes_controller_spec.rb
@@ -14,10 +14,10 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'rails_helper'
@@ -208,7 +208,7 @@ RSpec.describe NotesController, :type => :controller do
       expect(response).to have_http_status(:created)
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
       delete :destroy, params: { 'scope' => 'DEFAULT', 'id' => json['start'] }
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:success)
       get :index, params: { 'scope' => 'DEFAULT', 'name' => json['name'] }
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/timeline_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/timeline_controller_spec.rb
@@ -14,10 +14,10 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'rails_helper'
@@ -131,7 +131,7 @@ RSpec.describe TimelineController, :type => :controller do
       delete :destroy, params: {"scope"=>"DEFAULT", "name"=>"test"}
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
       expect(json["name"]).to eql("test")
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/trigger_group_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/trigger_group_controller_spec.rb
@@ -14,17 +14,15 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'rails_helper'
 
 RSpec.describe TriggerGroupController, :type => :controller do
-  NAME = 'systemGroup'.freeze
-
   before(:each) do
     mock_redis()
     allow_any_instance_of(OpenC3::MicroserviceModel).to receive(:create).and_return(nil)
@@ -32,7 +30,7 @@ RSpec.describe TriggerGroupController, :type => :controller do
 
   def generate_trigger_group_hash
     return {
-      'name': NAME,
+      'name': 'SystemGroup',
       'color': '#ff0000'
     }
   end
@@ -72,7 +70,7 @@ RSpec.describe TriggerGroupController, :type => :controller do
     end
   end
 
-  xdescribe 'POST two triggers with the same name on different scopes then GET index' do
+  describe 'POST two triggers with the same name on different scopes then GET index' do
     it 'returns an array of one and status code 200' do
       hash = generate_trigger_group_hash()
       post :create, params: hash.merge({'scope'=>'DEFAULT'})
@@ -81,8 +79,7 @@ RSpec.describe TriggerGroupController, :type => :controller do
       post :create, params: hash.merge({'scope'=>'TEST'})
       expect(response).to have_http_status(:created)
       test_json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
-      # name should not match
-      expect(default_json['name']).not_to eql(test_json['name'])
+      expect(default_json['name']).to eql(test_json['name'])
       # check the value on the index
       get :index, params: {'scope'=>'DEFAULT'}
       expect(response).to have_http_status(:ok)
@@ -110,7 +107,7 @@ RSpec.describe TriggerGroupController, :type => :controller do
   #   end
   # end
 
-  xdescribe 'POST' do
+  describe 'POST' do
     it 'returns a hash and status code 400 on error' do
       post :create, params: {'scope'=>'DEFAULT'}
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
@@ -128,25 +125,25 @@ RSpec.describe TriggerGroupController, :type => :controller do
     end
   end
 
-  xdescribe 'DELETE' do
+  describe 'DELETE' do
     it 'returns a json hash of name and status code 404 when not found' do
-      delete :destroy, params: {'scope'=>'DEFAULT', 'name'=>'test'}
+      delete :destroy, params: { scope: 'DEFAULT', group: 'test'}
       expect(response).to have_http_status(:not_found)
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
       expect(json['status']).to eql('error')
       expect(json['message']).not_to be_nil
     end
 
-    it 'returns a json hash of name and status code 204' do
+    it 'returns a json hash of name and status code 200' do
       allow_any_instance_of(OpenC3::MicroserviceModel).to receive(:undeploy).and_return(nil)
       hash = generate_trigger_group_hash()
       post :create, params: hash.merge({'scope'=>'DEFAULT'})
       expect(response).to have_http_status(:created)
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
-      delete :destroy, params: {'scope'=>'DEFAULT', 'name'=>json['name']}
-      expect(response).to have_http_status(:no_content)
+      delete :destroy, params: { scope: 'DEFAULT', group: json['name'] }
+      expect(response).to have_http_status(:success)
       json = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
-      expect(json['name']).to eql('test')
+      expect(json['group']).to eql('SystemGroup')
     end
   end
 end

--- a/openc3-cosmos-script-runner-api/app/controllers/application_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -59,13 +59,13 @@ class ApplicationController < ActionController::API
         token: request.headers['HTTP_AUTHORIZATION'],
       )
     rescue OpenC3::AuthError => e
-      render(json: { status: 'error', message: e.message }, status: 401) and
-        return false
+      render json: { status: 'error', message: e.message }, status: 401
+      return false
     rescue OpenC3::ForbiddenError => e
-      render(json: { status: 'error', message: e.message }, status: 403) and
-        return false
+      render json: { status: 'error', message: e.message }, status: 403
+      return false
     end
-    true
+    return true
   end
 
   def sanitize_params(param_list, require_params: true, allow_forward_slash: false)
@@ -90,7 +90,7 @@ class ApplicationController < ActionController::API
           value = arg.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.tr("\u{202E}%$|:;/\t\r\n\\", "-")
         end
         if value != arg
-          render(json: { status: 'error', message: "Invalid #{param_list[index]}: #{arg}" }, status: 400)
+          render json: { status: 'error', message: "Invalid #{param_list[index]}: #{arg}" }, status: 400
           return false
         end
       end

--- a/openc3-cosmos-script-runner-api/app/controllers/completed_script_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/completed_script_controller.rb
@@ -14,15 +14,15 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
-# This file may also be used under the terms of a commercial license 
+# This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 class CompletedScriptController < ApplicationController
   def index
     return unless authorization('script_view')
-    render :json => CompletedScript.all(params[:scope])
+    render json: CompletedScript.all(params[:scope])
   end
 end

--- a/openc3-cosmos-script-runner-api/app/controllers/running_script_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/running_script_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -23,14 +23,14 @@
 class RunningScriptController < ApplicationController
   def index
     return unless authorization('script_view')
-    render :json => RunningScript.all
+    render json: RunningScript.all
   end
 
   def show
     return unless authorization('script_view')
     running_script = RunningScript.find(params[:id].to_i)
     if running_script
-      render :json => running_script
+      render json: running_script
     else
       head :not_found
     end

--- a/openc3-cosmos-script-runner-api/app/controllers/scripts_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/scripts_controller.rb
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2024, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -43,7 +43,7 @@ class ScriptsController < ApplicationController
     scope = sanitize_params([:scope])
     return unless scope
     scope = scope[0]
-    render :json => Script.all(scope)
+    render json: Script.all(scope)
   end
 
   def delete_temp
@@ -51,7 +51,7 @@ class ScriptsController < ApplicationController
     scope = sanitize_params([:scope])
     return unless scope
     scope = scope[0]
-    render :json => Script.delete_temp(scope)
+    render json: Script.delete_temp(scope)
   end
 
   def body
@@ -77,7 +77,7 @@ class ScriptsController < ApplicationController
         results['error'] = results_error
         results['success'] = success
       end
-      # Using 'render :json => results' results in a raw json string like:
+      # Using 'render json: results' results in a raw json string like:
       # {"contents":"{\"json_class\":\"String\",\"raw\":[35,226,128...]}","breakpoints":[],"locked":false}
       render plain: JSON.generate(results)
     else
@@ -101,10 +101,10 @@ class ScriptsController < ApplicationController
       results['success'] = success
     end
     OpenC3::Logger.info("Script created: #{name}", scope: scope, user: username()) if success
-    render :json => results
+    render json: results
   rescue => e
     logger.error(e.formatted)
-    render(json: { status: 'error', message: e.message }, status: 500)
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def run
@@ -119,7 +119,7 @@ class ScriptsController < ApplicationController
     running_script_id = Script.run(scope, name, suite_runner, disconnect, environment, user_full_name(), username())
     if running_script_id
       OpenC3::Logger.info("Script started: #{name}", scope: scope, user: username())
-      render :plain => running_script_id.to_s
+      render plain: running_script_id.to_s
     else
       head :not_found
     end
@@ -151,7 +151,7 @@ class ScriptsController < ApplicationController
     head :ok
   rescue => e
     logger.error(e.formatted)
-    render(json: { status: 'error', message: e.message }, status: 500)
+    render json: { status: 'error', message: e.message }, status: 500
   end
 
   def syntax
@@ -163,7 +163,7 @@ class ScriptsController < ApplicationController
     return unless authorization('script_run', target_name: target_name)
     script = Script.syntax(name, request.body.read)
     if script
-      render :json => script
+      render json: script
     else
       head :error
     end
@@ -176,7 +176,7 @@ class ScriptsController < ApplicationController
     name = name[0]
     script = Script.instrumented(name, request.body.read)
     if script
-      render :json => script
+      render json: script
     else
       head :error
     end

--- a/openc3-cosmos-script-runner-api/scripts/run_script.rb
+++ b/openc3-cosmos-script-runner-api/scripts/run_script.rb
@@ -41,7 +41,7 @@ OpenC3::EphemeralStore.instance
 ENV['OPENC3_REDIS_USERNAME'] = nil
 ENV['OPENC3_REDIS_PASSWORD'] = nil
 
-SCRIPT_API = 'script-api'
+# Note: SCRIPT_API = 'script-api' in running_script.rb
 
 id = ARGV[0]
 script = JSON.parse(OpenC3::Store.get("running-script:#{id}"), :allow_nan => true, :create_additions => true)

--- a/openc3.code-workspace
+++ b/openc3.code-workspace
@@ -16,14 +16,8 @@
   "settings": {
     "rubyLsp.bundleGemfile": "openc3/Gemfile",
     "vetur.validation.template": false,
-    "eslint.validate": [
-      "vue",
-      "html",
-      "javascript"
-    ],
-    "eslint.workingDirectories": [
-      "./openc3-cosmos-init/plugins"
-    ],
+    "eslint.validate": ["vue", "html", "javascript"],
+    "eslint.workingDirectories": ["./openc3-cosmos-init/plugins"],
     "eslint.packageManager": "yarn",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {

--- a/openc3/lib/openc3/script/calendar.rb
+++ b/openc3/lib/openc3/script/calendar.rb
@@ -98,12 +98,7 @@ module OpenC3
         result = JSON.parse(response.body, :allow_nan => true, :create_additions => true)
         raise "#{error_message} due to #{result['message']}"
       end
-      # TODO: Not sure why the response body is empty (on delete) but check for that
-      if response.body.nil? or response.body.empty?
-        return nil
-      else
-        return JSON.parse(response.body, :allow_nan => true, :create_additions => true)
-      end
+      return JSON.parse(response.body, :allow_nan => true, :create_additions => true)
     end
   end
 end


### PR DESCRIPTION
Setting status to 204 means "No content" yet we were returning content in almost all the delete cases. This was causing a bug that we just worked around in calendar.rb but was just wrong based on our use. I also changed all the controllers to match the more common Rails style of symbol keys:

```
render json: { key: value, more: stuff}
```
rather than our existing mix of hash rocket with some symbol and some string keys:
```
render :json => { 'key' => value, :more => stuff}
```