### PR TITLE
[Unit Tests] - Script Runner API

### DIFF
--- a/openc3-cosmos-script-runner-api/config/environments/test.rb
+++ b/openc3-cosmos-script-runner-api/config/environments/test.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
@@ -47,4 +47,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Silence logs during test runs
+  config.log_level = :fatal # Only log fatal errors
 end

--- a/openc3-cosmos-script-runner-api/spec/controllers/running_script_controller_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/controllers/running_script_controller_spec.rb
@@ -1,0 +1,380 @@
+# encoding: ascii-8bit
+
+# Copyright 2025 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+require "rails_helper"
+
+RSpec.describe RunningScriptController, type: :controller do
+  before(:each) do
+    mock_redis
+
+    # Create a script in Redis
+    script_status = OpenC3::ScriptStatusModel.new(
+      name: "1",
+      state: "running",
+      scope: "DEFAULT",
+      filename: "INST/procedures/test.rb",
+      current_filename: "INST/procedures/test.rb",
+      line_no: 10,
+      start_time: Time.now.utc.iso8601,
+      username: "test_user",
+      user_full_name: "Test Tester"
+    )
+    script_status.create
+
+    allow(OpenC3::Logger).to receive(:info)
+  end
+
+  describe "GET index" do
+    it "returns a list of running scripts" do
+      get :index, params: {"scope" => "DEFAULT"}
+      expect(response.status).to eq(200)
+      expect(response.content_type).to include("application/json")
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json).to include(:items, :total)
+      expect(json[:items]).to be_an(Array)
+      expect(json[:total]).to eq(1)
+    end
+
+    it "respects limit and offset parameters" do
+      get :index, params: {"scope" => "DEFAULT", "limit" => 1, "offset" => 0}
+      expect(response.status).to eq(200)
+      json = JSON.parse(response.body)
+      expect(json["items"].size).to eq(1)
+
+      get :index, params: {"scope" => "DEFAULT", "limit" => 1, "offset" => 1}
+      expect(response.status).to eq(200)
+      json = JSON.parse(response.body)
+      expect(json["items"].size).to eq(0)
+    end
+
+    it "handles forbidden errors when authorization is enabled" do
+      get :index
+      expect(response.status).to eq(401)
+    end
+  end
+
+  describe "GET show" do
+    context "when script exists" do
+      it "returns the script by id" do
+        get :show, params: {id: "1", scope: "DEFAULT"}
+
+        expect(response.status).to eq(200)
+        expect(response.content_type).to include("application/json")
+
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(json[:name]).to eq("1")
+        expect(json[:state]).to eq("running")
+        expect(json[:filename]).to eq("INST/procedures/test.rb")
+      end
+    end
+
+    context "when script does not exist" do
+      it "returns not found" do
+        get :show, params: {id: "999", scope: "DEFAULT"}
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "script control actions" do
+    describe "POST stop" do
+      context "when script exists" do
+        it "stops the script" do
+          expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "stop")
+
+          post :stop, params: {id: "1", scope: "DEFAULT"}
+
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when script does not exist" do
+        it "returns not found" do
+          post :stop, params: {id: "999", scope: "DEFAULT"}
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+
+    describe "POST pause" do
+      context "when script exists" do
+        it "pauses the script" do
+          expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "pause")
+
+          post :pause, params: {id: "1", scope: "DEFAULT"}
+
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when script does not exist" do
+        it "returns not found" do
+          post :pause, params: {id: "999", scope: "DEFAULT"}
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+
+    describe "POST go" do
+      context "when script exists" do
+        it "resumes the script" do
+          expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "go")
+
+          post :go, params: {id: "1", scope: "DEFAULT"}
+
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when script does not exist" do
+        it "returns not found" do
+          post :go, params: {id: "999", scope: "DEFAULT"}
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+
+    describe "POST step" do
+      context "when script exists" do
+        it "steps the script" do
+          expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "step")
+
+          post :step, params: {id: "1", scope: "DEFAULT"}
+
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when script does not exist" do
+        it "returns not found" do
+          post :step, params: {id: "999", scope: "DEFAULT"}
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+
+    describe "POST retry" do
+      context "when script exists" do
+        it "retries the script" do
+          expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "retry")
+
+          post :retry, params: {id: "1", scope: "DEFAULT"}
+
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when script does not exist" do
+        it "returns not found" do
+          post :retry, params: {id: "999", scope: "DEFAULT"}
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+  end
+
+  describe "DELETE delete" do
+    before(:each) do
+      allow(Process).to receive(:kill)
+      allow(Process).to receive(:getpgid)
+    end
+
+    context "when script exists" do
+      before(:each) do
+        # Create a script model with a pid for the delete action to work with
+        script_model = double("ScriptModel")
+        allow(script_model).to receive(:name).and_return("INST/procedures/test.rb")
+        allow(script_model).to receive(:pid).and_return("12345")
+        allow(OpenC3::ScriptStatusModel).to receive(:get_model).and_return(script_model)
+      end
+
+      it "stops and deletes the script" do
+        allow(Process).to receive(:getpgid).and_raise(Errno::ESRCH)
+        expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "stop")
+
+        delete :delete, params: {id: "1", scope: "DEFAULT"}
+
+        expect(response.status).to eq(200)
+      end
+
+      it "uses SIGINT if stop command doesn't work" do
+        # First call to Process.getpgid returns true (process still running)
+        # Second call raises ESRCH (process stopped after SIGINT)
+        call_count = 0
+        allow(Process).to receive(:getpgid) do
+          call_count += 1
+          if call_count <= 10 # First 10 calls (for the first second)
+            12345 # Return pid, meaning process is still running
+          else
+            raise Errno::ESRCH # Process has stopped
+          end
+        end
+
+        expect(Process).to receive(:kill).with("SIGINT", 12345)
+        expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "stop")
+
+        delete :delete, params: {id: "1", scope: "DEFAULT"}
+
+        expect(response.status).to eq(200)
+      end
+
+      it "uses SIGKILL if process still doesn't stop" do
+        # All calls to Process.getpgid return true (process never stops)
+        allow(Process).to receive(:getpgid).and_return(12345)
+
+        script_model = double("ScriptModel")
+        allow(script_model).to receive(:name).and_return("INST/procedures/test.rb")
+        allow(script_model).to receive(:pid).and_return("12345")
+        allow(script_model).to receive(:end_time=) do |value|
+          @end_time = value
+        end
+        allow(script_model).to receive(:state=) do |value|
+          @state = value
+        end
+        allow(script_model).to receive(:update)
+        allow(OpenC3::ScriptStatusModel).to receive(:get_model).and_return(script_model)
+
+        expect(Process).to receive(:kill).with("SIGINT", 12345)
+        expect(Process).to receive(:kill).with("SIGKILL", 12345)
+        expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "stop")
+
+        delete :delete, params: {id: "1", scope: "DEFAULT"}
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when script does not exist" do
+      it "returns not found" do
+        delete :delete, params: {id: "999", scope: "DEFAULT"}
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "script prompt interactions" do
+    context "when script exists" do
+      it "handles standard answer prompts" do
+        expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).with(
+          "cmd-running-script-channel:1",
+          {method: "ask", answer: "yes", prompt_id: "abc123"}
+        )
+
+        post :prompt, params: {
+          id: "1",
+          scope: "DEFAULT",
+          method: "ask",
+          answer: "yes",
+          prompt_id: "abc123"
+        }
+
+        expect(response.status).to eq(200)
+      end
+
+      it "handles password prompts" do
+        expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).with(
+          "cmd-running-script-channel:1",
+          {method: "prompt_for_hazardous", password: "secret", prompt_id: "abc123"}
+        )
+
+        post :prompt, params: {
+          id: "1",
+          scope: "DEFAULT",
+          method: "prompt_for_hazardous",
+          password: "secret",
+          prompt_id: "abc123"
+        }
+
+        expect(response.status).to eq(200)
+      end
+
+      it "handles multiple choice prompts" do
+        multiple_options = ["option1", "option2"]
+
+        expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).with(
+          "cmd-running-script-channel:1",
+          {method: "combo_box", multiple: JSON.generate(multiple_options), prompt_id: "abc123"}
+        )
+
+        post :prompt, params: {
+          id: "1",
+          scope: "DEFAULT",
+          method: "combo_box",
+          multiple: true,
+          answer: multiple_options,
+          prompt_id: "abc123"
+        }
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when script does not exist" do
+      it "returns not found" do
+        post :prompt, params: {
+          id: "999",
+          scope: "DEFAULT",
+          prompt_id: "abc123"
+        }
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "script method invocation" do
+    context "when script exists" do
+      it "invokes a method with arguments" do
+        method_args = ["arg1", "arg2"]
+
+        expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).with(
+          "cmd-running-script-channel:1",
+          {method: "some_method", args: method_args, prompt_id: "abc123"}
+        )
+
+        post :method, params: {
+          id: "1",
+          scope: "DEFAULT",
+          method: "some_method",
+          args: method_args,
+          prompt_id: "abc123"
+        }
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when script does not exist" do
+      it "returns not found" do
+        post :method, params: {
+          id: "999",
+          scope: "DEFAULT",
+          method: "some_method",
+          args: ["arg1", "arg2"],
+          prompt_id: "abc123"
+        }
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/openc3-cosmos-script-runner-api/spec/controllers/scripts_controller_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/controllers/scripts_controller_spec.rb
@@ -1,7 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2025
-# OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it

--- a/openc3-cosmos-script-runner-api/spec/controllers/scripts_controller_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/controllers/scripts_controller_spec.rb
@@ -1,6 +1,7 @@
 # encoding: ascii-8bit
 
-# Copyright 2022 OpenC3, Inc.
+# Copyright 2025
+# OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -16,14 +17,77 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
-require 'rails_helper'
-require 'openc3/utilities/aws_bucket'
-require_relative '../../app/models/script'
+require "rails_helper"
+require "openc3/utilities/aws_bucket"
+require_relative "../../app/models/script"
 
-RSpec.describe ScriptsController, :type => :controller do
+RSpec.describe ScriptsController, type: :controller do
   before(:each) do
-    ENV.delete('OPENC3_LOCAL_MODE')
-    mock_redis()
+    ENV.delete("OPENC3_LOCAL_MODE")
+    mock_redis
+  end
+
+  describe "ping" do
+    it "returns OK" do
+      get :ping
+      expect(response.body).to eq("OK")
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "index" do
+    it "returns all scripts" do
+      scripts = [
+        {"name" => "script1.rb", "modified_time" => Time.now.to_s},
+        {"name" => "script2.rb", "modified_time" => Time.now.to_s}
+      ]
+      expect(Script).to receive(:all).with("DEFAULT", nil).and_return(scripts)
+
+      get :index, params: {scope: "DEFAULT"}
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json.length).to eq(2)
+      expect(json[0]["name"]).to eq("script1.rb")
+    end
+
+    it "returns scripts filtered by target" do
+      scripts = [
+        {"name" => "INST/script1.rb", "modified_time" => Time.now.to_s}
+      ]
+      expect(Script).to receive(:all).with("DEFAULT", "INST").and_return(scripts)
+
+      get :index, params: {scope: "DEFAULT", target: "INST"}
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json.length).to eq(1)
+      expect(json[0]["name"]).to eq("INST/script1.rb")
+    end
+
+    it "handles authorization failure" do
+      get :index
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "delete_temp" do
+    it "deletes temporary scripts" do
+      deleted_files = ["temp/script1.rb", "temp/script2.rb"]
+      expect(Script).to receive(:delete_temp).with("DEFAULT").and_return(deleted_files)
+
+      post :delete_temp, params: {scope: "DEFAULT"}
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).length).to eq(2)
+    end
+
+    it "handles authorization failure" do
+      post :delete_temp
+
+      expect(response).to have_http_status(:unauthorized)
+    end
   end
 
   describe "create" do
@@ -36,7 +100,7 @@ RSpec.describe ScriptsController, :type => :controller do
       expect(s3).to receive(:wait_until)
       allow(Aws::S3::Client).to receive(:new).and_return(s3)
 
-      post :create, params: { scope: 'DEFAULT', name: 'script.rb', text: 'text' }
+      post :create, params: {scope: "DEFAULT", name: "script.rb", text: "text"}
       expect(response).to have_http_status(:ok)
     end
 
@@ -44,14 +108,14 @@ RSpec.describe ScriptsController, :type => :controller do
       s3 = instance_double("Aws::S3::Client")
       # Simulate returning a file with 'new text'
       file = double("file")
-      allow(file).to receive_message_chain(:body, read: 'new text')
+      allow(file).to receive_message_chain(:body, read: "new text")
       expect(s3).to receive(:get_object).and_return(file)
       # Expect to call put_object to store the changed script
       expect(s3).to receive(:put_object)
       expect(s3).to receive(:wait_until)
       allow(Aws::S3::Client).to receive(:new).and_return(s3)
 
-      post :create, params: { scope: 'DEFAULT', name: 'script.rb', text: 'text' }
+      post :create, params: {scope: "DEFAULT", name: "script.rb", text: "text"}
       expect(response).to have_http_status(:ok)
     end
 
@@ -59,36 +123,277 @@ RSpec.describe ScriptsController, :type => :controller do
       s3 = instance_double("Aws::S3::Client")
       # Simulate returning a file with identical 'text'
       file = double("file")
-      allow(file).to receive_message_chain(:body, read: 'text')
+      allow(file).to receive_message_chain(:body, read: "text")
       expect(s3).to receive(:get_object).and_return(file)
       expect(s3).to_not receive(:put_object)
       allow(Aws::S3::Client).to receive(:new).and_return(s3)
 
-      post :create, params: { scope: 'DEFAULT', name: 'script.rb', text: 'text' }
+      post :create, params: {scope: "DEFAULT", name: "script.rb", text: "text"}
       expect(response).to have_http_status(:ok)
     end
 
     it "does not pass params which aren't permitted" do
       expect(Script).to receive(:create) do |params|
         # Check that we don't pass extra params
-        expect(params.keys).to eql(%w(text breakpoints scope name))
+        expect(params.keys).to eql(%w[text breakpoints scope name])
       end
-      post :create, params: { scope: 'DEFAULT', name: 'script.rb', text: 'text', breakpoints: [1], other: 'nope' }
+      post :create, params: {scope: "DEFAULT", name: "script.rb", text: "text", breakpoints: [1], other: "nope"}
       expect(response).to have_http_status(:ok)
     end
   end
 
   describe "run" do
     it "returns an ok response" do
-      expect(Script).to receive(:run).with('DEFAULT', 'INST/procedures/test.rb', nil, false, nil, "Anonymous", "anonymous", 1, nil).and_return(1)
-      post :run, params: { scope: 'DEFAULT', name: 'INST/procedures/test.rb' }
+      expect(Script).to receive(:run).with("DEFAULT", "INST/procedures/test.rb", nil, false, nil, "Anonymous", "anonymous", 1, nil).and_return(1)
+      post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
       expect(response).to have_http_status(:ok)
     end
 
     it "returns an error response" do
-      expect(Script).to receive(:run).with('DEFAULT', 'INST/procedures/test.rb', nil, false, nil, "Anonymous", "anonymous", 1, nil)
-      post :run, params: { scope: 'DEFAULT', name: 'INST/procedures/test.rb' }
+      expect(Script).to receive(:run).with("DEFAULT", "INST/procedures/test.rb", nil, false, nil, "Anonymous", "anonymous", 1, nil)
+      post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "body" do
+    it "returns script content when the script exists" do
+      script_content = "puts 'Hello World'"
+      breakpoints = [1, 5]
+
+      expect(Script).to receive(:body).with("DEFAULT", "INST/procedures/test.rb").and_return(script_content)
+      expect(Script).to receive(:locked?).with("DEFAULT", "INST/procedures/test.rb").and_return(false)
+      expect(Script).to receive(:lock).with("DEFAULT", "INST/procedures/test.rb", "anonymous")
+      expect(Script).to receive(:get_breakpoints).with("DEFAULT", "INST/procedures/test.rb").and_return(breakpoints)
+
+      get :body, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["contents"]).to eq(script_content)
+      expect(json["breakpoints"]).to eq(breakpoints)
+      expect(json["locked"]).to eq(false)
+    end
+
+    it "does not lock script if already locked" do
+      script_content = "puts 'Hello World'"
+      breakpoints = [1, 5]
+
+      expect(Script).to receive(:body).with("DEFAULT", "INST/procedures/test.rb").and_return(script_content)
+      expect(Script).to receive(:locked?).with("DEFAULT", "INST/procedures/test.rb").and_return(true)
+      expect(Script).not_to receive(:lock)
+      expect(Script).to receive(:get_breakpoints).with("DEFAULT", "INST/procedures/test.rb").and_return(breakpoints)
+
+      get :body, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["contents"]).to eq(script_content)
+      expect(json["locked"]).to eq(true)
+    end
+
+    it "processes suite files correctly" do
+      script_content = "class TestSuite < OpenC3::Suite\n  def test_method\n    puts 'test'\n  end\nend"
+      breakpoints = []
+      suites_data = "{\"suites\":[]}"
+
+      expect(Script).to receive(:body).with("DEFAULT", "INST/procedures/test.rb").and_return(script_content)
+      expect(Script).to receive(:locked?).with("DEFAULT", "INST/procedures/test.rb").and_return(false)
+      expect(Script).to receive(:lock).with("DEFAULT", "INST/procedures/test.rb", "anonymous")
+      expect(Script).to receive(:get_breakpoints).with("DEFAULT", "INST/procedures/test.rb").and_return(breakpoints)
+      expect(Script).to receive(:process_suite).with("INST/procedures/test.rb", script_content, username: "anonymous", scope: "DEFAULT").and_return([suites_data, nil, true])
+
+      get :body, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["contents"]).to eq(script_content)
+      expect(json["suites"]).to eq(suites_data)
+      expect(json["success"]).to eq(true)
+    end
+
+    it "processes Python suite files correctly" do
+      script_content = "class TestSuite(Suite):\n  def test_method(self):\n    print('test')\n"
+      breakpoints = []
+      suites_data = "{\"suites\":[]}"
+
+      expect(Script).to receive(:body).with("DEFAULT", "INST/procedures/test.py").and_return(script_content)
+      expect(Script).to receive(:locked?).with("DEFAULT", "INST/procedures/test.py").and_return(false)
+      expect(Script).to receive(:lock).with("DEFAULT", "INST/procedures/test.py", "anonymous")
+      expect(Script).to receive(:get_breakpoints).with("DEFAULT", "INST/procedures/test.py").and_return(breakpoints)
+      expect(Script).to receive(:process_suite).with("INST/procedures/test.py", script_content, username: "anonymous", scope: "DEFAULT").and_return([suites_data, nil, true])
+
+      get :body, params: {scope: "DEFAULT", name: "INST/procedures/test.py"}
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["contents"]).to eq(script_content)
+      expect(json["suites"]).to eq(suites_data)
+      expect(json["success"]).to eq(true)
+    end
+
+    it "returns not found when script does not exist" do
+      expect(Script).to receive(:body).with("DEFAULT", "INST/procedures/nonexistent.rb").and_return(nil)
+      get :body, params: {scope: "DEFAULT", name: "INST/procedures/nonexistent.rb"}
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "handles authorization failure" do
+      get :body, params: {name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "lock" do
+    it "locks a script" do
+      expect(Script).to receive(:lock).with("DEFAULT", "INST/procedures/test.rb", "anonymous")
+
+      post :lock, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "handles authorization failure" do
+      post :lock, params: {name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "unlock" do
+    it "unlocks a script that is locked by the user" do
+      expect(Script).to receive(:locked?).with("DEFAULT", "INST/procedures/test.rb").and_return("anonymous")
+      expect(Script).to receive(:unlock).with("DEFAULT", "INST/procedures/test.rb")
+
+      post :unlock, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not unlock a script locked by another user" do
+      expect(Script).to receive(:locked?).with("DEFAULT", "INST/procedures/test.rb").and_return("another_user")
+      expect(Script).not_to receive(:unlock)
+
+      post :unlock, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "handles authorization failure" do
+      post :unlock, params: {name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "destroy" do
+    it "destroys a script" do
+      expect(Script).to receive(:destroy).with("DEFAULT", "INST/procedures/test.rb")
+      allow(OpenC3::Logger).to receive(:info)
+
+      delete :destroy, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "handles exceptions" do
+      expect(Script).to receive(:destroy).with("DEFAULT", "INST/procedures/test.rb").and_raise("Destruction failed")
+      allow_any_instance_of(ScriptsController).to receive(:log_error)
+
+      delete :destroy, params: {scope: "DEFAULT", name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(500)
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq("error")
+      expect(json["message"]).to eq("Destruction failed")
+    end
+
+    it "handles authorization failure" do
+      delete :destroy, params: {name: "INST/procedures/test.rb"}
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "delete_all_breakpoints" do
+    it "deletes all breakpoints" do
+      # Need to mock OpenC3::Store directly
+      redis = mock_redis
+      expect(redis).to receive(:del).with("DEFAULT__script-breakpoints")
+
+      post :delete_all_breakpoints, params: {scope: "DEFAULT"}
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "handles authorization failure" do
+      post :delete_all_breakpoints
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "syntax" do
+    it "checks Ruby syntax successfully" do
+      valid_script = "puts 'Hello World'"
+
+      expect(Script).to receive(:syntax).with("script.rb", valid_script).and_return({
+        "title" => "Syntax Check Successful",
+        "description" => ["Syntax OK"]
+      })
+
+      post :syntax, params: {name: "script.rb", scope: "DEFAULT"}, body: valid_script
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["title"]).to eq("Syntax Check Successful")
+    end
+
+    it "reports Ruby syntax errors" do
+      invalid_script = "puts 'Hello World"
+
+      expect(Script).to receive(:syntax).with("script.rb", invalid_script).and_return({
+        "title" => "Syntax Check Failed",
+        "description" => ["2: syntax error, unexpected end-of-input"]
+      })
+
+      post :syntax, params: {name: "script.rb", scope: "DEFAULT"}, body: invalid_script
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["title"]).to eq("Syntax Check Failed")
+    end
+
+    it "handles authorization failure" do
+      post :syntax, params: {name: "INST/procedures/script.rb"}
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "instrumented" do
+    it "returns instrumented script" do
+      script = "puts 'Hello World'"
+      instrumented_result = {
+        "title" => "Instrumented Script",
+        "description" => "[\"instrumented code here\"]"
+      }
+
+      expect(Script).to receive(:instrumented).with("script.rb", script).and_return(instrumented_result)
+
+      post :instrumented, params: {name: "script.rb", scope: "DEFAULT"}, body: script
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["title"]).to eq("Instrumented Script")
+    end
+
+    it "handles authorization failure" do
+      post :instrumented, params: {name: "script.rb"}
+
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 end

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
@@ -12,3 +12,376 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
+
+require "rails_helper"
+require "tempfile"
+
+RSpec.describe RunningScript, type: :model do
+  before(:each) do
+    mock_redis
+    RunningScript.clear_breakpoints
+    RunningScript.file_cache = {}
+    RunningScript.instrumented_cache = {}
+
+    # Allow puts to prevent output during tests
+    allow($stdout).to receive(:puts)
+    allow($stderr).to receive(:puts)
+    allow_any_instance_of(IO).to receive(:puts)
+    allow_any_instance_of(StringIO).to receive(:puts)
+  end
+
+  describe "self.spawn" do
+    before do
+      # Only mock the process spawning parts to avoid actual process creation
+      process_double = double("process")
+      allow(process_double).to receive(:io).and_return(double("io", inherit!: nil))
+      allow(process_double).to receive(:cwd=)
+      allow(process_double).to receive(:environment).and_return({})
+      allow(process_double).to receive(:detach=)
+      allow(process_double).to receive(:start)
+      allow(ChildProcess).to receive(:build).and_return(process_double)
+    end
+
+    it "spawns a ruby script process" do
+      expect(ChildProcess).to receive(:build).with("ruby", anything, "1", "DEFAULT")
+
+      result = RunningScript.spawn("DEFAULT", "script.rb")
+      expect(result).to eq(1)
+    end
+
+    it "spawns a python script process" do
+      expect(ChildProcess).to receive(:build).with("python", anything, "1", "DEFAULT")
+
+      result = RunningScript.spawn("DEFAULT", "script.py")
+      expect(result).to eq(1)
+    end
+
+    it "creates a script status model with appropriate parameters" do
+      allow(OpenC3::ScriptStatusModel).to receive(:new).and_call_original
+
+      expect(OpenC3::ScriptStatusModel).to receive(:new).with(
+        hash_including(
+          name: "1",
+          state: "spawning",
+          shard: 0,
+          filename: "script.rb",
+          current_filename: "script.rb",
+          line_no: 0,
+          start_line_no: 1,
+          username: "Anonymous",
+          user_full_name: "Anonymous",
+          disconnect: false,
+          scope: "DEFAULT"
+        )
+      )
+
+      RunningScript.spawn("DEFAULT", "script.rb")
+    end
+
+    it "uses custom username and user_full_name when provided" do
+      allow(OpenC3::ScriptStatusModel).to receive(:new).and_call_original
+
+      expect(OpenC3::ScriptStatusModel).to receive(:new).with(
+        hash_including(
+          username: "testuser",
+          user_full_name: "Test User"
+        )
+      )
+
+      RunningScript.spawn("DEFAULT", "script.rb", nil, false, nil, "Test User", "testuser")
+    end
+
+    it "handles offline access token when username is provided" do
+      # We need to mock the offline access model and auth parts
+      model_double = double("model", offline_access_token: "valid_token", update: nil)
+      auth_double = double("auth")
+      allow(auth_double).to receive(:get_token_from_refresh_token).and_return(true)
+      allow(OpenC3::OpenC3KeycloakAuthentication).to receive(:new).and_return(auth_double)
+      allow(OpenC3::OfflineAccessModel).to receive(:get_model).with(name: "testuser", scope: "DEFAULT").and_return(model_double)
+
+      process_env_double = {}
+      process_double = double("process")
+      allow(process_double).to receive(:io).and_return(double("io", inherit!: nil))
+      allow(process_double).to receive(:cwd=)
+      allow(process_double).to receive(:environment).and_return(process_env_double)
+      allow(process_double).to receive(:detach=)
+      allow(process_double).to receive(:start)
+      allow(ChildProcess).to receive(:build).and_return(process_double)
+
+      RunningScript.spawn("DEFAULT", "script.rb", nil, false, nil, "Test User", "testuser")
+
+      expect(process_env_double["OPENC3_API_TOKEN"]).to eq("valid_token")
+    end
+
+    it "raises an error if offline token is invalid" do
+      # Mock just the authentication parts
+      model_double = double("model", offline_access_token: "invalid_token", update: nil)
+      allow(model_double).to receive(:offline_access_token=)
+      auth_double = double("auth")
+      allow(auth_double).to receive(:get_token_from_refresh_token).and_return(false)
+      allow(OpenC3::OpenC3KeycloakAuthentication).to receive(:new).and_return(auth_double)
+      allow(OpenC3::OfflineAccessModel).to receive(:get_model).with(name: "testuser", scope: "DEFAULT").and_return(model_double)
+
+      expect {
+        RunningScript.spawn("DEFAULT", "script.rb", nil, false, nil, "Test User", "testuser")
+      }.to raise_error("offline_access token invalid for script")
+    end
+  end
+
+  describe "self.instrument_script" do
+    it "adds instrumentation code to Ruby scripts" do
+      simple_script = "puts 'Hello'"
+      result = RunningScript.instrument_script(simple_script, "test.rb")
+
+      # Verify that the instrumentation adds pre and post line hooks
+      expect(result).to include("RunningScript.instance.script_binding = binding()")
+      expect(result).to include("RunningScript.instance.pre_line_instrumentation")
+      expect(result).to include("RunningScript.instance.post_line_instrumentation")
+      expect(result).to include("rescue Exception => eval_error")
+    end
+
+    it "caches the script text when cache is true" do
+      simple_script = "puts 'Hello'"
+
+      RunningScript.instrument_script(simple_script, "test.rb", true, cache: true)
+
+      expect(RunningScript.file_cache["test.rb"]).to eq(simple_script)
+    end
+
+    it "doesn't cache the script text when cache is false" do
+      simple_script = "puts 'Hello'"
+
+      RunningScript.instrument_script(simple_script, "test.rb", true, cache: false)
+
+      expect(RunningScript.file_cache["test.rb"]).to be_nil
+    end
+
+    it "adds line_offset to instrumentation for partial scripts" do
+      simple_script = "puts 'Line 10'"
+      result = RunningScript.instrument_script(simple_script, "test.rb", true, line_offset: 9)
+
+      # Check that the line number in the instrumentation is offset
+      expect(result).to include("RunningScript.instance.pre_line_instrumentation('test.rb', 10)")
+    end
+
+    it "marks the script as private when mark_private is true" do
+      simple_script = "puts 'Hello'"
+      result = RunningScript.instrument_script(simple_script, "test.rb", true)
+
+      # Check that the private keyword is added
+      expect(result).to start_with("private;")
+    end
+
+    it "doesn't mark the script as private when mark_private is false" do
+      simple_script = "puts 'Hello'"
+      result = RunningScript.instrument_script(simple_script, "test.rb", false)
+
+      # Check that the private keyword is not added
+      expect(result).not_to start_with("private;")
+    end
+  end
+
+  describe "initialization and state management" do
+    let(:script_status) {
+      OpenC3::ScriptStatusModel.new(
+        name: "12345",
+        state: "running",
+        shard: 0,
+        filename: "test_script.rb",
+        current_filename: "test_script.rb",
+        line_no: 0,
+        start_line_no: 1,
+        username: "test_user",
+        user_full_name: "Test User",
+        start_time: Time.now.utc.iso8601,
+        disconnect: false,
+        scope: "DEFAULT"
+      )
+    }
+
+    before do
+      # Allow script status to be created but not actually stored
+      allow(script_status).to receive(:create)
+      allow(script_status).to receive(:update)
+
+      # Mock script retrieval
+      allow(::Script).to receive(:body).and_return("puts 'Test Script'")
+      allow(::Script).to receive(:get_breakpoints).and_return([])
+
+      # Prevent actual message logging
+      allow(OpenC3::MessageLog).to receive(:new).and_return(double("message_log", write: nil))
+
+      # Prevent actual IO redirection
+      allow_any_instance_of(RunningScript).to receive(:redirect_io)
+
+      # Prevent actual script running and anycable publishing
+      allow_any_instance_of(RunningScript).to receive(:running_script_anycable_publish)
+    end
+
+    it "correctly manages step/go/pause internal flags" do
+      # Set up RunningScript instance
+      running_script = RunningScript.new(script_status)
+
+      # Test step mode
+      running_script.step
+      expect(running_script.instance_variable_get(:@step)).to be true
+      expect(running_script.instance_variable_get(:@go)).to be true
+      expect(running_script.instance_variable_get(:@pause)).to be true
+
+      # Test go mode
+      running_script.go
+      expect(running_script.instance_variable_get(:@step)).to be false
+      expect(running_script.instance_variable_get(:@go)).to be true
+      expect(running_script.instance_variable_get(:@pause)).to be false
+
+      # Test pause mode
+      running_script.pause
+      expect(running_script.instance_variable_get(:@go)).to be false
+      expect(running_script.instance_variable_get(:@pause)).to be true
+
+      # Test continue with step mode on
+      running_script.instance_variable_set(:@step, true)
+      running_script.continue
+      expect(running_script.instance_variable_get(:@go)).to be true
+      expect(running_script.instance_variable_get(:@pause)).to be true
+    end
+
+    it "handles stopping a script" do
+      # Set up RunningScript instance
+      running_script = RunningScript.new(script_status)
+
+      # Setup the class variable directly
+      thread_double = double("thread")
+      allow(OpenC3).to receive(:kill_thread)
+
+      RunningScript.class_variable_set(:@@run_thread, thread_double)
+
+      # Test stopping the script
+      running_script.stop
+
+      expect(running_script.instance_variable_get(:@stop)).to be true
+      expect(script_status.state).to eq("stopped")
+      expect(script_status.end_time).not_to be_nil
+
+      # Reset the class variable after the test
+      RunningScript.class_variable_set(:@@run_thread, nil)
+    end
+  end
+
+  describe "breakpoint management" do
+    it "sets a breakpoint" do
+      RunningScript.set_breakpoint("test.rb", 10)
+
+      breakpoints = RunningScript.breakpoints
+      expect(breakpoints["test.rb"][10]).to be true
+    end
+
+    it "clears a specific breakpoint" do
+      RunningScript.set_breakpoint("test.rb", 10)
+      RunningScript.set_breakpoint("test.rb", 20)
+
+      RunningScript.clear_breakpoint("test.rb", 10)
+
+      breakpoints = RunningScript.breakpoints
+      expect(breakpoints["test.rb"][10]).to be_nil
+      expect(breakpoints["test.rb"][20]).to be true
+    end
+
+    it "clears all breakpoints for a file" do
+      RunningScript.set_breakpoint("test.rb", 10)
+      RunningScript.set_breakpoint("test.rb", 20)
+      RunningScript.set_breakpoint("other.rb", 30)
+
+      RunningScript.clear_breakpoints("test.rb")
+
+      breakpoints = RunningScript.breakpoints
+      expect(breakpoints["test.rb"]).to be_nil
+      expect(breakpoints["other.rb"][30]).to be true
+    end
+
+    it "clears all breakpoints when no filename is given" do
+      RunningScript.set_breakpoint("test.rb", 10)
+      RunningScript.set_breakpoint("other.rb", 20)
+
+      RunningScript.clear_breakpoints
+
+      expect(RunningScript.breakpoints).to eq({})
+    end
+  end
+
+  describe "parse_options" do
+    let(:script_status) {
+      OpenC3::ScriptStatusModel.new(
+        name: "12345",
+        state: "running",
+        shard: 0,
+        filename: "test_script.rb",
+        current_filename: "test_script.rb",
+        line_no: 0,
+        start_line_no: 1,
+        username: "test_user",
+        user_full_name: "Test User",
+        start_time: Time.now.utc.iso8601,
+        disconnect: false,
+        scope: "DEFAULT"
+      )
+    }
+
+    before do
+      # Allow script status to be created but not actually stored
+      allow(script_status).to receive(:create)
+      allow(script_status).to receive(:update)
+
+      # Mock script retrieval
+      allow(::Script).to receive(:body).and_return("puts 'Test Script'")
+      allow(::Script).to receive(:get_breakpoints).and_return([])
+
+      # Prevent actual message logging and IO redirection
+      allow(OpenC3::MessageLog).to receive(:new).and_return(double("message_log", write: nil))
+      allow_any_instance_of(RunningScript).to receive(:redirect_io)
+      allow_any_instance_of(RunningScript).to receive(:running_script_anycable_publish)
+    end
+
+    it "sets manual mode when given 'manual' option" do
+      running_script = RunningScript.new(script_status)
+      running_script.parse_options(["manual"])
+
+      expect($manual).to be true
+      expect(OpenC3::SuiteRunner.settings["Manual"]).to be true
+    end
+
+    it "sets pauseOnError when given 'pauseOnError' option" do
+      running_script = RunningScript.new(script_status)
+      running_script.parse_options(["pauseOnError"])
+
+      expect(RunningScript.pause_on_error).to be true
+      expect(OpenC3::SuiteRunner.settings["Pause on Error"]).to be true
+    end
+
+    it "sets continueAfterError when given 'continueAfterError' option" do
+      running_script = RunningScript.new(script_status)
+      running_script.parse_options(["continueAfterError"])
+
+      expect(running_script.continue_after_error).to be true
+      expect(OpenC3::SuiteRunner.settings["Continue After Error"]).to be true
+    end
+
+    it "sets abortAfterError when given 'abortAfterError' option" do
+      running_script = RunningScript.new(script_status)
+      running_script.parse_options(["abortAfterError"])
+
+      expect(OpenC3::Test.abort_on_exception).to be true
+      expect(OpenC3::SuiteRunner.settings["Abort After Error"]).to be true
+    end
+
+    it "configures multiple options correctly" do
+      running_script = RunningScript.new(script_status)
+      running_script.parse_options(["manual", "pauseOnError", "loop", "breakLoopOnError"])
+
+      expect($manual).to be true
+      expect(RunningScript.pause_on_error).to be true
+      expect(OpenC3::SuiteRunner.settings["Loop"]).to be true
+      expect(OpenC3::SuiteRunner.settings["Break Loop On Error"]).to be true
+    end
+  end
+end

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
@@ -17,6 +17,23 @@ require "rails_helper"
 require "tempfile"
 
 RSpec.describe RunningScript, type: :model do
+  let(:script_status) {
+    OpenC3::ScriptStatusModel.new(
+      name: "12345",
+      state: "running",
+      shard: 0,
+      filename: "test_script.rb",
+      current_filename: "test_script.rb",
+      line_no: 0,
+      start_line_no: 1,
+      username: "test_user",
+      user_full_name: "Test User",
+      start_time: Time.now.utc.iso8601,
+      disconnect: false,
+      scope: "DEFAULT"
+    )
+  }
+
   before(:each) do
     mock_redis
     RunningScript.clear_breakpoints
@@ -181,226 +198,7 @@ RSpec.describe RunningScript, type: :model do
     end
   end
 
-  describe "initialization and state management" do
-    let(:script_status) {
-      OpenC3::ScriptStatusModel.new(
-        name: "12345",
-        state: "running",
-        shard: 0,
-        filename: "test_script.rb",
-        current_filename: "test_script.rb",
-        line_no: 0,
-        start_line_no: 1,
-        username: "test_user",
-        user_full_name: "Test User",
-        start_time: Time.now.utc.iso8601,
-        disconnect: false,
-        scope: "DEFAULT"
-      )
-    }
-
-    before do
-      # Allow script status to be created but not actually stored
-      allow(script_status).to receive(:create)
-      allow(script_status).to receive(:update)
-
-      # Mock script retrieval
-      allow(::Script).to receive(:body).and_return("puts 'Test Script'")
-      allow(::Script).to receive(:get_breakpoints).and_return([])
-
-      # Prevent actual message logging
-      allow(OpenC3::MessageLog).to receive(:new).and_return(double("message_log", write: nil))
-
-      # Prevent actual IO redirection
-      allow_any_instance_of(RunningScript).to receive(:redirect_io)
-
-      # Prevent actual script running and anycable publishing
-      allow_any_instance_of(RunningScript).to receive(:running_script_anycable_publish)
-    end
-
-    it "correctly manages step/go/pause internal flags" do
-      # Set up RunningScript instance
-      running_script = RunningScript.new(script_status)
-
-      # Test step mode
-      running_script.step
-      expect(running_script.instance_variable_get(:@step)).to be true
-      expect(running_script.instance_variable_get(:@go)).to be true
-      expect(running_script.instance_variable_get(:@pause)).to be true
-
-      # Test go mode
-      running_script.go
-      expect(running_script.instance_variable_get(:@step)).to be false
-      expect(running_script.instance_variable_get(:@go)).to be true
-      expect(running_script.instance_variable_get(:@pause)).to be false
-
-      # Test pause mode
-      running_script.pause
-      expect(running_script.instance_variable_get(:@go)).to be false
-      expect(running_script.instance_variable_get(:@pause)).to be true
-
-      # Test continue with step mode on
-      running_script.instance_variable_set(:@step, true)
-      running_script.continue
-      expect(running_script.instance_variable_get(:@go)).to be true
-      expect(running_script.instance_variable_get(:@pause)).to be true
-    end
-
-    it "handles stopping a script" do
-      # Set up RunningScript instance
-      running_script = RunningScript.new(script_status)
-
-      # Setup the class variable directly
-      thread_double = double("thread")
-      allow(OpenC3).to receive(:kill_thread)
-
-      RunningScript.class_variable_set(:@@run_thread, thread_double)
-
-      # Test stopping the script
-      running_script.stop
-
-      expect(running_script.instance_variable_get(:@stop)).to be true
-      expect(script_status.state).to eq("stopped")
-      expect(script_status.end_time).not_to be_nil
-
-      # Reset the class variable after the test
-      RunningScript.class_variable_set(:@@run_thread, nil)
-    end
-  end
-
-  describe "breakpoint management" do
-    it "sets a breakpoint" do
-      RunningScript.set_breakpoint("test.rb", 10)
-
-      breakpoints = RunningScript.breakpoints
-      expect(breakpoints["test.rb"][10]).to be true
-    end
-
-    it "clears a specific breakpoint" do
-      RunningScript.set_breakpoint("test.rb", 10)
-      RunningScript.set_breakpoint("test.rb", 20)
-
-      RunningScript.clear_breakpoint("test.rb", 10)
-
-      breakpoints = RunningScript.breakpoints
-      expect(breakpoints["test.rb"][10]).to be_nil
-      expect(breakpoints["test.rb"][20]).to be true
-    end
-
-    it "clears all breakpoints for a file" do
-      RunningScript.set_breakpoint("test.rb", 10)
-      RunningScript.set_breakpoint("test.rb", 20)
-      RunningScript.set_breakpoint("other.rb", 30)
-
-      RunningScript.clear_breakpoints("test.rb")
-
-      breakpoints = RunningScript.breakpoints
-      expect(breakpoints["test.rb"]).to be_nil
-      expect(breakpoints["other.rb"][30]).to be true
-    end
-
-    it "clears all breakpoints when no filename is given" do
-      RunningScript.set_breakpoint("test.rb", 10)
-      RunningScript.set_breakpoint("other.rb", 20)
-
-      RunningScript.clear_breakpoints
-
-      expect(RunningScript.breakpoints).to eq({})
-    end
-  end
-
-  describe "parse_options" do
-    let(:script_status) {
-      OpenC3::ScriptStatusModel.new(
-        name: "12345",
-        state: "running",
-        shard: 0,
-        filename: "test_script.rb",
-        current_filename: "test_script.rb",
-        line_no: 0,
-        start_line_no: 1,
-        username: "test_user",
-        user_full_name: "Test User",
-        start_time: Time.now.utc.iso8601,
-        disconnect: false,
-        scope: "DEFAULT"
-      )
-    }
-
-    before do
-      # Allow script status to be created but not actually stored
-      allow(script_status).to receive(:create)
-      allow(script_status).to receive(:update)
-
-      # Mock script retrieval
-      allow(::Script).to receive(:body).and_return("puts 'Test Script'")
-      allow(::Script).to receive(:get_breakpoints).and_return([])
-
-      # Prevent actual message logging and IO redirection
-      allow(OpenC3::MessageLog).to receive(:new).and_return(double("message_log", write: nil))
-      allow_any_instance_of(RunningScript).to receive(:redirect_io)
-      allow_any_instance_of(RunningScript).to receive(:running_script_anycable_publish)
-    end
-
-    it "sets manual mode when given 'manual' option" do
-      running_script = RunningScript.new(script_status)
-      running_script.parse_options(["manual"])
-
-      expect(OpenC3::SuiteRunner.settings["Manual"]).to be true
-    end
-
-    it "sets pauseOnError when given 'pauseOnError' option" do
-      running_script = RunningScript.new(script_status)
-      running_script.parse_options(["pauseOnError"])
-
-      expect(RunningScript.pause_on_error).to be true
-      expect(OpenC3::SuiteRunner.settings["Pause on Error"]).to be true
-    end
-
-    it "sets continueAfterError when given 'continueAfterError' option" do
-      running_script = RunningScript.new(script_status)
-      running_script.parse_options(["continueAfterError"])
-
-      expect(running_script.continue_after_error).to be true
-      expect(OpenC3::SuiteRunner.settings["Continue After Error"]).to be true
-    end
-
-    it "sets abortAfterError when given 'abortAfterError' option" do
-      running_script = RunningScript.new(script_status)
-      running_script.parse_options(["abortAfterError"])
-
-      expect(OpenC3::Test.abort_on_exception).to be true
-      expect(OpenC3::SuiteRunner.settings["Abort After Error"]).to be true
-    end
-
-    it "configures multiple options correctly" do
-      running_script = RunningScript.new(script_status)
-      running_script.parse_options(["manual", "pauseOnError", "loop", "breakLoopOnError"])
-
-      expect(RunningScript.pause_on_error).to be true
-      expect(OpenC3::SuiteRunner.settings["Loop"]).to be true
-      expect(OpenC3::SuiteRunner.settings["Break Loop On Error"]).to be true
-    end
-  end
-
-  describe "instrumentation methods and utility methods" do
-    let(:script_status) {
-      OpenC3::ScriptStatusModel.new(
-        name: "12345",
-        state: "running",
-        shard: 0,
-        filename: "test_script.rb",
-        current_filename: "test_script.rb",
-        line_no: 0,
-        start_line_no: 1,
-        username: "test_user",
-        user_full_name: "Test User",
-        start_time: Time.now.utc.iso8601,
-        disconnect: false,
-        scope: "DEFAULT"
-      )
-    }
-
+  describe "script status methods" do
     before do
       # Allow script status to be created but not actually stored
       allow(script_status).to receive(:create)
@@ -417,215 +215,356 @@ RSpec.describe RunningScript, type: :model do
       # Prevent actual IO redirection
       allow_any_instance_of(RunningScript).to receive(:redirect_io)
 
-      # Prevent actual script running
-      allow_any_instance_of(RunningScript).to receive(:handle_potential_tab_change)
-      allow_any_instance_of(RunningScript).to receive(:handle_pause)
-      allow_any_instance_of(RunningScript).to receive(:handle_line_delay)
-      allow_any_instance_of(RunningScript).to receive(:handle_output_io)
+      # Prevent actual script running and anycable publishing
       allow_any_instance_of(RunningScript).to receive(:running_script_anycable_publish)
-      allow_any_instance_of(RunningScript).to receive(:update_running_script_store)
     end
 
-    describe "pre_line_instrumentation" do
-      it "updates script status with current filename and line number" do
+    describe "initialization and state management" do
+      it "correctly manages step/go/pause internal flags" do
+        # Set up RunningScript instance
         running_script = RunningScript.new(script_status)
 
-        running_script.use_instrumentation = true
+        # Test step mode
+        running_script.step
+        expect(running_script.instance_variable_get(:@step)).to be true
+        expect(running_script.instance_variable_get(:@go)).to be true
+        expect(running_script.instance_variable_get(:@pause)).to be true
 
-        expect(OpenC3::Logger).to receive(:detail_string=).with("new_file.rb:42")
-        expect(running_script).to receive(:update_running_script_store).with("running")
-        expect(running_script).to receive(:running_script_anycable_publish).with(
-          "running-script-channel:12345",
-          {
-            type: :line,
-            filename: "new_file.rb",
-            line_no: 42,
-            state: script_status.state
-          }
-        )
+        # Test go mode
+        running_script.go
+        expect(running_script.instance_variable_get(:@step)).to be false
+        expect(running_script.instance_variable_get(:@go)).to be true
+        expect(running_script.instance_variable_get(:@pause)).to be false
 
-        running_script.pre_line_instrumentation("new_file.rb", 42)
+        # Test pause mode
+        running_script.pause
+        expect(running_script.instance_variable_get(:@go)).to be false
+        expect(running_script.instance_variable_get(:@pause)).to be true
 
-        expect(script_status.current_filename).to eq("new_file.rb")
-        expect(script_status.line_no).to eq(42)
+        # Test continue with step mode on
+        running_script.instance_variable_set(:@step, true)
+        running_script.continue
+        expect(running_script.instance_variable_get(:@go)).to be true
+        expect(running_script.instance_variable_get(:@pause)).to be true
       end
 
-      it "raises StopScript if stop flag is set" do
+      it "handles stopping a script" do
+        # Set up RunningScript instance
         running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = true
 
-        running_script.instance_variable_set(:@stop, true)
+        # Setup the class variable directly
+        thread_double = double("thread")
+        allow(OpenC3).to receive(:kill_thread)
 
-        # Call pre_line_instrumentation and expect it to raise StopScript
-        expect {
+        RunningScript.class_variable_set(:@@run_thread, thread_double)
+
+        # Test stopping the script
+        running_script.stop
+
+        expect(running_script.instance_variable_get(:@stop)).to be true
+        expect(script_status.state).to eq("stopped")
+        expect(script_status.end_time).not_to be_nil
+
+        # Reset the class variable after the test
+        RunningScript.class_variable_set(:@@run_thread, nil)
+      end
+    end
+
+    describe "breakpoint management" do
+      it "sets a breakpoint" do
+        RunningScript.set_breakpoint("test.rb", 10)
+
+        breakpoints = RunningScript.breakpoints
+        expect(breakpoints["test.rb"][10]).to be true
+      end
+
+      it "clears a specific breakpoint" do
+        RunningScript.set_breakpoint("test.rb", 10)
+        RunningScript.set_breakpoint("test.rb", 20)
+
+        RunningScript.clear_breakpoint("test.rb", 10)
+
+        breakpoints = RunningScript.breakpoints
+        expect(breakpoints["test.rb"][10]).to be_nil
+        expect(breakpoints["test.rb"][20]).to be true
+      end
+
+      it "clears all breakpoints for a file" do
+        RunningScript.set_breakpoint("test.rb", 10)
+        RunningScript.set_breakpoint("test.rb", 20)
+        RunningScript.set_breakpoint("other.rb", 30)
+
+        RunningScript.clear_breakpoints("test.rb")
+
+        breakpoints = RunningScript.breakpoints
+        expect(breakpoints["test.rb"]).to be_nil
+        expect(breakpoints["other.rb"][30]).to be true
+      end
+
+      it "clears all breakpoints when no filename is given" do
+        RunningScript.set_breakpoint("test.rb", 10)
+        RunningScript.set_breakpoint("other.rb", 20)
+
+        RunningScript.clear_breakpoints
+
+        expect(RunningScript.breakpoints).to eq({})
+      end
+    end
+
+    describe "parse_options" do
+      it "sets manual mode when given 'manual' option" do
+        running_script = RunningScript.new(script_status)
+        running_script.parse_options(["manual"])
+
+        expect(OpenC3::SuiteRunner.settings["Manual"]).to be true
+      end
+
+      it "sets pauseOnError when given 'pauseOnError' option" do
+        running_script = RunningScript.new(script_status)
+        running_script.parse_options(["pauseOnError"])
+
+        expect(RunningScript.pause_on_error).to be true
+        expect(OpenC3::SuiteRunner.settings["Pause on Error"]).to be true
+      end
+
+      it "sets continueAfterError when given 'continueAfterError' option" do
+        running_script = RunningScript.new(script_status)
+        running_script.parse_options(["continueAfterError"])
+
+        expect(running_script.continue_after_error).to be true
+        expect(OpenC3::SuiteRunner.settings["Continue After Error"]).to be true
+      end
+
+      it "sets abortAfterError when given 'abortAfterError' option" do
+        running_script = RunningScript.new(script_status)
+        running_script.parse_options(["abortAfterError"])
+
+        expect(OpenC3::Test.abort_on_exception).to be true
+        expect(OpenC3::SuiteRunner.settings["Abort After Error"]).to be true
+      end
+
+      it "configures multiple options correctly" do
+        running_script = RunningScript.new(script_status)
+        running_script.parse_options(["manual", "pauseOnError", "loop", "breakLoopOnError"])
+
+        expect(RunningScript.pause_on_error).to be true
+        expect(OpenC3::SuiteRunner.settings["Loop"]).to be true
+        expect(OpenC3::SuiteRunner.settings["Break Loop On Error"]).to be true
+      end
+    end
+
+    describe "instrumentation methods and utility methods" do
+      before do
+        # Prevent actual script running
+        allow_any_instance_of(RunningScript).to receive(:handle_potential_tab_change)
+        allow_any_instance_of(RunningScript).to receive(:handle_pause)
+        allow_any_instance_of(RunningScript).to receive(:handle_line_delay)
+        allow_any_instance_of(RunningScript).to receive(:handle_output_io)
+        allow_any_instance_of(RunningScript).to receive(:running_script_anycable_publish)
+        allow_any_instance_of(RunningScript).to receive(:update_running_script_store)
+      end
+
+      describe "pre_line_instrumentation" do
+        it "updates script status with current filename and line number" do
+          running_script = RunningScript.new(script_status)
+
+          running_script.use_instrumentation = true
+
+          expect(OpenC3::Logger).to receive(:detail_string=).with("new_file.rb:42")
+          expect(running_script).to receive(:update_running_script_store).with("running")
+          expect(running_script).to receive(:running_script_anycable_publish).with(
+            "running-script-channel:12345",
+            {
+              type: :line,
+              filename: "new_file.rb",
+              line_no: 42,
+              state: script_status.state
+            }
+          )
+
           running_script.pre_line_instrumentation("new_file.rb", 42)
-        }.to raise_error(OpenC3::StopScript)
+
+          expect(script_status.current_filename).to eq("new_file.rb")
+          expect(script_status.line_no).to eq(42)
+        end
+
+        it "raises StopScript if stop flag is set" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = true
+
+          running_script.instance_variable_set(:@stop, true)
+
+          # Call pre_line_instrumentation and expect it to raise StopScript
+          expect {
+            running_script.pre_line_instrumentation("new_file.rb", 42)
+          }.to raise_error(OpenC3::StopScript)
+        end
+
+        it "doesn't update anything when use_instrumentation is false" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = false
+
+          expect(running_script).not_to receive(:update_running_script_store)
+          expect(running_script).not_to receive(:running_script_anycable_publish)
+
+          running_script.pre_line_instrumentation("new_file.rb", 42)
+        end
       end
 
-      it "doesn't update anything when use_instrumentation is false" do
-        running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = false
+      describe "post_line_instrumentation" do
+        it "calls handle_output_io when instrumentation is enabled" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = true
 
-        expect(running_script).not_to receive(:update_running_script_store)
-        expect(running_script).not_to receive(:running_script_anycable_publish)
+          expect(running_script).to receive(:handle_output_io).with("new_file.rb", 42)
 
-        running_script.pre_line_instrumentation("new_file.rb", 42)
-      end
-    end
+          running_script.post_line_instrumentation("new_file.rb", 42)
+        end
 
-    describe "post_line_instrumentation" do
-      it "calls handle_output_io when instrumentation is enabled" do
-        running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = true
+        it "doesn't call handle_output_io when instrumentation is disabled" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = false
 
-        expect(running_script).to receive(:handle_output_io).with("new_file.rb", 42)
+          expect(running_script).not_to receive(:handle_output_io)
 
-        running_script.post_line_instrumentation("new_file.rb", 42)
-      end
+          running_script.post_line_instrumentation("new_file.rb", 42)
+        end
 
-      it "doesn't call handle_output_io when instrumentation is disabled" do
-        running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = false
+        it "adjusts line number with line_offset" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = true
 
-        expect(running_script).not_to receive(:handle_output_io)
+          running_script.instance_variable_set(:@line_offset, 10)
 
-        running_script.post_line_instrumentation("new_file.rb", 42)
-      end
+          expect(running_script).to receive(:handle_output_io).with("new_file.rb", 52) # 42 + 10
 
-      it "adjusts line number with line_offset" do
-        running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = true
-
-        running_script.instance_variable_set(:@line_offset, 10)
-
-        expect(running_script).to receive(:handle_output_io).with("new_file.rb", 52) # 42 + 10
-
-        running_script.post_line_instrumentation("new_file.rb", 42)
-      end
-    end
-
-    describe "exception_instrumentation" do
-      it "re-raises StopScript and SkipScript exceptions" do
-        running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = true
-
-        stop_script_error = OpenC3::StopScript.new
-        skip_script_error = OpenC3::SkipScript.new
-
-        expect {
-          running_script.exception_instrumentation(stop_script_error, "test.rb", 10)
-        }.to raise_error(OpenC3::StopScript)
-
-        expect {
-          running_script.exception_instrumentation(skip_script_error, "test.rb", 10)
-        }.to raise_error(OpenC3::SkipScript)
+          running_script.post_line_instrumentation("new_file.rb", 42)
+        end
       end
 
-      it "calls handle_exception for non-StopScript/SkipScript exceptions" do
-        running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = true
+      describe "exception_instrumentation" do
+        it "re-raises StopScript and SkipScript exceptions" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = true
 
-        standard_error = StandardError.new("Test error")
+          stop_script_error = OpenC3::StopScript.new
+          skip_script_error = OpenC3::SkipScript.new
 
-        expect(running_script).to receive(:handle_exception).with(standard_error, false, "test.rb", 10)
+          expect {
+            running_script.exception_instrumentation(stop_script_error, "test.rb", 10)
+          }.to raise_error(OpenC3::StopScript)
 
-        running_script.exception_instrumentation(standard_error, "test.rb", 10)
-      end
+          expect {
+            running_script.exception_instrumentation(skip_script_error, "test.rb", 10)
+          }.to raise_error(OpenC3::SkipScript)
+        end
 
-      it "adjusts line number with line_offset" do
-        running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = true
+        it "calls handle_exception for non-StopScript/SkipScript exceptions" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = true
 
-        running_script.instance_variable_set(:@line_offset, 10)
+          standard_error = StandardError.new("Test error")
 
-        standard_error = StandardError.new("Test error")
+          expect(running_script).to receive(:handle_exception).with(standard_error, false, "test.rb", 10)
 
-        # Expect handle_exception to be called with adjusted line number
-        expect(running_script).to receive(:handle_exception).with(standard_error, false, "test.rb", 20) # 10 + 10
-
-        running_script.exception_instrumentation(standard_error, "test.rb", 10)
-      end
-
-      it "doesn't handle exceptions when use_instrumentation is false" do
-        running_script = RunningScript.new(script_status)
-        running_script.use_instrumentation = false
-
-        standard_error = StandardError.new("Test error")
-
-        expect(running_script).not_to receive(:handle_exception)
-
-        expect {
           running_script.exception_instrumentation(standard_error, "test.rb", 10)
-        }.to raise_error(StandardError)
-      end
-    end
+        end
 
-    describe "unique_filename" do
-      it "returns the script filename when it exists" do
-        running_script = RunningScript.new(script_status)
+        it "adjusts line number with line_offset" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = true
 
-        expect(running_script.send(:unique_filename)).to eq("test_script.rb")
-      end
+          running_script.instance_variable_set(:@line_offset, 10)
 
-      it "returns 'Untitled' with ID when filename is empty" do
-        script_status.filename = ""
-        running_script = RunningScript.new(script_status)
+          standard_error = StandardError.new("Test error")
 
-        expect(running_script.send(:unique_filename)).to eq("Untitled12345")
-      end
-    end
+          # Expect handle_exception to be called with adjusted line number
+          expect(running_script).to receive(:handle_exception).with(standard_error, false, "test.rb", 20) # 10 + 10
 
-    describe "stop_message_log" do
-      it "stops the message log with metadata" do
-        running_script = RunningScript.new(script_status)
+          running_script.exception_instrumentation(standard_error, "test.rb", 10)
+        end
 
-        RunningScript.class_variable_set(:@@message_log, @message_log_double)
+        it "doesn't handle exceptions when use_instrumentation is false" do
+          running_script = RunningScript.new(script_status)
+          running_script.use_instrumentation = false
 
-        expected_metadata = {
-          "id" => "12345",
-          "user" => "test_user",
-          "scriptname" => "test_script.rb"
-        }
+          standard_error = StandardError.new("Test error")
 
-        expect(@message_log_double).to receive(:stop).with(true, metadata: expected_metadata).and_return("log_file_path")
+          expect(running_script).not_to receive(:handle_exception)
 
-        running_script.send(:stop_message_log)
-
-        expect(script_status.log).to eq("log_file_path")
-        expect(RunningScript.class_variable_get(:@@message_log)).to be_nil
+          expect {
+            running_script.exception_instrumentation(standard_error, "test.rb", 10)
+          }.to raise_error(StandardError)
+        end
       end
 
-      it "does nothing if message_log is nil" do
-        running_script = RunningScript.new(script_status)
-        RunningScript.class_variable_set(:@@message_log, nil)
-        running_script.send(:stop_message_log)
+      describe "unique_filename" do
+        it "returns the script filename when it exists" do
+          running_script = RunningScript.new(script_status)
 
-        expect(script_status.log).to be_nil
-        expect(RunningScript.class_variable_get(:@@message_log)).to be_nil
-      end
-    end
+          expect(running_script.send(:unique_filename)).to eq("test_script.rb")
+        end
 
-    describe "debug" do
-      it "evaluates debug text in script_binding when available" do
-        running_script = RunningScript.new(script_status)
+        it "returns 'Untitled' with ID when filename is empty" do
+          script_status.filename = ""
+          running_script = RunningScript.new(script_status)
 
-        script_binding = binding
-        test_var = "test value"  # This will be accessible in the binding
-
-        running_script.script_binding = script_binding
-        expect(running_script).to receive(:handle_output_io).twice
-        expect(script_binding.eval("test_var")).to eq("test value")
-        running_script.debug("test_var")
+          expect(running_script.send(:unique_filename)).to eq("Untitled12345")
+        end
       end
 
-      it "evaluates in Object context when script_binding is not available" do
-        running_script = RunningScript.new(script_status)
+      describe "stop_message_log" do
+        it "stops the message log with metadata" do
+          running_script = RunningScript.new(script_status)
 
-        running_script.script_binding = nil
-        expect(running_script).to receive(:handle_output_io).twice
-        expect(Object).to receive(:class_eval).with("1 + 1", "debug", 1)
+          RunningScript.class_variable_set(:@@message_log, @message_log_double)
 
-        running_script.debug("1 + 1")
+          expected_metadata = {
+            "id" => "12345",
+            "user" => "test_user",
+            "scriptname" => "test_script.rb"
+          }
+
+          expect(@message_log_double).to receive(:stop).with(true, metadata: expected_metadata).and_return("log_file_path")
+
+          running_script.send(:stop_message_log)
+
+          expect(script_status.log).to eq("log_file_path")
+          expect(RunningScript.class_variable_get(:@@message_log)).to be_nil
+        end
+
+        it "does nothing if message_log is nil" do
+          running_script = RunningScript.new(script_status)
+          RunningScript.class_variable_set(:@@message_log, nil)
+          running_script.send(:stop_message_log)
+
+          expect(script_status.log).to be_nil
+          expect(RunningScript.class_variable_get(:@@message_log)).to be_nil
+        end
+      end
+
+      describe "debug" do
+        it "evaluates debug text in script_binding when available" do
+          running_script = RunningScript.new(script_status)
+
+          script_binding = binding
+          test_var = "test value"  # This will be accessible in the binding
+
+          running_script.script_binding = script_binding
+          expect(running_script).to receive(:handle_output_io).twice
+          expect(script_binding.eval("test_var")).to eq("test value")
+          running_script.debug("test_var")
+        end
+
+        it "evaluates in Object context when script_binding is not available" do
+          running_script = RunningScript.new(script_status)
+
+          running_script.script_binding = nil
+          expect(running_script).to receive(:handle_output_io).twice
+          expect(Object).to receive(:class_eval).with("1 + 1", "debug", 1)
+
+          running_script.debug("1 + 1")
+        end
       end
     end
   end

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
@@ -1,0 +1,14 @@
+# encoding: ascii-8bit
+
+# Copyright 2025 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.

--- a/openc3-cosmos-script-runner-api/spec/models/script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/script_spec.rb
@@ -1,0 +1,447 @@
+# encoding: ascii-8bit
+
+# Copyright 2025 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+require "rails_helper"
+require "tempfile"
+require "open3"
+
+RSpec.describe Script, type: :model do
+  before(:each) do
+    mock_redis
+  end
+
+  describe "self.all" do
+    it "gets all scripts" do
+      allow(OpenC3::TargetFile).to receive(:all).and_return(["script1", "script2"])
+      expect(Script.all("DEFAULT")).to eq(["script1", "script2"])
+    end
+
+    it "gets all scripts for a target" do
+      allow(OpenC3::TargetFile).to receive(:all).and_return(["script1", "script2"])
+      expect(Script.all("DEFAULT", "TARGET")).to eq(["script1", "script2"])
+    end
+  end
+
+  describe "self.lock, self.unlock, self.locked?" do
+    it "locks and unlocks scripts" do
+      name = "script.rb"
+      username = "user1"
+
+      # Not locked initially
+      expect(Script.locked?("DEFAULT", name)).to be false
+
+      # Lock the script
+      Script.lock("DEFAULT", name, username)
+      expect(Script.locked?("DEFAULT", name)).to eq username
+
+      # Unlock the script
+      Script.unlock("DEFAULT", name)
+      expect(Script.locked?("DEFAULT", name)).to be false
+    end
+
+    it "handles modified script names with asterisks" do
+      name = "script.rb*"
+      username = "user1"
+
+      Script.lock("DEFAULT", name, username)
+      expect(Script.locked?("DEFAULT", name)).to eq username
+      expect(Script.locked?("DEFAULT", "script.rb")).to eq username
+
+      Script.unlock("DEFAULT", name)
+      expect(Script.locked?("DEFAULT", name)).to be false
+    end
+  end
+
+  describe "self.get_breakpoints" do
+    it "returns breakpoints for a script" do
+      name = "script.rb"
+      breakpoints = [10, 20, 30]
+
+      # Store breakpoints
+      OpenC3::Store.hset("DEFAULT__script-breakpoints", name, breakpoints.to_json)
+
+      # Retrieve breakpoints
+      expect(Script.get_breakpoints("DEFAULT", name)).to eq breakpoints
+    end
+
+    it "returns empty array if no breakpoints exist" do
+      name = "no_breakpoints.rb"
+      expect(Script.get_breakpoints("DEFAULT", name)).to eq []
+    end
+
+    it "handles modified script names with asterisks" do
+      name = "script.rb*"
+      breakpoints = [10, 20, 30]
+
+      # Store breakpoints
+      OpenC3::Store.hset("DEFAULT__script-breakpoints", "script.rb", breakpoints.to_json)
+
+      # Retrieve breakpoints
+      expect(Script.get_breakpoints("DEFAULT", name)).to eq breakpoints
+    end
+  end
+
+  describe "self.create" do
+    it "creates a new script" do
+      params = {
+        scope: "DEFAULT",
+        name: "new_script.rb",
+        text: "puts 'Hello'",
+        breakpoints: [5, 10]
+      }
+
+      allow(Script).to receive(:body).and_return(nil)
+      expect(OpenC3::TargetFile).to receive(:create).with("DEFAULT", "new_script.rb", "puts 'Hello'")
+
+      Script.create(params)
+
+      # Verify breakpoints were stored
+      stored_breakpoints = OpenC3::Store.hget("DEFAULT__script-breakpoints", "new_script.rb")
+      expect(JSON.parse(stored_breakpoints)).to eq([5, 10])
+    end
+
+    it "updates an existing script if text changed" do
+      params = {
+        scope: "DEFAULT",
+        name: "existing_script.rb",
+        text: "puts 'Updated'",
+        breakpoints: [15]
+      }
+
+      allow(Script).to receive(:body).and_return("puts 'Original'")
+      expect(OpenC3::TargetFile).to receive(:create).with("DEFAULT", "existing_script.rb", "puts 'Updated'")
+
+      Script.create(params)
+
+      # Verify breakpoints were stored
+      stored_breakpoints = OpenC3::Store.hget("DEFAULT__script-breakpoints", "existing_script.rb")
+      expect(JSON.parse(stored_breakpoints)).to eq([15])
+    end
+
+    it "doesn't update if text hasn't changed" do
+      params = {
+        scope: "DEFAULT",
+        name: "existing_script.rb",
+        text: "puts 'Same'",
+        breakpoints: [15]
+      }
+
+      allow(Script).to receive(:body).and_return("puts 'Same'")
+      expect(OpenC3::TargetFile).not_to receive(:create)
+
+      Script.create(params)
+
+      # Verify breakpoints were still stored
+      stored_breakpoints = OpenC3::Store.hget("DEFAULT__script-breakpoints", "existing_script.rb")
+      expect(JSON.parse(stored_breakpoints)).to eq([15])
+    end
+
+    it "removes breakpoints key if breakpoints array is empty" do
+      params = {
+        scope: "DEFAULT",
+        name: "script.rb",
+        text: "puts 'Hello'",
+        breakpoints: []
+      }
+
+      allow(Script).to receive(:body).and_return(nil)
+      expect(OpenC3::TargetFile).to receive(:create).with("DEFAULT", "script.rb", "puts 'Hello'")
+
+      # Pre-store breakpoints
+      OpenC3::Store.hset("DEFAULT__script-breakpoints", "script.rb", [5, 10].to_json)
+
+      Script.create(params)
+
+      # Verify breakpoints were removed
+      stored_breakpoints = OpenC3::Store.hget("DEFAULT__script-breakpoints", "script.rb")
+      expect(stored_breakpoints).to be_nil
+    end
+  end
+
+  describe "self.delete_temp" do
+    it "deletes temporary scripts and their breakpoints" do
+      allow(OpenC3::TargetFile).to receive(:delete_temp).and_return(["temp1.rb", "temp2.rb"])
+
+      # Pre-store breakpoints
+      OpenC3::Store.hset("DEFAULT__script-breakpoints", "temp/temp1.rb", [5, 10].to_json)
+      OpenC3::Store.hset("DEFAULT__script-breakpoints", "temp/temp2.rb", [15, 20].to_json)
+
+      Script.delete_temp("DEFAULT")
+
+      # Verify breakpoints were removed
+      expect(OpenC3::Store.hget("DEFAULT__script-breakpoints", "temp1.rb")).to be_nil
+      expect(OpenC3::Store.hget("DEFAULT__script-breakpoints", "temp2.rb")).to be_nil
+    end
+  end
+
+  describe "self.destroy" do
+    it "deletes a script and its breakpoints" do
+      name = "script_to_delete.rb"
+      allow(OpenC3::TargetFile).to receive(:destroy)
+
+      # Pre-store breakpoints
+      OpenC3::Store.hset("DEFAULT__script-breakpoints", name, [5, 10].to_json)
+
+      Script.destroy("DEFAULT", name)
+
+      # Verify breakpoints were removed
+      expect(OpenC3::Store.hget("DEFAULT__script-breakpoints", name)).to be_nil
+    end
+  end
+
+  describe "self.run" do
+    it "spawns a running script" do
+      expect(RunningScript).to receive(:spawn).with(
+        "DEFAULT", "script.rb", nil, false, nil, "User Name", "username", nil, nil
+      )
+
+      Script.run("DEFAULT", "script.rb", nil, false, nil, "User Name", "username")
+    end
+  end
+
+  describe "self.detect_language" do
+    it "detects Ruby based on file extension" do
+      expect(Script.detect_language("", "script.rb")).to eq "ruby"
+    end
+
+    it "detects Python based on file extension" do
+      expect(Script.detect_language("", "script.py")).to eq "python"
+    end
+
+    it "detects Ruby based on require keyword" do
+      expect(Script.detect_language("require 'openc3'")).to eq "ruby"
+    end
+
+    it "detects Ruby based on load keyword" do
+      expect(Script.detect_language("load 'file.rb'")).to eq "ruby"
+    end
+
+    it "detects Ruby based on puts keyword" do
+      expect(Script.detect_language("puts 'Hello'")).to eq "ruby"
+    end
+
+    it "detects Python based on import keyword" do
+      expect(Script.detect_language("import openc3")).to eq "python"
+    end
+
+    it "detects Python based on from keyword" do
+      expect(Script.detect_language("from openc3 import Script")).to eq "python"
+    end
+
+    it "detects Ruby based on end keyword" do
+      expect(Script.detect_language("def method\n  puts 'Hello'\nend")).to eq "ruby"
+    end
+
+    it "detects Python based on colon syntax" do
+      expect(Script.detect_language("def function():\n  print('Hello')")).to eq "python"
+    end
+
+    it "defaults to Ruby if no other indicators" do
+      expect(Script.detect_language("# Just a comment")).to eq "ruby"
+    end
+  end
+
+  describe "self.syntax" do
+    it "fails if no text is provided" do
+      result = Script.syntax("script.rb", nil)
+      expect(result["title"]).to eq "Syntax Check Failed"
+      expect(result["description"]).to eq "no text passed"
+    end
+
+    context "when checking Ruby syntax" do
+      it "returns success for valid Ruby syntax" do
+        allow_any_instance_of(IO).to receive(:readlines).and_return(["Syntax OK"])
+
+        result = Script.syntax("script.rb", "puts 'Valid Ruby'")
+        expect(result["title"]).to eq "Syntax Check Successful"
+        expect(JSON.parse(result["description"])).to include("Syntax OK")
+      end
+
+      it "returns failure for invalid Ruby syntax" do
+        allow_any_instance_of(IO).to receive(:readlines).and_return([":2: syntax error, unexpected end-of-input"])
+
+        result = Script.syntax("script.rb", "puts 'Invalid Ruby")
+        expect(result["title"]).to eq "Syntax Check Failed"
+        expect(JSON.parse(result["description"])).to include("2: syntax error, unexpected end-of-input")
+      end
+
+      it "handles unexpected nil result" do
+        allow_any_instance_of(IO).to receive(:readlines).and_return(nil)
+
+        result = Script.syntax("script.rb", "puts 'Ruby with nil result'")
+        expect(result["title"]).to eq "Syntax Check Exception"
+        expect(result["description"]).to eq "Ruby syntax check unexpectedly returned nil"
+      end
+    end
+
+    context "when checking Python syntax" do
+      it "returns success for valid Python syntax" do
+        allow(Open3).to receive(:capture2e).and_return(["", 0])
+
+        result = Script.syntax("script.py", "print('Valid Python')")
+        expect(result["title"]).to eq "Syntax Check Successful"
+        expect(JSON.parse(result["description"])).to eq(["Syntax OK"])
+      end
+
+      it "returns failure for invalid Python syntax" do
+        allow(Open3).to receive(:capture2e).and_return(["SyntaxError: invalid syntax", 1])
+
+        result = Script.syntax("script.py", "print('Invalid Python'")
+        expect(result["title"]).to eq "Syntax Check Failed"
+        expect(JSON.parse(result["description"])).to include("SyntaxError: invalid syntax")
+      end
+    end
+  end
+
+  describe "self.instrumented" do
+    context "for Ruby scripts" do
+      it "returns instrumented Ruby code" do
+        allow(RunningScript).to receive(:instrument_script).and_return("instrumented Ruby code")
+
+        result = Script.instrumented("script.rb", "puts 'Hello'")
+        expect(result["title"]).to eq "Instrumented Script"
+        expect(JSON.parse(result["description"])).to eq(["instrumented Ruby code"])
+      end
+    end
+  end
+
+  describe "self.process_suite" do
+    # Helper method to set up common mocks for process_suite tests
+    def setup_process_suite_mocks(language:, stdout_content: '{"suite":"data"}', stderr_content: "", exit_code: 0)
+      extension = (language == "ruby") ? ".rb" : ".py"
+
+      # Create mock suite tempfile
+      temp_path = File.join(Dir.tmpdir, "temp#{extension}")
+      suite_tempfile = double("tempfile", write: nil, close: nil, path: temp_path, delete: nil)
+      allow(Tempfile).to receive(:new).with(["suite", extension]).and_return(suite_tempfile)
+
+      # Setup ChildProcess to avoid trying to spawn real processes
+      process_env = {}
+      io_double = double("io")
+      allow(io_double).to receive(:stdout=)
+      allow(io_double).to receive(:stderr=)
+
+      process_double = double("process")
+      allow(process_double).to receive(:cwd=)
+      allow(process_double).to receive(:environment).and_return(process_env)
+      allow(process_double).to receive(:io).and_return(io_double)
+      allow(process_double).to receive(:start)
+      allow(process_double).to receive(:wait)
+      allow(process_double).to receive(:exit_code).and_return(exit_code)
+
+      allow(ChildProcess).to receive(:build).and_return(process_double)
+
+      # Mock stdout/stderr tempfiles
+      stdout_double = double("stdout")
+      allow(stdout_double).to receive(:sync=)
+      allow(stdout_double).to receive(:rewind)
+      allow(stdout_double).to receive(:read).and_return(stdout_content)
+      allow(stdout_double).to receive(:close)
+      allow(stdout_double).to receive(:unlink)
+
+      stderr_double = double("stderr")
+      allow(stderr_double).to receive(:sync=)
+      allow(stderr_double).to receive(:rewind)
+      allow(stderr_double).to receive(:read).and_return(stderr_content)
+      allow(stderr_double).to receive(:close)
+      allow(stderr_double).to receive(:unlink)
+
+      allow(Tempfile).to receive(:new).with("child-stdout").and_return(stdout_double)
+      allow(Tempfile).to receive(:new).with("child-stderr").and_return(stderr_double)
+
+      {process_env: process_env}
+    end
+
+    context "with successful execution" do
+      it "processes Ruby suite files" do
+        setup_process_suite_mocks(language: "ruby")
+
+        stdout_result, stderr_result, success = Script.process_suite("suite.rb", "suite content", scope: "DEFAULT")
+
+        expect(stdout_result).to eq '{"suite":"data"}'
+        expect(stderr_result).to eq ""
+        expect(success).to be true
+      end
+
+      it "processes Python suite files" do
+        setup_process_suite_mocks(language: "python")
+
+        stdout_result, stderr_result, success = Script.process_suite("suite.py", "suite content", scope: "DEFAULT")
+
+        expect(stdout_result).to eq '{"suite":"data"}'
+        expect(stderr_result).to eq ""
+        expect(success).to be true
+      end
+    end
+
+    context "with offline access token" do
+      it "uses the token when provided" do
+        # Mock offline access model
+        model_double = double("model", offline_access_token: "valid_token", update: nil)
+        allow(OpenC3::OfflineAccessModel).to receive(:get_model).and_return(model_double)
+
+        # Mock authentication
+        auth_double = double("auth")
+        allow(auth_double).to receive(:get_token_from_refresh_token).and_return(true)
+        allow(OpenC3::OpenC3KeycloakAuthentication).to receive(:new).and_return(auth_double)
+
+        # Setup process suite mocks
+        mocks = setup_process_suite_mocks(language: "ruby")
+
+        stdout_result, stderr_result, success = Script.process_suite("suite.rb", "suite content", username: "user1", scope: "DEFAULT")
+
+        expect(mocks[:process_env]["OPENC3_API_TOKEN"]).to eq "valid_token"
+        expect(stdout_result).to eq '{"suite":"data"}'
+        expect(stderr_result).to eq ""
+        expect(success).to be true
+      end
+
+      it "raises an error if offline token is invalid" do
+        # Mock offline access model with invalid token
+        model_double = double("model", offline_access_token: "invalid_token", update: nil)
+        allow(model_double).to receive(:offline_access_token=)
+        allow(OpenC3::OfflineAccessModel).to receive(:get_model).and_return(model_double)
+
+        # Mock authentication failure
+        auth_double = double("auth")
+        allow(auth_double).to receive(:get_token_from_refresh_token).and_return(false)
+        allow(OpenC3::OpenC3KeycloakAuthentication).to receive(:new).and_return(auth_double)
+
+        expect do
+          Script.process_suite("suite.rb", "suite content", username: "user1", scope: "DEFAULT")
+        end.to raise_error("offline_access token invalid for script")
+      end
+
+      it "returns empty strings if service password isn't set for viewer users" do
+        # No offline access model
+        allow(OpenC3::OfflineAccessModel).to receive(:get_model).and_return(nil)
+
+        # Remove service password
+        original_env = ENV.to_hash
+        ENV.delete("OPENC3_SERVICE_PASSWORD")
+
+        stdout_result, stderr_result, success = Script.process_suite("suite.rb", "suite content", username: "viewer", scope: "DEFAULT")
+
+        # Restore environment
+        ENV.clear
+        original_env.each { |k, v| ENV[k] = v }
+
+        expect(stdout_result).to eq ""
+        expect(stderr_result).to eq ""
+        expect(success).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Increases code coverage on Script Runner API to 64.2% (+38.5%). 
Some of the code in `running_script.rb` requires heavy stubbing, looking to address that separately.
`running_script.rb` is quite a large file, and I was following the convention of One Ruby file -> One Spec file, but if you'd like me to break it out, please let me know!