### PR TITLE
Fix eslint config

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/eslint.config.mjs
@@ -8,31 +8,34 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends("plugin:prettier/recommended"), {
+export default [
+  ...compat.extends("plugin:prettier/recommended"),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        ecmaVersion: 2020,
-        sourceType: "module",
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
     },
-}];
+  },
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-admin/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-admin/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -426,9 +426,10 @@ export default {
       this.saveDefaultConfig(this.currentConfig)
     },
     cmdOrTlm: function () {
-      if (this.items.length === 0) { // just to prevent the save from happening twice
+      if (this.items.length === 0) {
         this.saveDefaultConfig(this.currentConfig)
       } else {
+        // Setting this.items will trigger a saveDefaultConfig() in the handler below
         this.items = []
       }
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-handbooks/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-handbooks/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmgrapher/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmgrapher/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,50 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/eslint.config.mjs
@@ -1,6 +1,5 @@
 import prettier from "eslint-plugin-prettier";
 import globals from "globals";
-import parser from "vue-eslint-parser";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
@@ -9,50 +8,34 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
-    "plugin:vue/vue3-essential",
-    "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+export default [
+  ...compat.extends("plugin:prettier/recommended"),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
-
-        "vue/multi-word-component-names": "off",
-
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
     },
-}, {
-    files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
-
-    languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
-    },
-}];
+  },
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,48 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/multi-word-component-names": "off",
+
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/eslint.config.mjs
@@ -1,4 +1,5 @@
 import prettier from "eslint-plugin-prettier";
+import prettierConfig from "@vue/eslint-config-prettier";
 import globals from "globals";
 import parser from "vue-eslint-parser";
 import path from "node:path";
@@ -9,51 +10,54 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:vue/vue3-essential",
     "plugin:prettier/recommended",
-    "@vue/prettier",
-), {
+  ),
+  {
     plugins: {
-        prettier,
+      prettier,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: parser,
-        ecmaVersion: 2022,
-        sourceType: "module",
+      parser: parser,
+      ecmaVersion: 2022,
+      sourceType: "module",
     },
 
     rules: {
-        "no-console": "error",
-        "no-debugger": "error",
-        // "logical-assignment-operators": "off",
+      "no-console": "error",
+      "no-debugger": "error",
 
-        "prettier/prettier": ["warn", {
-            endOfLine: "auto",
-        }],
+      "prettier/prettier": ["warn", {
+        endOfLine: "auto",
+      }],
 
-        "vue/multi-word-component-names": "off",
+      "vue/multi-word-component-names": "off",
 
-        "vue/valid-v-slot": ["error", {
-            allowModifiers: true,
-        }],
+      "vue/valid-v-slot": ["error", {
+        allowModifiers: true,
+      }],
     },
-}, {
+  },
+  {
     files: ["**/__tests__/*.{j,t}s?(x)", "**/tests/unit/**/*.spec.{j,t}s?(x)"],
 
     languageOptions: {
-        globals: {
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.jest,
+      },
     },
-}];
+  },
+  prettierConfig,
+];

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/NotFound.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/NotFound.vue
@@ -52,7 +52,10 @@ export default {
     }, 150)
   },
   unmounted() {
-    window.removeEventListener(SINGLE_SPA_APP_CHANGE_EVENT, this.handleAppChange)
+    window.removeEventListener(
+      SINGLE_SPA_APP_CHANGE_EVENT,
+      this.handleAppChange,
+    )
   },
   methods: {
     handleAppChange: function (event) {


### PR DESCRIPTION
`@vue/eslint-config-prettier` [v10.0.0](https://github.com/vuejs/eslint-config-prettier/releases/tag/v10.0.0) removed support for the legacy config format that we were using with `compat.extends([...] "@vue/prettier")`. Replaced that with the new flat format.

Also:
- removed the vue stuff from js-common's config
- bumped ace-diff ecmaVersion so it matches everything else
- cleaned up some ugliness that was generated by the eslint flat config migration tool