### PR TITLE
Move root redirect to nav guard

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
@@ -337,24 +337,6 @@ export default {
           urlRerouteOnly: true,
         })
 
-        // Redirect some base paths to the first tool
-        if (
-          window.location.pathname == '/' ||
-          window.location.pathname == '/tools' ||
-          window.location.pathname == '/tools/'
-        ) {
-          // TODO: There's some sort of race condition here which makes this flaky if the user went to '/login' with
-          // no `?redirect=` query param while they were already authenticated. That sends them to '/', causing
-          // another redirect here that gets stepped on, so they're left at '/'. The nav bar shows, so they can click
-          // on a tool, or refresh the page to make this redirect actually happen.
-          for (let key of Object.keys(this.shownTools)) {
-            if (this.appNav[key].shown) {
-              history.replaceState(null, '', this.appNav[key].url)
-              break
-            }
-          }
-        }
-
         // Check every minute if we need to update our token
         setInterval(() => {
           OpenC3Auth.updateToken(120).then(function (refreshed) {


### PR DESCRIPTION
This fixes the issue where going to the route `'/'` did not reliably redirect you to the first tool. I don't want this redirect to get hung up on a slow API response, so I added a timeout of 150ms before it gives up and goes to a hardcoded cmdtlmserver

Looks like this also fixes [this todo](https://github.com/OpenC3/cosmos/blob/4641f87651947a917c677512aaf0dcffc8102abc/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue#L346-L349).

Will also need the same change made in Enterprise once this PR is approved