### PR TITLE
Add `range` arg option to get_object calls

### DIFF
--- a/openc3/lib/openc3/utilities/aws_bucket.rb
+++ b/openc3/lib/openc3/utilities/aws_bucket.rb
@@ -100,11 +100,11 @@ module OpenC3
       end
     end
 
-    def get_object(bucket:, key:, path: nil)
+    def get_object(bucket:, key:, path: nil, range: nil)
       if path
-        @client.get_object(bucket: bucket, key: key, response_target: path)
+        @client.get_object(bucket: bucket, key: key, response_target: path, range: range)
       else
-        @client.get_object(bucket: bucket, key: key)
+        @client.get_object(bucket: bucket, key: key, range: range)
       end
     # If the key is not found return nil
     rescue Aws::S3::Errors::NoSuchKey

--- a/openc3/lib/openc3/utilities/bucket.rb
+++ b/openc3/lib/openc3/utilities/bucket.rb
@@ -53,7 +53,7 @@ module OpenC3
       raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
     end
 
-    def get_object(bucket:, key:, path: nil)
+    def get_object(bucket:, key:, path: nil, range: nil)
       raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
     end
 

--- a/openc3/python/openc3/utilities/aws_bucket.py
+++ b/openc3/python/openc3/utilities/aws_bucket.py
@@ -118,7 +118,7 @@ class AwsBucket(Bucket):
         if self.exist(bucket):
             self.client.delete_bucket(Bucket=bucket)
 
-    def get_object(self, bucket, key, path=None, range=None):
+    def get_object(self, bucket, key, path=None, range=""):
         try:
             if path:
                 response = self.client.get_object(Bucket=bucket, Key=key, Range=range)

--- a/openc3/python/openc3/utilities/aws_bucket.py
+++ b/openc3/python/openc3/utilities/aws_bucket.py
@@ -118,15 +118,15 @@ class AwsBucket(Bucket):
         if self.exist(bucket):
             self.client.delete_bucket(Bucket=bucket)
 
-    def get_object(self, bucket, key, path=None):
+    def get_object(self, bucket, key, path=None, range=None):
         try:
             if path:
-                response = self.client.get_object(Bucket=bucket, Key=key)
+                response = self.client.get_object(Bucket=bucket, Key=key, Range=range)
                 with open(path, "wb") as f:
                     f.write(response["Body"].read())
                 return response
             else:
-                return self.client.get_object(Bucket=bucket, Key=key)
+                return self.client.get_object(Bucket=bucket, Key=key, Range=range)
         # If the key is not found return nil
         except ClientError:
             return None

--- a/openc3/python/openc3/utilities/bucket.py
+++ b/openc3/python/openc3/utilities/bucket.py
@@ -59,7 +59,7 @@ class Bucket:
             f"{self.__class__.__name__} has not implemented method '{inspect.currentframe().f_code.co_name}'"
         )
 
-    def get_object(self, bucket, key, path=None):
+    def get_object(self, bucket, key, path=None, range=None):
         raise NotImplementedError(
             f"{self.__class__.__name__} has not implemented method '{inspect.currentframe().f_code.co_name}'"
         )

--- a/openc3/python/openc3/utilities/bucket.py
+++ b/openc3/python/openc3/utilities/bucket.py
@@ -59,7 +59,7 @@ class Bucket:
             f"{self.__class__.__name__} has not implemented method '{inspect.currentframe().f_code.co_name}'"
         )
 
-    def get_object(self, bucket, key, path=None, range=None):
+    def get_object(self, bucket, key, path=None, range=""):
         raise NotImplementedError(
             f"{self.__class__.__name__} has not implemented method '{inspect.currentframe().f_code.co_name}'"
         )

--- a/openc3/spec/local_s3.rb
+++ b/openc3/spec/local_s3.rb
@@ -79,7 +79,7 @@ module LocalS3
       bucket
     end
 
-    def get_object(bucket:, key:, response_target: nil)
+    def get_object(bucket:, key:, response_target: nil, range: nil)
       s3_obj = S3Object.new(bucket_name: bucket, key: key)
       data = File.open(File.expand_path(File.join(@fs_root, bucket, key))) do |file|
         file.read

--- a/openc3/spec/utilities/local_mode_spec.rb
+++ b/openc3/spec/utilities/local_mode_spec.rb
@@ -210,7 +210,7 @@ module OpenC3
         6.times do |index|
           key = "DEFAULT/targets_modified/INST/screens/myscreen#{index}.txt"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
 
         expect(ToolConfigModel).to receive(:save_config).with("telemetry-grapher", "temps", "[]", {:local_mode=>false, :scope=>"DEFAULT"})
@@ -601,7 +601,7 @@ module OpenC3
         key = "DEFAULT/targets_modified/INST/procedures/mod.rb"
         full_path = "#{@tmp_dir}/#{key}"
         rubys3_client = double()
-        expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+        expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         expect(Aws::S3::Client).to receive(:new).and_return(rubys3_client)
         LocalMode.sync_remote_to_local(Bucket.getClient, key)
       end
@@ -716,7 +716,7 @@ module OpenC3
         6.times do |index|
           key = "DEFAULT/targets_modified/INST/screens/myscreen#{index}.txt"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         LocalMode.sync_with_bucket(Bucket.getClient, scope: 'DEFAULT')
       end
@@ -735,12 +735,12 @@ module OpenC3
         6.times do |index|
           key = "DEFAULT/targets_modified/INST/screens/myscreen#{index}.txt"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         4.times do |index|
           key = "DEFAULT/targets_modified/ANOTHER/something/mod#{index}.ext"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         LocalMode.sync_with_bucket(Bucket.getClient, scope: 'DEFAULT')
       end
@@ -759,7 +759,7 @@ module OpenC3
         6.times do |index|
           key = "DEFAULT/targets_modified/INST/screens/myscreen#{index}.txt"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         LocalMode.sync_with_bucket(Bucket.getClient, scope: 'DEFAULT')
       end
@@ -778,22 +778,22 @@ module OpenC3
         6.times do |index|
           key = "DEFAULT/targets_modified/INST/screens/myscreen#{index}.txt"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         3.times do |index|
           key = "DEFAULT/targets_modified/ANOTHER/tables/mod#{index}.bin"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         4.times do |index|
           key = "DEFAULT/targets_modified/ANOTHER/something/mod#{index}.ext"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         2.times do |index|
           key = "DEFAULT/targets_modified/__TEMP__/temp#{index}.rb"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         LocalMode.sync_with_bucket(Bucket.getClient, scope: 'DEFAULT')
       end
@@ -830,12 +830,12 @@ module OpenC3
         6.times do |index|
           key = "DEFAULT/targets_modified/INST/screens/myscreen#{index}.txt"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         4.times do |index|
           key = "DEFAULT/targets_modified/ANOTHER/something/mod#{index}.ext"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         LocalMode.sync_with_bucket(Bucket.getClient, scope: 'DEFAULT')
         5.times do |index|
@@ -869,7 +869,7 @@ module OpenC3
         6.times do |index|
           key = "DEFAULT/targets_modified/INST/screens/myscreen#{index}.txt"
           full_path = "#{@tmp_dir}/#{key}"
-          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path })
+          expect(rubys3_client).to receive(:get_object).with({bucket: 'config', key: key, response_target: full_path, range: nil })
         end
         LocalMode.sync_targets_modified
       end


### PR DESCRIPTION
The following get_object lookups have been tested with Minio and AWS S3:
```
**PYTHON**
from openc3.utilities.bucket import Bucket
client = Bucket.getClient()
response = client.get_object(bucket="config", key="DEFAULT/targets_modified/test.csv", range="bytes=1-10")
print(response["Body"].read())

from openc3.utilities.bucket import Bucket
client = Bucket.getClient()
response = client.get_object(bucket="config", key="DEFAULT/targets_modified/test.csv")
print(response["Body"].read())
```

```
**RUBY**
client = OpenC3::Bucket.getClient
response = client.get_object(bucket: "config", key: "DEFAULT/targets_modified/test.csv", range: "bytes=1-10")
puts response.body.read

client = OpenC3::Bucket.getClient
response = client.get_object(bucket: "config", key: "DEFAULT/targets_modified/test.csv")
puts response.body.read
```