### PR TITLE
Fix bug in confirm dialog with validation text

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/dialog/ConfirmDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/dialog/ConfirmDialog.vue
@@ -110,14 +110,19 @@ export default {
       this.reject = reject
     },
     ok: function () {
-      if (this.params.validateText === this.validationText) {
+      if (!this.params.validateText || this.params.validateText === this.validationText) {
         this.show = false
         this.resolve(true)
+        this.refresh()
       }
     },
     cancel: function () {
       this.show = false
       this.reject(true)
+      this.refresh()
+    },
+    refresh: function () {
+      this.validationText = ''
     },
   },
 }


### PR DESCRIPTION
If you opened a dialog where you inputted validation text, subsequent non-validation-text dialogs on that page wouldn't work