### PR TITLE
Fix redirect from root path

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/router.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/router.js
@@ -24,9 +24,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { Empty } from '@openc3/vue-common/components'
 import { Login } from '@openc3/vue-common/tools/base'
 
-const DEFAULT_TOOL_PATH = '/tools/cmdtlmserver'
-
-const router = createRouter({
+export default createRouter({
   history: createWebHistory(),
   routes: [
     {
@@ -42,11 +40,3 @@ const router = createRouter({
     },
   ],
 })
-
-router.beforeEach(({ path }) => {
-  if (['/', '/tools', '/tools/'].includes(path)) {
-    singleSpaNavigate(DEFAULT_TOOL_PATH)
-  }
-})
-
-export default router

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
@@ -337,6 +337,20 @@ export default {
           urlRerouteOnly: true,
         })
 
+        // Redirect some base paths to the first tool
+        if (
+          window.location.pathname == '/' ||
+          window.location.pathname == '/tools' ||
+          window.location.pathname == '/tools/'
+        ) {
+          for (let key of Object.keys(this.shownTools)) {
+            if (this.appNav[key].shown) {
+              history.replaceState(null, '', this.appNav[key].url)
+              break
+            }
+          }
+        }
+
         // Check every minute if we need to update our token
         setInterval(() => {
           OpenC3Auth.updateToken(120).then(function (refreshed) {


### PR DESCRIPTION
I'm not sure what changed... This basically reverts what I did during the vue 3 migration since the `replaceState` solution from COSMOS 5 wasn't working back then. (Looks like Enterprise never got this, and it's happy)