### PR TITLE
Add autocomplete to Tlm Viewer dropdowns

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
@@ -29,7 +29,7 @@
         <v-expansion-panel-text>
           <v-container>
             <v-row class="pa-3">
-              <v-select
+              <v-autocomplete
                 class="mr-4"
                 density="compact"
                 hide-details
@@ -42,7 +42,7 @@
                 style="max-width: 300px"
                 data-test="select-target"
               />
-              <v-select
+              <v-autocomplete
                 class="mr-4"
                 density="compact"
                 hide-details
@@ -280,8 +280,10 @@ export default {
       this.selectedScreen = this.screens[target][0]
     },
     screenSelect(screen) {
-      this.selectedScreen = screen
-      this.showScreen(this.selectedTarget, this.selectedScreen)
+      if (screen) {
+        this.selectedScreen = screen
+        this.showScreen(this.selectedTarget, this.selectedScreen)
+      }
     },
     newScreen() {
       this.newScreenDialog = true


### PR DESCRIPTION
Closes #2159 
<img width="1241" alt="Screenshot 2025-07-01 at 1 51 53 PM" src="https://github.com/user-attachments/assets/6832af97-63f3-4f05-ab3a-38fdc206cfc4" />
Adds autocomplete type-ahead (similar to command sender) to the dropdowns for Tlm Viewer