### PR TITLE
Improve handling of long file names

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/FileOpenSaveDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/FileOpenSaveDialog.vue
@@ -21,7 +21,7 @@
 -->
 
 <template>
-  <v-dialog v-model="show" width="600" @keydown.enter="success()">
+  <v-dialog v-model="show" width="800" @keydown.enter="success()">
     <v-card>
       <v-overlay :model-value="loading">
         <v-progress-circular

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
@@ -674,6 +674,9 @@ export default {
   padding: 4px;
 }
 .tpic-select {
-  max-width: 300px;
+  max-width: 400px;
+}
+.v-autocomplete .v-select__selections {
+  word-break: break-all;
 }
 </style>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TreeNode.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TreeNode.vue
@@ -21,6 +21,15 @@
 # based on code example provided in https://github.com/vuetifyjs/vuetify/issues/19919
 -->
 <template>
+  <!-- Global tooltip for all tree nodes -->
+  <v-tooltip
+    v-if="globalTooltip.show"
+    :model-value="true"
+    :text="globalTooltip.text"
+    location="top"
+    :style="`position: fixed; left: ${globalTooltip.x}px; top: ${globalTooltip.y}px; pointer-events: none;`"
+  />
+  
   <div class="tree-node">
     <div v-if="showNode" class="node-content" @click="handleClick(node)">
       <div class="content-wrapper">
@@ -55,6 +64,8 @@
           class="title"
           :tabindex="node.children ? -1 : 0"
           @keyup.enter="handleClick(node)"
+          @mouseenter="showGlobalTooltip($event, node.title)"
+          @mouseleave="hideGlobalTooltip"
         >
           {{ node.title }}
         </span>
@@ -137,6 +148,31 @@ watch(
 )
 
 const emit = defineEmits(['nodeToggled', 'request'])
+
+const globalTooltip = ref({
+  show: false,
+  text: '',
+  x: 0,
+  y: 0
+})
+
+const showGlobalTooltip = (event, text) => {
+  // Only show tooltip if text is long enough to potentially overflow
+  if (!text || text.length <= 50) return
+  
+  const rect = event.target.getBoundingClientRect()
+  const centerX = rect.left
+  const centerY = rect.top
+  
+  globalTooltip.value.text = text
+  globalTooltip.value.x = centerX
+  globalTooltip.value.y = centerY - 40
+  globalTooltip.value.show = true
+}
+
+const hideGlobalTooltip = () => {
+  globalTooltip.value.show = false
+}
 
 const handleClick = (node) => {
   if (node.children) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TreeNode.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TreeNode.vue
@@ -21,7 +21,6 @@
 # based on code example provided in https://github.com/vuetifyjs/vuetify/issues/19919
 -->
 <template>
-  <!-- Global tooltip for all tree nodes -->
   <v-tooltip
     v-if="globalTooltip.show"
     :model-value="true"

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TreeNode.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TreeNode.vue
@@ -22,8 +22,7 @@
 -->
 <template>
   <v-tooltip
-    v-if="globalTooltip.show"
-    :model-value="true"
+    v-model="globalTooltip.show"
     :text="globalTooltip.text"
     location="top"
     :style="`position: fixed; left: ${globalTooltip.x}px; top: ${globalTooltip.y}px; pointer-events: none;`"

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -142,19 +142,28 @@
                 <span v-else> Back to New Script </span>
               </v-tooltip>
             </div>
-            <v-select
-              id="filename"
-              v-model="filenameSelect"
-              :items="fileList"
-              :disabled="fileList.length <= 1"
-              label="Filename"
-              data-test="filename"
-              style="width: 300px"
-              density="compact"
-              variant="outlined"
-              hide-details
-              @update:model-value="fileNameChanged"
-            />
+            <v-tooltip
+              location="bottom"
+              :text="filenameSelect"
+              :disabled="!filenameSelect || filenameSelect.length <= 45"
+            >
+              <template v-slot:activator="{ props }">
+                <div v-bind="props" style="width: 32rem">
+                  <v-select
+                    id="filename"
+                    v-model="filenameSelect"
+                    :items="fileList"
+                    :disabled="fileList.length <= 1"
+                    label="Filename"
+                    data-test="filename"
+                    density="compact"
+                    variant="outlined"
+                    hide-details
+                    @update:model-value="fileNameChanged"
+                  />
+                </div>
+              </template>
+            </v-tooltip>
             <v-text-field
               v-model="scriptId"
               label="Script ID"


### PR DESCRIPTION
closes #2259 
closes #2222 

Added tooltips, widened dialogs, and added CSS to handle particularly long packet names / file names.

<img width="1471" height="720" alt="Screenshot 2025-08-08 at 4 58 29 PM" src="https://github.com/user-attachments/assets/c9ffcb1c-5770-4f71-847a-4c7353d34f96" />
<img width="979" height="297" alt="Screenshot 2025-08-11 at 11 23 15 AM" src="https://github.com/user-attachments/assets/ebea5ece-e4ad-45c6-9264-19f5a36f137d" />
<img width="1236" height="621" alt="Screenshot 2025-08-11 at 12 23 06 PM" src="https://github.com/user-attachments/assets/57223937-f66f-4e5f-9370-491884adcd90" />
