### PR TITLE
Make ace-diff publishable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,25 +136,37 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: openc3/python/dist
-      - name: publish npm js package
+      - name: publish npm ace-diff package
+        if: ${{ github.event.inputs.update_latest == 'true' }}
+        run: npm publish --access public
+        working-directory: openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: publish npm ace-diff package pre
+        if: ${{ github.event.inputs.update_latest != 'true' }}
+        run: npm publish --tag pre --access public
+        working-directory: openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: publish npm js-common package
         if: ${{ github.event.inputs.update_latest == 'true' }}
         run: npm publish --access public
         working-directory: openc3-cosmos-init/plugins/packages/openc3-js-common
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: publish npm js package pre
+      - name: publish npm js-common package pre
         if: ${{ github.event.inputs.update_latest != 'true' }}
         run: npm publish --tag pre --access public
         working-directory: openc3-cosmos-init/plugins/packages/openc3-js-common
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: publish npm vue package
+      - name: publish npm vue-common package
         if: ${{ github.event.inputs.update_latest == 'true' }}
         run: npm publish --access public
         working-directory: openc3-cosmos-init/plugins/packages/openc3-vue-common
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: publish npm vue package pre
+      - name: publish npm vue-common package pre
         if: ${{ github.event.inputs.update_latest != 'true' }}
         run: npm publish --tag pre --access public
         working-directory: openc3-cosmos-init/plugins/packages/openc3-vue-common

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/RELEASE.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/RELEASE.txt
@@ -1,0 +1,3 @@
+npm publish --access public
+or
+npm publish --tag beta --access public

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/package.json
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff/package.json
@@ -1,17 +1,22 @@
 {
   "name": "@openc3/ace-diff",
   "version": "6.4.2-beta0",
-  "private": true,
   "description": "Custom AceDiff build for OpenC3 COSMOS",
+  "homepage": "https://openc3.com",
   "source": "src/index.js",
   "main": "dist/ace-diff.min.js",
+  "module": "src/index.js",
+  "bugs": {
+    "url": "https://github.com/OpenC3/cosmos/issues"
+  },
   "scripts": {
     "build": "vite build",
     "lint": "eslint src"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ace-diff/ace-diff.git"
+    "url": "git+https://github.com/OpenC3/cosmos.git",
+    "directory": "openc3-cosmos-init/plugins/packages/openc3-cosmos-ace-diff"
   },
   "author": "Ben Keen, Jason Thomas",
   "license": "MIT",


### PR DESCRIPTION
Draft for now. @jmthomas reached out to the owner of https://github.com/ace-diff/ace-diff to see about taking it over since it looks abandoned. (Our fork should maybe be in its own repo, anyway.)