### PR TITLE
Small login bugs

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
@@ -343,6 +343,10 @@ export default {
           window.location.pathname == '/tools' ||
           window.location.pathname == '/tools/'
         ) {
+          // TODO: There's some sort of race condition here which makes this flaky if the user went to '/login' with
+          // no `?redirect=` query param while they were already authenticated. That sends them to '/', causing
+          // another redirect here that gets stepped on, so they're left at '/'. The nav bar shows, so they can click
+          // on a tool, or refresh the page to make this redirect actually happen.
           for (let key of Object.keys(this.shownTools)) {
             if (this.appNav[key].shown) {
               history.replaceState(null, '', this.appNav[key].url)


### PR DESCRIPTION
Couple minor issues that have been bugging me:
- If the user somehow goes to /login while they're already authenticated (e.g. from a browser bookmark), they shouldn't be asked for the password again
- If they ended up on /login with no `?redirect=` query param, `redirect.startsWith` would error and trigger the catch block that erroneously alerts them that they entered an incorrect password