### PR TITLE
Handle exceptions in ModelController

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/model_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/model_controller.rb
@@ -28,7 +28,7 @@ class ModelController < ApplicationController
     render json: @model_class.names(scope: params[:scope])
   rescue StandardError => error
     render json: { status: 'error', message: error.message }, status: 500
-    OpenC3::Logger.error(error.formatted)
+    logger.error(error.formatted)
   end
 
   def create(update_model = false)
@@ -44,7 +44,7 @@ class ModelController < ApplicationController
     head :ok
   rescue StandardError => error
     render json: { status: 'error', message: error.message }, status: 500
-    OpenC3::Logger.error(error.formatted)
+    logger.error(error.formatted)
   end
 
   def show
@@ -56,7 +56,7 @@ class ModelController < ApplicationController
     end
   rescue StandardError => error
     render json: { status: 'error', message: error.message }, status: 500
-    OpenC3::Logger.error(error.formatted)
+    logger.error(error.formatted)
   end
 
   def update
@@ -70,6 +70,6 @@ class ModelController < ApplicationController
     head :ok
   rescue StandardError => error
     render json: { status: 'error', message: error.message }, status: 500
-    OpenC3::Logger.error(error.formatted)
+    logger.error(error.formatted)
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/model_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/model_controller.rb
@@ -26,6 +26,9 @@ class ModelController < ApplicationController
   def index
     return unless authorization('system')
     render json: @model_class.names(scope: params[:scope])
+  rescue StandardError => error
+    render json: { status: 'error', message: error.message }, status: 500
+    OpenC3::Logger.error(error.formatted)
   end
 
   def create(update_model = false)
@@ -39,6 +42,9 @@ class ModelController < ApplicationController
       OpenC3::Logger.info("#{@model_class.name} created: #{params[:json]}", scope: params[:scope], user: username())
     end
     head :ok
+  rescue StandardError => error
+    render json: { status: 'error', message: error.message }, status: 500
+    OpenC3::Logger.error(error.formatted)
   end
 
   def show
@@ -48,6 +54,9 @@ class ModelController < ApplicationController
     else
       render json: @model_class.get(name: params[:id], scope: params[:scope])
     end
+  rescue StandardError => error
+    render json: { status: 'error', message: error.message }, status: 500
+    OpenC3::Logger.error(error.formatted)
   end
 
   def update
@@ -59,5 +68,8 @@ class ModelController < ApplicationController
     @model_class.new(name: params[:id], scope: params[:scope]).destroy
     OpenC3::Logger.info("#{@model_class.name} destroyed: #{params[:id]}", scope: params[:scope], user: username())
     head :ok
+  rescue StandardError => error
+    render json: { status: 'error', message: error.message }, status: 500
+    OpenC3::Logger.error(error.formatted)
   end
 end

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/tools/admin/tabs/ToolsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/tools/admin/tabs/ToolsTab.vue
@@ -156,12 +156,19 @@ export default {
         },
         // Tools are global and are always installed into the DEFAULT scope
         params: { scope: 'DEFAULT' },
-      }).then((response) => {
-        this.$notify.normal({
-          title: `Added tool ${this.name}`,
-        })
-        this.update()
       })
+        .then((response) => {
+          this.$notify.normal({
+            title: `Added tool ${this.name}`,
+          })
+          this.update()
+        })
+        .catch((error) => {
+          window.$cosmosNotify.serious({
+            title: `Failed to add tool ${this.name}`,
+            message: error.response.data,
+          })
+        })
     },
     editTool(name) {
       Api.get(`/openc3-api/tools/${name}`, {

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/tools/base/AppNav.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-common/src/tools/base/AppNav.vue
@@ -353,12 +353,20 @@ export default {
     navigateToUrl,
     newTabUrl(tool) {
       let url = null
-      if (tool.url[0] == '/' && tool.url[1] != '/') {
-        url = new URL(tool.url, window.location.origin)
-      } else {
-        url = new URL(tool.url)
+      try {
+        if (tool.url[0] == '/' && tool.url[1] != '/') {
+          url = new URL(tool.url, window.location.origin)
+        } else {
+          url = new URL(tool.url)
+        }
+        url.searchParams.set('scope', window.openc3Scope)
+      } catch (error) {
+        window.$cosmosNotify.serious({
+          title: `Invalid URL '${tool.url}' for tool ${tool.name}`,
+          message: error.message,
+        })
+        url.href = '/'
       }
-      url.searchParams.set('scope', window.openc3Scope)
       return url.href
     },
   },


### PR DESCRIPTION
Also handle bad URLs in ToolsTab and AppNav.

Any exception raised in a model.rb and not explicitly handled will just result in a 500 error. I recently made a change to `tool_model.rb` in #1701 that checks the URL and raises if it is bad. This just resulted in an unknown 500 error before the change but now shows a popup with the error message. 