### PR TITLE
Correct documentation on default LED Widget width

### DIFF
--- a/docs.openc3.com/docs/configuration/telemetry-screens.md
+++ b/docs.openc3.com/docs/configuration/telemetry-screens.md
@@ -887,8 +887,8 @@ By default TRUE is green and FALSE is red and all other values are black. Additi
 | Packet name | The packet name | True |
 | Item name | The item name | True |
 | Value type | The type of the value to display. Default is CONVERTED.<br/><br/>Valid Values: <span class="values">RAW, CONVERTED, FORMATTED, WITH_UNITS</span> | False |
-| Width | Width of the LED circle (default = 15) | False |
-| Height | Height of the LED circle (default = 15) | False |
+| Width | Width of the LED circle (default = 20) | False |
+| Height | Height of the LED circle (default = 20) | False |
 
 Example Usage:
 ```ruby

--- a/openc3/data/config/widgets.yaml
+++ b/openc3/data/config/widgets.yaml
@@ -746,11 +746,11 @@ Telemetry Widgets:
           values: <%= %w(RAW CONVERTED FORMATTED WITH_UNITS) %>
         - name: Width
           required: false
-          description: Width of the LED circle (default = 15)
+          description: Width of the LED circle (default = 20)
           values: .*
         - name: Height
           required: false
-          description: Height of the LED circle (default = 15)
+          description: Height of the LED circle (default = 20)
           values: .*
       example: |
         LED INST PARAMS VALUE5 RAW 25 20 # Ellipse


### PR DESCRIPTION
The default width of LED widget (in LED) is 20, whereas the default for LABELLED is 15. Correcting documentation to reflect this.