### PR TITLE
Fix import-map-overrides dialog style

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/index-allow-http.html
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/index-allow-http.html
@@ -79,6 +79,7 @@
     <import-map-overrides-full
       show-when-local-storage="devtools"
     ></import-map-overrides-full>
+    <script src="/js/fixImoStyle.js"></script>
     <script>
       ;(function () {
         Object.getPrototypeOf(System).firstGlobalProp = true

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/index.html
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/index.html
@@ -79,6 +79,7 @@
     <import-map-overrides-full
       show-when-local-storage="devtools"
     ></import-map-overrides-full>
+    <script src="/js/fixImoStyle.js"></script>
     <script>
       ;(function () {
         Object.getPrototypeOf(System).firstGlobalProp = true

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/fixImoStyle.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/fixImoStyle.js
@@ -1,0 +1,32 @@
+/*
+# Copyright 2025, OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+*/
+
+;(function () {
+  const css = `
+  .imo-module-dialog {
+    color: black;
+  }
+  `
+
+  const style = document.createElement('style')
+  style.appendChild(document.createTextNode(css))
+  const imo = document.getElementsByTagName('import-map-overrides-full')
+  if (imo.length) {
+    imo[0].shadowRoot.appendChild(style)
+  }
+})()

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/assets/stylesheets/layout/_overrides.scss
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/assets/stylesheets/layout/_overrides.scss
@@ -321,12 +321,3 @@ input {
 .v-list-item-action {
   margin-right: 15px !important;
 }
-
-// Fix the single spa debug panel so the text is readable
-.imo-modal-container form,
-.imo-modal-container input {
-  color: black;
-}
-.imo-module-dialog tr {
-  background-color: white;
-}


### PR DESCRIPTION
They changed to putting everything in the shadow DOM, which means we can't style it directly from our stylesheets anymore. Dialog text was unreadable due to it using the default `color: canvastext;` from the user-agent sheet for dialogs, which is `rgb(255,255,255)`. I think their [demo](https://user-images.githubusercontent.com/5524384/77237035-07476600-6b8a-11ea-9041-8b70f633d5d0.gif) still works because of differing themes.

Before:
<img width="482" alt="image" src="https://github.com/user-attachments/assets/e0955714-9e9c-4447-86eb-863bde4aee16" />

After:
<img width="480" alt="image" src="https://github.com/user-attachments/assets/68c52a26-bad8-4729-9fb1-18f2ee54a86f" />
