### PR TITLE
Remove extra : in toast notification when there's no body

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/notify/Toast.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/notify/Toast.vue
@@ -36,7 +36,12 @@
           v-if="toastNotification.title"
           class="text-subtitle-1 mr-1 notification-text"
         >
-          {{ toastNotification.title }}:
+          <template v-if="toastNotification.body || toastNotification.message">
+            {{ toastNotification.title }}:
+          </template>
+          <template v-else>
+            {{ toastNotification.title }}
+          </template>
         </span>
         <span
           v-if="toastNotification.body"
@@ -52,7 +57,7 @@
         </span>
       </div>
       <v-spacer />
-      <v-btn variant="text" @click.stop="hide" class="notification-text">
+      <v-btn variant="text" class="notification-text" @click.stop="hide">
         Dismiss
       </v-btn>
     </v-sheet>


### PR DESCRIPTION
This way it's just `{title}` instead of `{title}:`. The `:` is still there when there's a body

<img width="495" alt="image" src="https://github.com/user-attachments/assets/5239f143-7de5-4bdb-824e-470dfaf03220" />

<img width="352" alt="image" src="https://github.com/user-attachments/assets/4dd8a50b-3ba0-413d-b5c6-5238a363400a" />
