### PR TITLE
Do not disable command chooser when command name is null

### DIFF
--- a/docs.openc3.com/docs/guides/troubleshooting.md
+++ b/docs.openc3.com/docs/guides/troubleshooting.md
@@ -76,4 +76,17 @@ We've seen a number of issues deploying COSMOS via Docker in various types of in
    - Enable the Setting
    - Completely restart Chrome. On MacOS make sure the dot below the icon in chrome is gone by long pressing the icon and choosing Quit.
 
+1. When using your own certs, you see an error banner with "Token is invalid" with "Failed to open TCP connection to &lt;KEYCLOAK URL&gt; (execution expired)".
+
+   We have seen this when a local firewall is blocking the 443 port to Keycloak. Keycloak itself can still be reachable at `&lt;KEYCLOAK URL&gt;/auth` which makes it feel like this is not a firewall issue. However, if you exec into the `cmd-tlm-api` container you should be able to curl the following Keycloak URL:
+
+   ```bash
+   docker ps
+   docker exec -it <CONTAINER ID FOR CMD_TLM_API> sh
+   $ ping <KEYCLOAK URL>
+   $ curl -vvv <KEYCLOAK URL>/realms/openc3/protocol/openid-connect/certs
+   ```
+
+   If this does not return you could be blocking the 443 port to Keycloak. Update your firewall settings and try again.
+
 Encountering an issue not on this list? If you're a customer, please get in touch at [support@openc3.com](mailto:support@openc3.com).

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -28,7 +28,7 @@
         <target-packet-item-chooser
           :initial-target-name="$route.params.target"
           :initial-packet-name="$route.params.packet"
-          :disabled="sendDisabled || commandName == null"
+          :disabled="sendDisabled"
           button-text="Send"
           mode="cmd"
           @on-set="commandChanged($event)"


### PR DESCRIPTION
closes #2272 

@ryanmelt Not sure why you changed this but if you have a target with no commands this effectively disables the command selection permanently.