### PR TITLE
Don't make path clickable in Bucket Explorer

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/src/tools/BucketExplorer/BucketExplorer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/src/tools/BucketExplorer/BucketExplorer.vue
@@ -96,15 +96,15 @@
               aria-label="Navigate Back"
               @click.stop="backArrow"
             />
-            <span class=".text-body-1 ma-2 font-size" data-test="file-path">
-              <a
-                v-for="(part, index) in breadcrumbPath"
-                :key="index"
-                style="cursor: pointer"
-                @click.prevent="gotoPath(part.path)"
-                >/&nbsp;{{ part.name }}&nbsp;
-              </a>
-            </span>
+            <div class=".text-body-1 ma-2 font-size" data-test="file-path">
+              <span v-for="(part, index) in breadcrumbPath" :key="index">
+                /&nbsp;<a
+                  style="cursor: pointer"
+                  @click.prevent="gotoPath(part.path)"
+                  >{{ part.name }}
+                </a>
+              </span>
+            </div>
             <v-spacer />
             <div class="ma-2 font-size">
               Folder Size: {{ folderTotal }}
@@ -559,7 +559,12 @@ export default {
         data: this.file,
       })
       this.file = null
-      this.path = this.uploadFilePath.split('/').slice(0, -1).join('/') + '/'
+      let parts = this.uploadFilePath.split('/')
+      if (parts.length > 1) {
+        this.path = parts.slice(0, -1).join('/') + '/'
+      } else {
+        this.path = ''
+      }
       this.updateFiles()
     },
     deleteFile(filename) {


### PR DESCRIPTION
Previously the slash and the space around the slash was clickable which caused weird issues if you clicked it. I also fixed a bug when uploading to the root where it would append an extra slash.
<img width="538" alt="Screenshot 2025-04-25 at 2 59 37 PM" src="https://github.com/user-attachments/assets/9d2aa4d4-966c-4f75-b645-36a55a29ee73" />
