### PR TITLE
Fix multiple subscriptions on the same connection

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/channels/autonomic_events_channel.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/channels/autonomic_events_channel.rb
@@ -24,16 +24,18 @@ class AutonomicEventsChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
   def subscribed
-    stream_from uuid
-    @@broadcasters[uuid] = AutonomicEventsApi.new(uuid, self, params['history_count'], scope: scope)
+    subscription_key = "autonomic_events_#{uuid}"
+    stream_from subscription_key
+    @@broadcasters[subscription_key] = AutonomicEventsApi.new(subscription_key, params['history_count'], scope: scope)
   end
 
   def unsubscribed
-    if @@broadcasters[uuid]
-      stop_stream_from uuid
-      @@broadcasters[uuid].kill
-      @@broadcasters[uuid] = nil
-      @@broadcasters.delete(uuid)
+    subscription_key = "autonomic_events_#{uuid}"
+    if @@broadcasters[subscription_key]
+      stop_stream_from subscription_key
+      @@broadcasters[subscription_key].kill
+      @@broadcasters[subscription_key] = nil
+      @@broadcasters.delete(subscription_key)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/channels/calendar_events_channel.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/channels/calendar_events_channel.rb
@@ -24,16 +24,18 @@ class CalendarEventsChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
   def subscribed
-    stream_from uuid
-    @@broadcasters[uuid] = CalendarEventsApi.new(uuid, self, params['history_count'], scope: scope)
+    subscription_key = "calendar_events_#{uuid}"
+    stream_from subscription_key
+    @@broadcasters[subscription_key] = CalendarEventsApi.new(subscription_key, params['history_count'], scope: scope)
   end
 
   def unsubscribed
-    if @@broadcasters[uuid]
-      stop_stream_from uuid
-      @@broadcasters[uuid].kill
-      @@broadcasters[uuid] = nil
-      @@broadcasters.delete(uuid)
+    subscription_key = "calendar_events_#{uuid}"
+    if @@broadcasters[subscription_key]
+      stop_stream_from subscription_key
+      @@broadcasters[subscription_key].kill
+      @@broadcasters[subscription_key] = nil
+      @@broadcasters.delete(subscription_key)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/channels/config_events_channel.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/channels/config_events_channel.rb
@@ -20,16 +20,18 @@ class ConfigEventsChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
   def subscribed
-    stream_from uuid
-    @@broadcasters[uuid] = ConfigEventsApi.new(uuid, self, params['history_count'], scope: scope)
+    subscription_key = "config_events_#{uuid}"
+    stream_from subscription_key
+    @@broadcasters[subscription_key] = ConfigEventsApi.new(subscription_key, params['history_count'], scope: scope)
   end
 
   def unsubscribed
-    if @broadcasters[uuid]
-      stop_stream_from uuid
-      @@broadcasters[uuid].kill
-      @@broadcasters[uuid] = nil
-      @@broadcasters.delete(uuid)
+    subscription_key = "config_events_#{uuid}"
+    if @broadcasters[subscription_key]
+      stop_stream_from subscription_key
+      @@broadcasters[subscription_key].kill
+      @@broadcasters[subscription_key] = nil
+      @@broadcasters.delete(subscription_key)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/channels/limits_events_channel.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/channels/limits_events_channel.rb
@@ -24,16 +24,18 @@ class LimitsEventsChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
   def subscribed
-    stream_from uuid
-    @@broadcasters[uuid] = LimitsEventsApi.new(uuid, self, params['history_count'], scope: scope)
+    subscription_key = "limits_events_#{uuid}"
+    stream_from subscription_key
+    @@broadcasters[subscription_key] = LimitsEventsApi.new(subscription_key, params['history_count'], scope: scope)
   end
 
   def unsubscribed
-    if @@broadcasters[uuid]
-      stop_stream_from uuid
-      @@broadcasters[uuid].kill
-      @@broadcasters[uuid] = nil
-      @@broadcasters.delete(uuid)
+    subscription_key = "limits_events_#{uuid}"
+    if @@broadcasters[subscription_key]
+      stop_stream_from subscription_key
+      @@broadcasters[subscription_key].kill
+      @@broadcasters[subscription_key] = nil
+      @@broadcasters.delete(subscription_key)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/channels/messages_channel.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/channels/messages_channel.rb
@@ -20,11 +20,11 @@ class MessagesChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
   def subscribed
-    stream_from uuid
+    subscription_key = "messages_#{uuid}"
+    stream_from subscription_key
 
-    @@broadcasters[uuid] = MessagesApi.new(
-      uuid,
-      self,
+    @@broadcasters[subscription_key] = MessagesApi.new(
+      subscription_key,
       params["history_count"],
       start_offset: params["start_offset"],
       start_time: params["start_time"],
@@ -36,11 +36,12 @@ class MessagesChannel < ApplicationCable::Channel
   end
 
   def unsubscribed
-    if @@broadcasters[uuid]
-      stop_stream_from uuid
-      @@broadcasters[uuid].kill
-      @@broadcasters[uuid] = nil
-      @@broadcasters.delete(uuid)
+    subscription_key = "messages_#{uuid}"
+    if @@broadcasters[subscription_key]
+      stop_stream_from subscription_key
+      @@broadcasters[subscription_key].kill
+      @@broadcasters[subscription_key] = nil
+      @@broadcasters.delete(subscription_key)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/channels/streaming_channel.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/channels/streaming_channel.rb
@@ -24,16 +24,18 @@ class StreamingChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
   def subscribed
-    stream_from uuid
-    @@broadcasters[uuid] = StreamingApi.new(uuid, self, scope: scope)
+    subscription_key = "streaming_#{uuid}"
+    stream_from subscription_key
+    @@broadcasters[subscription_key] = StreamingApi.new(subscription_key, scope: scope)
   end
 
   def unsubscribed
-    if @@broadcasters[uuid]
-      stop_stream_from uuid
-      @@broadcasters[uuid].kill
-      @@broadcasters[uuid] = nil
-      @@broadcasters.delete(uuid)
+    subscription_key = "streaming_#{uuid}"
+    if @@broadcasters[subscription_key]
+      stop_stream_from subscription_key
+      @@broadcasters[subscription_key].kill
+      @@broadcasters[subscription_key] = nil
+      @@broadcasters.delete(subscription_key)
     end
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/channels/system_events_channel.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/channels/system_events_channel.rb
@@ -20,16 +20,18 @@ class SystemEventsChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
   def subscribed
-    stream_from uuid
-    @@broadcasters[uuid] = SystemEventsApi.new(uuid, self, params['history_count'], scope: scope)
+    subscription_key = "system_events_#{uuid}"
+    stream_from subscription_key
+    @@broadcasters[subscription_key] = SystemEventsApi.new(subscription_key, params['history_count'], scope: scope)
   end
 
   def unsubscribed
-    if @@broadcasters[uuid]
-      stop_stream_from uuid
-      @@broadcasters[uuid].kill
-      @@broadcasters[uuid] = nil
-      @@broadcasters.delete(uuid)
+    subscription_key = "system_events_#{uuid}"
+    if @@broadcasters[subscription_key]
+      stop_stream_from subscription_key
+      @@broadcasters[subscription_key].kill
+      @@broadcasters[subscription_key] = nil
+      @@broadcasters.delete(subscription_key)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/channels/timeline_events_channel.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/channels/timeline_events_channel.rb
@@ -24,16 +24,18 @@ class TimelineEventsChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
   def subscribed
-    stream_from uuid
-    @@broadcasters[uuid] = TimelineEventsApi.new(uuid, self, params['history_count'], scope: scope)
+    subscription_key = "timeline_events_#{uuid}"
+    stream_from subscription_key
+    @@broadcasters[subscription_key] = TimelineEventsApi.new(subscription_key, params['history_count'], scope: scope)
   end
 
   def unsubscribed
-    if @@broadcasters[uuid]
-      stop_stream_from uuid
-      @@broadcasters[uuid].kill
-      @@broadcasters[uuid] = nil
-      @@broadcasters.delete(uuid)
+    subscription_key = "timeline_events_#{uuid}"
+    if @@broadcasters[subscription_key]
+      stop_stream_from subscription_key
+      @@broadcasters[subscription_key].kill
+      @@broadcasters[subscription_key] = nil
+      @@broadcasters.delete(subscription_key)
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/models/autonomic_events_api.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/autonomic_events_api.rb
@@ -23,9 +23,9 @@
 require_relative 'topics_thread'
 
 class AutonomicEventsApi
-  def initialize(uuid, channel, history_count = 0, scope:)
+  def initialize(subscription_key, history_count = 0, scope:)
     topics = ["#{scope}__openc3_autonomic"] # MUST be equal to `AutonomicTopic::PRIMARY_KEY`
-    @thread = TopicsThread.new(topics, channel, history_count)
+    @thread = TopicsThread.new(topics, subscription_key, history_count)
     @thread.start
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/calendar_events_api.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/calendar_events_api.rb
@@ -23,9 +23,9 @@
 require_relative 'topics_thread'
 
 class CalendarEventsApi
-  def initialize(uuid, channel, history_count = 0, scope:)
+  def initialize(subscription_key, history_count = 0, scope:)
     topics = ["#{scope}__openc3_calendar"] # MUST be equal to CalendarTopic::PRIMARY_KEY
-    @thread = TopicsThread.new(topics, channel, history_count)
+    @thread = TopicsThread.new(topics, subscription_key, history_count)
     @thread.start
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/config_events_api.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/config_events_api.rb
@@ -19,10 +19,10 @@
 require_relative 'topics_thread'
 
 class ConfigEventsApi
-  def initialize(uuid, channel, history_count = 0, start_offset = nil, scope:)
+  def initialize(subscription_key, history_count = 0, start_offset = nil, scope:)
     topics = ["#{scope}__CONFIG"]
     start_offsets = [start_offset] if start_offset and start_offset != 'undefined'
-    @thread = TopicsThread.new(topics, channel, history_count, offsets: start_offsets, transmit_msg_id: true)
+    @thread = TopicsThread.new(topics, subscription_key, history_count, offsets: start_offsets, transmit_msg_id: true)
     @thread.start
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/limits_events_api.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/limits_events_api.rb
@@ -23,9 +23,9 @@
 require 'topics_thread'
 
 class LimitsEventsApi
-  def initialize(uuid, channel, history_count = 0, scope:)
+  def initialize(subscription_key, history_count = 0, scope:)
     topics = ["#{scope}__openc3_limits_events"]
-    @thread = TopicsThread.new(topics, channel, history_count)
+    @thread = TopicsThread.new(topics, subscription_key, history_count)
     @thread.start
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/messages_api.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/messages_api.rb
@@ -20,8 +20,7 @@ require_relative "messages_thread"
 
 class MessagesApi
   def initialize(
-    uuid,
-    channel,
+    subscription_key,
     history_count = 0,
     start_offset: nil,
     start_time: nil,
@@ -32,7 +31,7 @@ class MessagesApi
   )
     @thread =
       MessagesThread.new(
-        channel,
+        subscription_key,
         history_count,
         start_offset: start_offset,
         start_time: start_time,

--- a/openc3-cosmos-cmd-tlm-api/app/models/messages_thread.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/messages_thread.rb
@@ -23,7 +23,7 @@ class MessagesThread < TopicsThread
   ALLOWABLE_START_TIME_OFFSET_NSEC = 60 * Time::NSEC_PER_SECOND
 
   def initialize(
-    channel,
+    subscription_key,
     history_count = 0,
     max_batch_size = 100,
     start_offset: nil,
@@ -48,7 +48,7 @@ class MessagesThread < TopicsThread
     offsets = nil
     # $ means only new messages for the ephemeral topic
     offsets = [start_offset, "$"] if start_offset
-    super(@topics, channel, history_count, max_batch_size, offsets: offsets)
+    super(@topics, subscription_key, history_count, max_batch_size, offsets: offsets)
   end
 
   def setup_thread_body

--- a/openc3-cosmos-cmd-tlm-api/app/models/streaming_api.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/streaming_api.rb
@@ -30,9 +30,8 @@ require_relative 'streaming_object_collection'
 class StreamingApi
   include OpenC3::Authorization
 
-  def initialize(uuid, channel, scope: nil)
-    @uuid = uuid
-    @channel = channel
+  def initialize(subscription_key, scope: nil)
+    @subscription_key = subscription_key
     @mutex = Mutex.new
     @realtime_thread = nil
     @logged_threads = []
@@ -194,7 +193,7 @@ class StreamingApi
 
   def transmit_results(results, force: false)
     if results.length > 0 or force
-      ActionCable.server.broadcast(@channel.uuid, results.as_json(:allow_nan => true))
+      ActionCable.server.broadcast(@subscription_key, results.as_json(:allow_nan => true))
     end
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/system_events_api.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/system_events_api.rb
@@ -19,9 +19,9 @@
 require 'topics_thread'
 
 class SystemEventsApi
-  def initialize(uuid, channel, history_count = 0, scope:)
+  def initialize(subscription_key, history_count = 0, scope:)
     topics = ["OPENC3__SYSTEM__EVENTS"]
-    @thread = TopicsThread.new(topics, channel, history_count)
+    @thread = TopicsThread.new(topics, subscription_key, history_count)
     @thread.start
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/timeline_events_api.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/timeline_events_api.rb
@@ -23,9 +23,9 @@
 require_relative 'topics_thread'
 
 class TimelineEventsApi
-  def initialize(uuid, channel, history_count = 0, scope:)
+  def initialize(subscription_key, history_count = 0, scope:)
     topics = ["#{scope}__openc3_timelines"] # MUST be equal to TimelineTopic::PRIMARY_KEY
-    @thread = TopicsThread.new(topics, channel, history_count)
+    @thread = TopicsThread.new(topics, subscription_key, history_count)
     @thread.start
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/topics_thread.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/topics_thread.rb
@@ -24,10 +24,10 @@ require 'openc3'
 OpenC3.require_file 'openc3/utilities/store'
 
 class TopicsThread
-  def initialize(topics, channel, history_count = 0, max_batch_size = 100, offsets: nil, transmit_msg_id: false)
+  def initialize(topics, subscription_key, history_count = 0, max_batch_size = 100, offsets: nil, transmit_msg_id: false)
     @topics = topics
     @offsets = offsets
-    @channel = channel
+    @subscription_key = subscription_key
     @history_count = history_count.to_i
     @max_batch_size = max_batch_size
     @transmit_msg_id = transmit_msg_id
@@ -70,7 +70,7 @@ class TopicsThread
 
   def transmit_results(results, force: false)
     if results.length > 0 or force
-      ActionCable.server.broadcast(@channel.uuid, results.as_json(:allow_nan => true))
+      ActionCable.server.broadcast(@subscription_key, results.as_json(:allow_nan => true))
     end
   end
 

--- a/openc3-cosmos-cmd-tlm-api/spec/channels/streaming_channel_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/channels/streaming_channel_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe StreamingChannel, :type => :channel do
   it "subscribes" do
     subscribe()
     expect(subscription).to be_confirmed
-    expect(subscription).to have_stream_from('12345')
+    expect(subscription).to have_stream_from('streaming_12345')
   end
 
   context "adds" do

--- a/openc3-cosmos-cmd-tlm-api/spec/models/streaming_api_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/models/streaming_api_spec.rb
@@ -125,14 +125,13 @@ RSpec.describe StreamingApi, type: :model do
     end
 
     @messages = []
-    @channel = double('channel')
-    allow(@channel).to receive(:uuid).and_return("abc123")
+    @subscription_key = "streaming_abc123"
 
     allow(ActionCable.server).to receive(:broadcast) do |uuid, message|
       @messages << message
     end
 
-    @api = StreamingApi.new(123, @channel, scope: 'DEFAULT')
+    @api = StreamingApi.new(@subscription_key, scope: 'DEFAULT')
   end
 
   after(:each) do
@@ -142,7 +141,6 @@ RSpec.describe StreamingApi, type: :model do
   it 'stores the channel and threads' do
     expect(@api.instance_variable_get('@realtime_thread')).to be_nil
     expect(@api.instance_variable_get('@logged_threads')).to be_empty
-    expect(@api.instance_variable_get('@channel')).to eq(@channel)
   end
 
   context 'streaming with Redis' do


### PR DESCRIPTION
LimitsMonitor had two channels on the same cable, which was causing problems because they were both using the same uuid.  This change will allow for different channels on the same cable.