### PR TITLE
Reset the Tlm and Cmd Counts on Undeploy

### DIFF
--- a/openc3/lib/openc3/models/target_model.rb
+++ b/openc3/lib/openc3/models/target_model.rb
@@ -676,6 +676,8 @@ module OpenC3
       LimitsEventTopic.delete(@name, scope: @scope)
       Store.del("#{@scope}__openc3tlm__#{@name}")
       Store.del("#{@scope}__openc3cmd__#{@name}")
+      Store.del("#{@scope}__TELEMETRYCNTS__{#{@name}}")
+      Store.del("#{@scope}__COMMANDCNTS__{#{@name}}")
 
       # Note: these match the names of the services in deploy_microservices
       %w(MULTI DECOM COMMANDLOG DECOMCMDLOG PACKETLOG DECOMLOG REDUCER CLEANUP).each do |type|
@@ -795,6 +797,7 @@ module OpenC3
         if clear_old
           Store.del("#{@scope}__openc3tlm__#{target_name}")
           Store.del("#{@scope}__openc3tlm__#{target_name}__allitems")
+          Store.del("#{@scope}__TELEMETRYCNTS__{#{target_name}}")
         end
         packets.each do |packet_name, packet|
           Logger.debug "Configuring tlm packet: #{target_name} #{packet_name}"
@@ -816,7 +819,10 @@ module OpenC3
 
     def update_store_commands(packet_hash, clear_old: true)
       packet_hash.each do |target_name, packets|
-        Store.del("#{@scope}__openc3cmd__#{target_name}") if clear_old
+        if clear_old
+          Store.del("#{@scope}__openc3cmd__#{target_name}")
+          Store.del("#{@scope}__COMMANDCNTS__{#{target_name}}")
+        end
         packets.each do |packet_name, packet|
           Logger.debug "Configuring cmd packet: #{target_name} #{packet_name}"
           begin

--- a/openc3/python/openc3/models/target_model.py
+++ b/openc3/python/openc3/models/target_model.py
@@ -392,6 +392,7 @@ class TargetModel(Model):
             if clear_old:
                 Store.delete(f"{self.scope}__openc3tlm__{target_name}")
                 Store.delete(f"{self.scope}__openc3tlm__{target_name}__allitems")
+                Store.delete(f"{self.scope}__TELEMETRYCNTS__{{{target_name}}}")
             for packet_name, packet in packets.items():
                 Logger.debug(f"Configuring tlm packet= {target_name} {packet_name}")
                 try:
@@ -414,6 +415,7 @@ class TargetModel(Model):
         for target_name, packets in packet_hash.items():
             if clear_old:
                 Store.delete(f"{self.scope}__openc3cmd__{target_name}")
+                Store.delete(f"{self.scope}__COMMANDCNTS__{{{target_name}}}")
             for packet_name, packet in packets.items():
                 Logger.debug(f"Configuring cmd packet= {target_name} {packet_name}")
                 try:


### PR DESCRIPTION
This should reset the telemetry and command counts when a plugin is uninstalled.