### PR TITLE
Fix code scanning alert no. 234: Prototype-polluting function

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/src/helpers/merge.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/src/helpers/merge.js
@@ -17,6 +17,7 @@ function isObject(item) {
 export default function merge(target, source) {
   if (isObject(target) && isObject(source)) {
     Object.keys(source).forEach((key) => {
+      if (key === "__proto__" || key === "constructor") return;
       if (isObject(source[key])) {
         if (!target[key] || !isObject(target[key])) {
           target[key] = source[key]

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/src/helpers/merge.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/src/helpers/merge.js
@@ -17,7 +17,7 @@ function isObject(item) {
 export default function merge(target, source) {
   if (isObject(target) && isObject(source)) {
     Object.keys(source).forEach((key) => {
-      if (key === "__proto__" || key === "constructor") return;
+      if (key === '__proto__' || key === 'constructor') return
       if (isObject(source[key])) {
         if (!target[key] || !isObject(target[key])) {
           target[key] = source[key]


### PR DESCRIPTION
Fixes [https://github.com/OpenC3/cosmos/security/code-scanning/234](https://github.com/OpenC3/cosmos/security/code-scanning/234)

To fix the prototype pollution issue, we need to ensure that the `merge` function does not allow properties like `__proto__` and `constructor` to be merged. This can be achieved by adding checks to skip these properties during the merge process.

- We will modify the `merge` function to include checks that skip the `__proto__` and `constructor` properties.
- Specifically, we will add a condition to the loop that iterates over the keys of the `source` object to skip these properties.
- This change will be made in the `openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/src/helpers/merge.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
