### PR TITLE
Bump Traefik to 3.3.1

### DIFF
--- a/openc3-traefik/Dockerfile
+++ b/openc3-traefik/Dockerfile
@@ -1,6 +1,6 @@
 ARG OPENC3_DEPENDENCY_REGISTRY=docker.io
 ARG TRAEFIK_CONFIG=traefik.yaml
-FROM ${OPENC3_DEPENDENCY_REGISTRY}/traefik:v3.2.3
+FROM ${OPENC3_DEPENDENCY_REGISTRY}/traefik:v3.3.1
 
 # An ARG declared before a FROM is outside of a build stage, so it can’t be
 # used in any instruction after a FROM. So we need to re-ARG.


### PR DESCRIPTION
Latest version in Ironbank and includes the patch for CVE-2024-45338