### PR TITLE
Fix static routes

### DIFF
--- a/openc3-traefik/traefik-allow-http.yaml
+++ b/openc3-traefik/traefik-allow-http.yaml
@@ -66,7 +66,7 @@ http:
     # Where we need to add index.html to the path
     # Matches any tool name that starts with static and ends with slash
     statictools-index-router:
-      rule: PathRegexp(`/tools/static.*/`)
+      rule: PathRegexp(`/tools/static.*/$`)
       middlewares:
         # add index.html to the end
         - "addIndexHtml"

--- a/openc3-traefik/traefik-letsencrypt.yaml
+++ b/openc3-traefik/traefik-letsencrypt.yaml
@@ -103,7 +103,7 @@ http:
     # Where we need to add index.html to the path
     # Matches any tool name that starts with static and ends with slash
     statictools-index-router:
-      rule: PathRegexp(`/tools/static.*/`)
+      rule: PathRegexp(`/tools/static.*/$`)
       middlewares:
         # add index.html to the end
         - "addIndexHtml"

--- a/openc3-traefik/traefik-ssl.yaml
+++ b/openc3-traefik/traefik-ssl.yaml
@@ -88,7 +88,7 @@ http:
     # Where we need to add index.html to the path
     # Matches any tool name that starts with static and ends with slash
     statictools-index-router:
-      rule: PathRegexp(`/tools/static.*/`)
+      rule: PathRegexp(`/tools/static.*/$`)
       middlewares:
         # add index.html to the end
         - "addIndexHtml"

--- a/openc3-traefik/traefik.yaml
+++ b/openc3-traefik/traefik.yaml
@@ -66,7 +66,7 @@ http:
     # Where we need to add index.html to the path
     # Matches any tool name that starts with static and ends with slash
     statictools-index-router:
-      rule: PathRegexp(`/tools/static.*/`)
+      rule: PathRegexp(`/tools/static.*/$`)
       middlewares:
         # add index.html to the end
         - "addIndexHtml"


### PR DESCRIPTION
closes https://github.com/OpenC3/cosmos/issues/2182

The index router was matching e.g. `/tools/staticdocs/docs/tools/bucket-explorer` because there is another `/` after `static.*`. This makes the regex stricter so that route goes to the correct middleware (adding `.html` instead of `/index.html`)