### PR TITLE
Auto-Generate Docs when changes detected -- Add PAT for main push

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,19 +9,18 @@ on:
 
 jobs:
   build-and-commit:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Required to push commits
+          token: ${{ secrets.QA_PAT }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: "https://registry.npmjs.org"
       
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Existing action wasn't working as the action didn't have permission to push to `main`. Mimicking the implementation in: https://github.com/OpenC3/cosmos/blob/main/.github/workflows/release.yml

to check out with a PAT so that push is allowed