### PR TITLE
Clear screenItems when re-parsing screen definition

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
@@ -86,14 +86,14 @@
         <!-- Make the error messages a max height and scrollable -->
         <v-row style="max-height: 120px; overflow-y: auto">
           <div v-for="(error, index) in editErrors" :key="index">
-            <span class="text-red" v-text="error"></span>
+            <span class="text-red" v-text="error" />
           </div>
         </v-row>
         <v-row class="mt-5">
-          <span
-            >Ctrl-space brings up autocomplete. Right click keywords for
-            documentation.</span
-          >
+          <span>
+            Ctrl-space brings up autocomplete. Right click keywords for
+            documentation.
+          </span>
           <v-spacer />
           <v-btn
             class="mx-2"
@@ -150,6 +150,7 @@ export default {
       default: () => [],
     },
   },
+  emits: ['cancel', 'delete', 'save', 'update:modelValue'],
   data() {
     return {
       file: null,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -202,9 +202,9 @@
       :definition="currentDefinition"
       :keywords="keywords"
       :errors="errors"
-      @save="saveEdit($event)"
-      @cancel="cancelEdit()"
-      @delete="deleteScreen()"
+      @save="saveEdit"
+      @cancel="cancelEdit"
+      @delete="deleteScreen"
     />
 
     <!-- Error dialog -->
@@ -292,6 +292,15 @@ export default {
       default: false,
     },
   },
+  emits: [
+    'close-screen',
+    'delete-screen',
+    'drag-screen',
+    'edit-screen',
+    'float-screen',
+    'min-max-screen',
+    'unfloat-screen',
+  ],
   data() {
     return {
       api: null,
@@ -442,6 +451,7 @@ export default {
     parseDefinition: function () {
       // Each time we start over and parse the screen definition
       this.clearErrors()
+      this.screenItems = []
       this.namedWidgets = {}
       this.layoutStack = []
       this.dynamicWidgets = []

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VerticalWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VerticalWidget.vue
@@ -23,10 +23,10 @@
 <template>
   <div ref="container" :style="computedStyle">
     <component
-      v-bind="listeners"
-      v-for="(widget, index) in widgets"
-      :key="index"
       :is="widget.type"
+      v-for="(widget, index) in widgets"
+      v-bind="listeners"
+      :key="index"
       :target="widget.target"
       :parameters="widget.parameters"
       :settings="widget.settings"


### PR DESCRIPTION
Items were not being cleared when a screen is rendered, meaning that if you added an item that doesn't exist, the error alerting you to that fact would persist until you completely closed and reopened the screen (even after removing the bad item from the screen definition and clicking "save"). Clearing out `screenItems` when the screen definition is parsed fixes this, so all you have to do to clear the error is save the screen:

<img width="1286" alt="image" src="https://github.com/user-attachments/assets/e273702f-23a6-47e5-af6b-054326256eb3" />

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/72907a40-fd81-4847-969f-96f6c11c0ec1" />
