### PR TITLE
Fix script runner size

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -21,7 +21,7 @@
 -->
 
 <template>
-  <div v-if="!inline">
+  <template v-if="!inline">
     <top-bar :menus="menus" :title="title" />
     <v-snackbar
       v-model="showAlert"
@@ -297,7 +297,7 @@
         />
       </pane>
     </splitpanes>
-  </div>
+  </template>
 
   <div v-if="inline">
     <v-row>


### PR DESCRIPTION
Wrapping it in an extraneous div broke a css selector