### PR TITLE
Fix title widget centering

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TitleWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TitleWidget.vue
@@ -21,9 +21,9 @@
 -->
 
 <template>
-  <span class="text-h5 text-center pa-1 mt-1 label" :style="computedStyle">
+  <div class="text-h5 text-center pa-1 mt-1 label" :style="computedStyle">
     {{ labelText }}
-  </span>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Closes https://github.com/OpenC3/cosmos/issues/1923

Looks like spans won't take a full-width anymore in Vuetify 3 (which imo is correct behavior anyway)

<img width="198" alt="image" src="https://github.com/user-attachments/assets/415d898b-602f-4040-9174-c78f4aca925d" />
