### PR TITLE
Popups and horizontal scroll

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/src/BigWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/src/BigWidget.vue
@@ -22,7 +22,7 @@
 
 <template>
   <div class="value-widget-container">
-    <v-tooltip location="bottom">
+    <v-tooltip location="top">
       <template v-slot:activator="{ props }">
         <v-text-field
           variant="solo"

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -74,8 +74,8 @@
       <div class="pa-3">Status: {{ status }}</div>
     </v-card>
     <div style="height: 15px" />
-    <v-row>
-      <v-col>
+    <v-row no-gutters>
+      <v-col class="pr-4">
         <v-card class="pb-2">
           <v-card-subtitle>
             <v-row>
@@ -100,8 +100,10 @@
               </v-col>
             </v-row>
           </v-card-subtitle>
-          <v-row class="mt-2 mb-2">
-            <pre ref="editor" class="editor" data-test="sender-history"></pre>
+          <v-row no-gutters class="mt-2 mb-2">
+            <v-col>
+              <pre ref="editor" class="editor" data-test="sender-history"></pre>
+            </v-col>
           </v-row>
         </v-card>
       </v-col>

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
@@ -25,7 +25,7 @@
     <v-card-title class="d-flex align-center justify-content-space-between">
       {{ data.length }} Targets
       <v-spacer />
-      <v-tooltip location="bottom" :disabled="enterprise && commandAuthority">
+      <v-tooltip location="top" :disabled="enterprise && commandAuthority">
         <template v-slot:activator="{ props }">
           <!-- This is a little weird because it captures all the clicks -->
           <!-- including the clicks on the button so the tooltipHandler -->
@@ -51,7 +51,7 @@
           learn more.
         </span>
       </v-tooltip>
-      <v-tooltip location="bottom" :disabled="enterprise && commandAuthority">
+      <v-tooltip location="top" :disabled="enterprise && commandAuthority">
         <template v-slot:activator="{ props }">
           <div v-bind="props" @click="tooltipHandler('releaseAll')">
             <v-btn

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -103,7 +103,7 @@
           {{ processButtonText }}
         </v-btn>
         <v-spacer />
-        <v-tooltip location="bottom">
+        <v-tooltip location="top">
           <template v-slot:activator="{ props }">
             <v-btn
               icon="mdi-pencil"
@@ -116,7 +116,7 @@
           </template>
           <span> Edit All Items </span>
         </v-tooltip>
-        <v-tooltip location="bottom">
+        <v-tooltip location="top">
           <template v-slot:activator="{ props }">
             <v-btn
               icon="mdi-delete"
@@ -157,7 +157,7 @@
           density="compact"
         >
           <template v-slot:item.edit="{ item }">
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon
                   @click.stop="item.edit = true"
@@ -230,7 +230,7 @@
             </v-dialog>
           </template>
           <template v-slot:item.delete="{ item }">
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon
                   @click="deleteItem(item)"

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/AddComponentDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/AddComponentDialog.vue
@@ -122,7 +122,7 @@
                   density="compact"
                 >
                   <template v-slot:item.delete="{ item }">
-                    <v-tooltip location="bottom">
+                    <v-tooltip location="top">
                       <template v-slot:activator="{ props }">
                         <v-icon @click="deleteItem(item)" v-bind="props">
                           mdi-delete

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/DataViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/DataViewer.vue
@@ -115,7 +115,7 @@
         >
           {{ tab.tabName }}
         </v-tab>
-        <v-tooltip location="bottom">
+        <v-tooltip location="top">
           <template v-slot:activator="{ props }">
             <v-btn
               icon="mdi-tab-plus"
@@ -145,7 +145,7 @@
               <v-card-title class="pa-3 d-flex align-center">
                 <span v-text="tab.name" />
                 <v-spacer />
-                <v-tooltip location="bottom">
+                <v-tooltip location="top">
                   <template v-slot:activator="{ props }">
                     <v-btn
                       variant="text"

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/src/tools/LimitsMonitor/LimitsControl.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/src/tools/LimitsMonitor/LimitsControl.vue
@@ -81,7 +81,7 @@
             v-on:add-item="addItem"
             v-on:delete-item="deleteItem"
           />
-          <v-tooltip location="bottom">
+          <v-tooltip location="top">
             <template v-slot:activator="{ props }">
               <v-btn
                 icon="mdi-close-circle-multiple"
@@ -94,7 +94,7 @@
             </template>
             <span>Ignore Entire Packet</span>
           </v-tooltip>
-          <v-tooltip location="bottom">
+          <v-tooltip location="top">
             <template v-slot:activator="{ props }">
               <v-btn
                 icon="mdi-close-circle"
@@ -107,7 +107,7 @@
             </template>
             <span>Ignore Item</span>
           </v-tooltip>
-          <v-tooltip location="bottom">
+          <v-tooltip location="top">
             <template v-slot:activator="{ props }">
               <v-btn
                 icon="mdi-eye-off"

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/Dialogs/OverridesDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/Dialogs/OverridesDialog.vue
@@ -59,7 +59,7 @@
             density="compact"
           >
             <template v-slot:item.delete="{ item }">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <v-icon @click="deleteOverride(item)" v-bind="props">
                     mdi-delete

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/ScriptRunner.vue
@@ -109,7 +109,7 @@
         <v-icon v-if="showDisconnect" class="mt-2" color="red">
           mdi-connection
         </v-icon>
-        <v-tooltip location="bottom">
+        <v-tooltip location="top">
           <template v-slot:activator="{ props }">
             <v-btn
               v-bind="props"
@@ -178,7 +178,7 @@
           >
             <span> Start </span>
           </v-btn>
-          <v-tooltip location="bottom">
+          <v-tooltip location="top">
             <template v-slot:activator="{ props }">
               <v-btn
                 v-bind="props"

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/SuiteRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/src/tools/ScriptRunner/SuiteRunner.vue
@@ -27,7 +27,7 @@
         <v-col cols="4">
           <v-row no-gutters>
             <v-col cols="6">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <div v-bind="props">
                     <v-checkbox
@@ -46,7 +46,7 @@
               </v-tooltip>
             </v-col>
             <v-col cols="6">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <div v-bind="props">
                     <v-checkbox
@@ -121,7 +121,7 @@
         <v-col cols="4">
           <v-row no-gutters>
             <v-col cols="6">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <div v-bind="props">
                     <v-checkbox
@@ -141,7 +141,7 @@
               </v-tooltip>
             </v-col>
             <v-col cols="6">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <div v-bind="props">
                     <v-checkbox
@@ -221,7 +221,7 @@
         <v-col cols="4">
           <v-row no-gutters>
             <v-col cols="6">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <div v-bind="props">
                     <v-checkbox
@@ -241,7 +241,7 @@
               </v-tooltip>
             </v-col>
             <v-col cols="6">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <div v-bind="props">
                     <v-checkbox

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
@@ -122,7 +122,7 @@
             </v-btn>
           </v-col>
           <v-col cols="auto">
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <span v-bind="props">
                   <v-checkbox

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
@@ -137,7 +137,6 @@ import {
   Openc3Screen,
   OpenConfigDialog,
   SaveConfigDialog,
-  TargetPacketItemChooser,
   TopBar,
 } from '@openc3/vue-common/components'
 import NewScreenDialog from './NewScreenDialog'

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/App.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/App.vue
@@ -28,7 +28,7 @@
     <v-main :style="mainStyle" min-height="100vh">
       <v-container fluid height="100%">
         <div><router-view /></div>
-        <div id="openc3-tool"></div>
+        <div id="openc3-tool" style="overflow: auto"></div>
       </v-container>
     </v-main>
     <app-footer app class="d-print-none" />

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -30,7 +30,7 @@
         v-show="!hideToolbarData"
       >
         <div v-show="errors.length !== 0" class="mx-2">
-          <v-tooltip text="Errors" location="bottom">
+          <v-tooltip text="Errors" location="top">
             <template v-slot:activator="{ props }">
               <v-icon v-bind="props" @click="errorDialog = true"
                 >mdi-alert</v-icon
@@ -39,7 +39,7 @@
           </v-tooltip>
         </div>
 
-        <v-tooltip text="Edit" location="bottom">
+        <v-tooltip text="Edit" location="top">
           <template v-slot:activator="{ props }">
             <v-icon
               v-bind="props"
@@ -55,7 +55,7 @@
         <v-spacer />
 
         <div v-show="expand">
-          <v-tooltip v-if="calcFullSize" text="Collapse" location="bottom">
+          <v-tooltip v-if="calcFullSize" text="Collapse" location="top">
             <template v-slot:activator="{ props }">
               <v-icon
                 v-bind="props"
@@ -65,7 +65,7 @@
               >
             </template>
           </v-tooltip>
-          <v-tooltip v-else text="Expand" location="bottom">
+          <v-tooltip v-else text="Expand" location="top">
             <template v-slot:activator="{ props }">
               <v-icon v-bind="props" @click="expandAll" data-test="expand-all"
                 >mdi-arrow-expand</v-icon
@@ -75,7 +75,7 @@
         </div>
 
         <div v-show="expand">
-          <v-tooltip v-if="fullWidth" text="Collapse Width" location="bottom">
+          <v-tooltip v-if="fullWidth" text="Collapse Width" location="top">
             <template v-slot:activator="{ props }">
               <v-icon
                 v-bind="props"
@@ -85,7 +85,7 @@
               >
             </template>
           </v-tooltip>
-          <v-tooltip v-else text="Expand Width" location="bottom">
+          <v-tooltip v-else text="Expand Width" location="top">
             <template v-slot:activator="{ props }">
               <v-icon
                 v-bind="props"
@@ -98,7 +98,7 @@
         </div>
 
         <div v-show="expand">
-          <v-tooltip v-if="fullHeight" text="Collapse Height" location="bottom">
+          <v-tooltip v-if="fullHeight" text="Collapse Height" location="top">
             <template v-slot:activator="{ props }">
               <v-icon
                 v-bind="props"
@@ -108,7 +108,7 @@
               >
             </template>
           </v-tooltip>
-          <v-tooltip v-else text="Expand Height" location="bottom">
+          <v-tooltip v-else text="Expand Height" location="top">
             <template v-slot:activator="{ props }">
               <v-icon
                 v-bind="props"
@@ -120,7 +120,7 @@
           </v-tooltip>
         </div>
 
-        <v-tooltip v-if="expand" text="Minimize" location="bottom">
+        <v-tooltip v-if="expand" text="Minimize" location="top">
           <template v-slot:activator="{ props }">
             <v-icon
               v-bind="props"
@@ -130,7 +130,7 @@
             >
           </template>
         </v-tooltip>
-        <v-tooltip v-else text="Maximize" location="bottom">
+        <v-tooltip v-else text="Maximize" location="top">
           <template v-slot:activator="{ props }">
             <v-icon
               v-bind="props"
@@ -141,7 +141,7 @@
           </template>
         </v-tooltip>
 
-        <v-tooltip text="Close" location="bottom">
+        <v-tooltip text="Close" location="top">
           <template v-slot:activator="{ props }">
             <v-icon
               v-bind="props"
@@ -305,7 +305,7 @@
     <div v-if="!sparkline" class="u-series" ref="info">
       <v-tooltip
         text="Click item to toggle, Right click to edit"
-        location="bottom"
+        location="top"
       >
         <template v-slot:activator="{ props }">
           <v-icon v-bind="props">mdi-information-variant-circle</v-icon>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/GraphEditDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/GraphEditDialog.vue
@@ -134,7 +134,7 @@
             </v-row>
           </div>
           <div class="edit-box">
-            <v-list density="compact">
+            <v-list density="compact" class="horizontal-lines">
               <v-list-item>
                 <span style="padding-top: 5px">
                   Add horizontal lines to the graph
@@ -161,7 +161,7 @@
                     />
                   </v-col>
                   <v-col>
-                    <v-tooltip text="Remove" location="bottom">
+                    <v-tooltip text="Remove" location="top">
                       <template v-slot:activator="{ props }">
                         <v-icon
                           v-bind="props"
@@ -190,7 +190,7 @@
             }"
           >
             <template v-slot:item.actions="{ item }">
-              <v-tooltip text="Remove" location="bottom">
+              <v-tooltip text="Remove" location="top">
                 <template v-slot:activator="{ props }">
                   <v-icon v-bind="props" @click="$emit('remove', item)">
                     mdi-delete
@@ -386,5 +386,8 @@ export default {
 .v-small-dialog__content {
   background-color: var(--color-background-surface-selected);
   padding: 5px 5px;
+}
+.horizontal-lines {
+  background-color: var(--color-background-surface-default);
 }
 </style>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
@@ -22,8 +22,8 @@
 
 <template>
   <div class="pt-4 pb-4">
-    <v-row>
-      <v-col :cols="colSize" class="select" data-test="select-target">
+    <v-row no-gutters>
+      <v-col :cols="colSize" class="tpic-select pr-4" data-test="select-target">
         <v-autocomplete
           label="Select Target"
           hide-details
@@ -36,7 +36,7 @@
           v-model="selectedTargetName"
         />
       </v-col>
-      <v-col :cols="colSize" class="select" data-test="select-packet">
+      <v-col :cols="colSize" class="tpic-select pr-4" data-test="select-packet">
         <v-autocomplete
           label="Select Packet"
           hide-details
@@ -53,7 +53,7 @@
       <v-col
         v-if="chooseItem"
         :cols="colSize"
-        class="select"
+        class="tpic-select pr-4"
         data-test="select-item"
       >
         <v-autocomplete
@@ -72,7 +72,7 @@
       <v-col
         v-if="chooseItem && itemIsArray()"
         cols="1"
-        class="select"
+        class="tpic-select pr-4"
         data-test="array-index"
       >
         <v-combobox
@@ -99,8 +99,8 @@
         </v-btn>
       </v-col>
     </v-row>
-    <v-row v-if="selectTypes">
-      <v-col :cols="colSize" class="select" data-test="data-type">
+    <v-row no-gutters v-if="selectTypes" class="pt-6">
+      <v-col :cols="colSize" class="tpic-select pr-4" data-test="data-type">
         <v-autocomplete
           label="Value Type"
           hide-details
@@ -110,7 +110,7 @@
           v-model="selectedValueType"
         />
       </v-col>
-      <v-col :cols="colSize" class="select" data-test="reduced">
+      <v-col :cols="colSize" class="tpic-select pr-4" data-test="reduced">
         <v-autocomplete
           label="Reduced"
           hide-details
@@ -120,7 +120,7 @@
           v-model="selectedReduced"
         />
       </v-col>
-      <v-col :cols="colSize" class="select" data-test="reduced-type">
+      <v-col :cols="colSize" class="tpic-select pr-4" data-test="reduced-type">
         <v-autocomplete
           label="Reduced Type"
           hide-details
@@ -133,7 +133,7 @@
       </v-col>
       <v-col :cols="colSize" style="max-width: 140px"> </v-col>
     </v-row>
-    <v-row no-gutters class="pt-3 pb-3">
+    <v-row no-gutters class="pa-3">
       <v-col v-if="hazardous" :cols="colSize" class="openc3-yellow"
         >Description: {{ description }} (HAZARDOUS)</v-col
       >
@@ -606,7 +606,7 @@ export default {
 .button {
   padding: 4px;
 }
-.select {
+.tpic-select {
   max-width: 300px;
 }
 </style>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/DownloadDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/DownloadDialog.vue
@@ -81,7 +81,7 @@
                     <v-progress-circular indeterminate color="primary" />
                   </div>
                   <div v-else>
-                    <v-tooltip location="bottom">
+                    <v-tooltip location="top">
                       <template v-slot:activator="{ props }">
                         <v-icon
                           v-bind="props"

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/InterfacesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/InterfacesTab.vue
@@ -28,7 +28,7 @@
           <v-list-item-title>{{ openc3_interface }}</v-list-item-title>
 
           <template v-slot:append>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="showInterface(openc3_interface)">
                   mdi-eye

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/MicroservicesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/MicroservicesTab.vue
@@ -36,7 +36,7 @@
           <template v-slot:append>
             <div v-if="microservice_status[microservice]">
               <div v-show="!!microservice_status[microservice].error">
-                <v-tooltip location="bottom">
+                <v-tooltip location="top">
                   <template v-slot:activator="{ props }">
                     <v-icon
                       v-bind="props"
@@ -49,7 +49,7 @@
                 </v-tooltip>
               </div>
             </div>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="showMicroservice(microservice)">
                   mdi-eye

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/PackagesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/PackagesTab.vue
@@ -66,7 +66,7 @@
           </v-list-item-subtitle>
 
           <template v-slot:append v-if="process.state !== 'Running'">
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="showOutput(process)">
                   mdi-eye
@@ -86,7 +86,7 @@
           <v-list-item-title>{{ gem }}</v-list-item-title>
 
           <template v-slot:append>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="deletePackage(gem)">
                   mdi-delete
@@ -104,7 +104,7 @@
           <v-list-item-title>{{ pkg }}</v-list-item-title>
 
           <template v-slot:append>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="deletePackage(pkg)">
                   mdi-delete

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/PluginsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/PluginsTab.vue
@@ -90,7 +90,7 @@
             <div v-if="process.state === 'Running'">
               <v-progress-circular indeterminate color="primary" />
             </div>
-            <v-tooltip v-else location="bottom">
+            <v-tooltip v-else location="top">
               <template v-slot:activator="{ props }">
                 <v-icon
                   v-bind="props"
@@ -132,7 +132,7 @@
 
           <template v-slot:append>
             <div class="mx-3">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <v-icon
                     v-bind="props"
@@ -146,7 +146,7 @@
               </v-tooltip>
             </div>
             <div class="mx-3">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <v-icon
                     v-bind="props"
@@ -160,7 +160,7 @@
               </v-tooltip>
             </div>
             <div class="mx-3">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <v-icon
                     v-bind="props"
@@ -174,7 +174,7 @@
               </v-tooltip>
             </div>
             <div class="mx-3">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <v-icon
                     v-bind="props"

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RoutersTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RoutersTab.vue
@@ -28,7 +28,7 @@
           <v-list-item-title>{{ router }}</v-list-item-title>
 
           <template v-slot:append>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="showRouter(router)">
                   mdi-eye

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/SecretsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/SecretsTab.vue
@@ -69,7 +69,7 @@
           <v-list-item-title>{{ secret }}</v-list-item-title>
 
           <template v-slot:append>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="deleteSecret(secret)">
                   mdi-delete

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/TargetsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/TargetsTab.vue
@@ -32,7 +32,7 @@
 
           <template v-slot:append>
             <div class="mx-3" v-if="target.modified">
-              <v-tooltip location="bottom">
+              <v-tooltip location="top">
                 <template v-slot:activator="{ props }">
                   <v-icon v-bind="props" @click="downloadTarget(target.name)">
                     mdi-download
@@ -41,7 +41,7 @@
                 <span>Download Target Modified Files</span>
               </v-tooltip>
             </div>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="showTarget(target.name)">
                   mdi-eye

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/ToolsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/ToolsTab.vue
@@ -59,7 +59,7 @@
           <v-list-item-title>{{ tool }}</v-list-item-title>
 
           <template v-slot:append>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="showTool(tool)">
                   mdi-eye
@@ -67,7 +67,7 @@
               </template>
               <span>Edit Tool</span>
             </v-tooltip>
-            <v-tooltip location="bottom">
+            <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props" @click="deleteTool(tool)">
                   mdi-delete

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/ActivityCreateDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/ActivityCreateDialog.vue
@@ -234,10 +234,7 @@
 
 <script>
 import { Api } from '@openc3/js-common/services'
-import {
-  EnvironmentChooser,
-  ScriptChooser,
-} from '@/components'
+import { EnvironmentChooser, ScriptChooser } from '@/components'
 import { TimeFilters } from '@/util'
 import CreateDialog from './CreateDialog'
 

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LedWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LedWidget.vue
@@ -21,9 +21,9 @@
 -->
 
 <template>
-  <v-tooltip bottom>
-    <template v-slot:activator="{ attrs }">
-      <div class="led mt-1" :style="cssProps" v-bind="attrs"></div>
+  <v-tooltip location="top">
+    <template v-slot:activator="{ props }">
+      <div class="led mt-1" :style="cssProps" v-bind="props"></div>
     </template>
     <span>{{ fullName }}</span>
   </v-tooltip>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LimitsbarWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LimitsbarWidget.vue
@@ -17,9 +17,9 @@
 -->
 
 <template>
-  <v-tooltip bottom>
-    <template v-slot:activator="{ attrs }">
-      <div class="limitsbar" :style="[cssProps, computedStyle]" v-bind="attrs">
+  <v-tooltip location="top">
+    <template v-slot:activator="{ props }">
+      <div class="limitsbar" :style="[cssProps, computedStyle]" v-bind="props">
         <div class="limitsbar__container">
           <div class="limitsbar__redlow" />
           <div class="limitsbar__redhigh" />

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ValueWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ValueWidget.vue
@@ -22,7 +22,7 @@
 
 <template>
   <div class="value-widget-container" :style="[computedStyle, aging]">
-    <v-tooltip location="bottom">
+    <v-tooltip location="top">
       <template v-slot:activator="{ props }">
         <v-text-field
           variant="solo"


### PR DESCRIPTION
Two tooltip bugs in LedWidget and LimitsbarWidget. Moved all tooltip to the top for consistency. Added some no_gutter to Command Sender and TargetPacketItemChooser to prevent a permanent horizontal scroll bar due to `style="overflow: auto"` in App.vue