### PR TITLE
Fix Firefox infinite redirect issue

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/router.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/src/router.js
@@ -31,6 +31,11 @@ const DEFAULT_TOOL_URL = '/tools/cmdtlmserver' // where to redirect to if we can
 
 const getFirstTool = async () => {
   // Tools are global and are always installed into the DEFAULT scope
+
+  // Skip API call if not authenticated to avoid redirect loop
+  if (!localStorage.openc3Token) {
+    return { url: DEFAULT_TOOL_URL }
+  }
   const { data } = await Api.get('/openc3-api/tools/all', {
     params: { scope: 'DEFAULT' },
   })


### PR DESCRIPTION
Clone changes from https://github.com/OpenC3/cosmos-enterprise/pull/264 in enterprise. This issue is not present in Core (as Keycloak is not here) but still cloning the same short-circuit logic for continuity.