### PR TITLE
Add formatting on byte column for Bucket Explorer

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/src/tools/BucketExplorer/BucketExplorer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/src/tools/BucketExplorer/BucketExplorer.vue
@@ -130,7 +130,7 @@
           {{ item.name }}
         </template>
         <template #item.size="{ item }">
-          {{ item.size ? item.size.toLocaleString() : '' }}
+          {{ item.size ? formatBytesToString(item.size) : '' }}
         </template>
         <template #item.action="{ item }">
           <v-btn
@@ -252,6 +252,7 @@
 
 <script>
 import { Api } from '@openc3/js-common/services'
+import { formatBytesToString } from '@openc3/js-common/utils'
 import { OutputDialog, TopBar } from '@openc3/vue-common/components'
 import axios from 'axios'
 
@@ -328,9 +329,8 @@ export default {
   },
   computed: {
     folderTotal() {
-      return this.files
-        .reduce((a, b) => a + (b.size ? b.size : 0), 0)
-        .toLocaleString()
+      return formatBytesToString(this.files
+        .reduce((a, b) => a + (b.size ? b.size : 0), 0))
     },
     breadcrumbPath() {
       const parts = this.path.split('/')
@@ -631,6 +631,7 @@ export default {
           this.updating = false
         })
     },
+    formatBytesToString,
   },
 }
 </script>

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/formatter.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/formatter.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2025, OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -16,7 +16,14 @@
 # if purchased from OpenC3, Inc.
 */
 
-import { prependBasePath } from './routeUtils'
-import { formatBytesToString } from './formatter'
+const formatBytesToString = function(bytes) {
+  if (bytes === 0) return '0 B'
+  
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const k = 1024
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
 
-export { prependBasePath, formatBytesToString }
+export { formatBytesToString }

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/formatter.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/formatter.js
@@ -20,7 +20,7 @@ const formatBytesToString = function(bytes) {
   if (bytes === 0) return '0 B'
   
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
-  const k = 1024
+  const k = 1000
   const i = Math.floor(Math.log(bytes) / Math.log(k))
   
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]


### PR DESCRIPTION
closes #2255 

Converts the Byte column to be more "human readable"

<img width="1639" height="842" alt="Screenshot 2025-08-07 at 6 17 17 PM" src="https://github.com/user-attachments/assets/a0263353-dce8-4078-9be5-5e69c5a0c1cc" />