### PR TITLE
Fix Classification-Banner and Snackbar relationship | gRPC | playwright

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/Dockerfile
+++ b/openc3-cosmos-cmd-tlm-api/Dockerfile
@@ -12,10 +12,6 @@ USER root
 
 RUN bundle config set --local without 'development test' \
   && bundle install --quiet \
-  # grpc needs to be uninstalled with the --platform flag to avoid errors on linux-musl
-  # See: https://github.com/protocolbuffers/protobuf/issues/16853#issuecomment-2583135716
-  # Should be fixed June 2025, look for grpc > 1.72.0 with a x86-linux-musl platform
-  && gem uninstall grpc --platform aarch64-linux --all --force \
   && rm -rf /usr/lib/ruby/gems/*/cache/* \
   /var/cache/apk/* \
   /tmp/* \

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -25,9 +25,11 @@
     <top-bar :menus="menus" :title="title" />
     <v-snackbar
       v-model="showAlert"
-      location="top"
+      absolute
       :color="alertType"
       :timeout="3000"
+      class="apply-top"
+      :style="classificationStyles"
     >
       <v-icon> mdi-{{ alertType }} </v-icon>
       {{ alertText }}
@@ -42,7 +44,9 @@
     </v-snackbar>
     <v-snackbar
       v-model="showEditingToast"
-      location="top"
+      absolute
+      class="apply-top"
+      :style="classificationStyles"
       :timeout="-1"
       color="orange"
     >
@@ -251,9 +255,10 @@
         <v-snackbar
           v-model="showSave"
           absolute
-          location="top right"
+          location="right"
           :timeout="-1"
-          class="saving"
+          class="saving apply-top"
+          :style="classificationStyles"
         >
           Saving...
         </v-snackbar>
@@ -510,6 +515,7 @@ import {
   SimpleTextDialog,
   TopBar,
 } from '@/components'
+import { ClassificationBanners } from '@/tools/base'
 import { fileIcon } from '@/util'
 import { EventListDialog } from '@/tools/calendar'
 
@@ -560,7 +566,7 @@ export default {
     ScriptLogMessages,
     CriticalCmdDialog,
   },
-  mixins: [AceEditorModes],
+  mixins: [AceEditorModes, ClassificationBanners],
   beforeRouteUpdate: function (to, from, next) {
     if (to.params.id) {
       this.tryLoadRunningScript(to.params.id).then(next)
@@ -2780,5 +2786,9 @@ class TestSuite(Suite):
   position: relative;
   cursor: pointer;
   border-radius: 6px;
+}
+
+.apply-top .v-snackbar__wrapper {
+  top: var(--classification-height-top);
 }
 </style>

--- a/openc3-cosmos-script-runner-api/Dockerfile
+++ b/openc3-cosmos-script-runner-api/Dockerfile
@@ -12,10 +12,6 @@ USER root
 
 RUN bundle config set --local without 'development test' \
   && bundle install --quiet \
-  # grpc needs to be uninstalled with the --platform flag to avoid errors on linux-musl
-  # See: https://github.com/protocolbuffers/protobuf/issues/16853#issuecomment-2583135716
-  # Should be fixed June 2025, look for grpc > 1.72.0 with a x86-linux-musl platform
-  && gem uninstall grpc --platform aarch64-linux --all --force \
   && rm -rf /usr/lib/ruby/gems/*/cache/* \
   /var/cache/apk/* \
   /tmp/* \

--- a/playwright/tests/admin/interfaces.p.spec.ts
+++ b/playwright/tests/admin/interfaces.p.spec.ts
@@ -28,7 +28,7 @@ test('displays interface names', async ({ page, utils }) => {
   await expect(page.getByText('EXAMPLE_INT')).toBeVisible()
   await expect(page.getByText('TEMPLATED_INT')).toBeVisible()
   // SYSTEM has no interface
-  await expect(page.getByText('SYSTEM')).not.toBeVisible()
+  await expect(page.getByText('SYSTEM', { exact: true })).not.toBeVisible()
 })
 
 test('displays interface details', async ({ page, utils }) => {


### PR DESCRIPTION
- gRPC 1.74.0 released July 24, removing the "uninstall" in the Dockerfiles that were causing issues
- Update the snackbars in ScriptRunner to respect the classification banners (closes #2224)
- Update playwright test that was impacting enterprise tests

<img width="1645" height="521" alt="Screenshot 2025-07-25 at 11 51 10 AM" src="https://github.com/user-attachments/assets/659d26f9-3a94-4095-af17-370fe706e142" />

<img width="1287" height="375" alt="Screenshot 2025-07-25 at 11 54 28 AM" src="https://github.com/user-attachments/assets/c4a65304-03ee-4044-b6f3-717db6028b1d" />

