### PR TITLE
fix(packets): correct dict iteration syntax in Telemetry.identify_packet

### DIFF
--- a/openc3/python/openc3/packets/telemetry.py
+++ b/openc3/python/openc3/packets/telemetry.py
@@ -266,7 +266,7 @@ class Telemetry:
             target = self.system.targets[target_name]
             if target and target.tlm_unique_id_mode:
                 # Iterate through the packets and see if any represent the buffer
-                for _, packet in target_packets:
+                for _, packet in target_packets.items():
                     if packet.identify(packet_data):
                         return packet
             else:


### PR DESCRIPTION
The method was attempting to iterate over target_packets using tuple unpacking, but `.items()` was missing from the dict iteration. This would cause a TypeError since Python dictionaries require `.items()` for key-value pair iteration.

Changed:
`for _, packet in target_packets:`
to:
`for _, packet in target_packets.items():`

This ensures proper dictionary key-value pair iteration when identifying packets in tlm_unique_id_mode.