### PR TITLE
Add pretty-print feature to redis tab

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RedisTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RedisTab.vue
@@ -34,21 +34,34 @@
       </v-card-subtitle>
       <v-card-text class="pb-0 ml-2">
         <v-text-field
+          v-model="redisCommandText"
+          hide-details
           label="Redis command"
           class="monospace"
-          v-model="redisCommandText"
           @keydown="commandKeydown"
         />
-        <span v-if="redisResponse" class="monospace">
-          Response: {{ redisResponse }}
-        </span>
+        <v-checkbox
+          v-model="prettyPrint"
+          label="Pretty print"
+          density="compact"
+          hide-details
+          class="mb-2"
+        />
+        <template v-if="redisResponse">
+          <pre
+            v-if="prettyPrint"
+            class="monospace"
+            v-text="formattedResponse"
+          />
+          <span v-else class="monospace"> Response: {{ redisResponse }} </span>
+        </template>
       </v-card-text>
       <v-card-actions class="px-2">
         <v-btn
           :disabled="!redisCommandText.length"
-          @click="executeRaw"
           color="success"
           variant="text"
+          @click="executeRaw"
         >
           Execute
         </v-btn>
@@ -89,6 +102,7 @@ export default {
       redisCommandText: '',
       redisResponse: null,
       redisEndpoint: '/openc3-api/redis/exec',
+      prettyPrint: false,
       headers: [
         { text: 'Redis', value: 'redis', width: 150 },
         { text: 'Command', value: 'command' },
@@ -96,6 +110,33 @@ export default {
       ],
       commands: [],
     }
+  },
+  computed: {
+    formattedResponse: function () {
+      let result = this.redisResponse
+      if (this.redisResponse && this.prettyPrint) {
+        if (typeof result === 'string') {
+          try {
+            result = JSON.parse(result)
+          } catch (e) {
+            // Oh 🐋
+          }
+        }
+        if (Array.isArray(result)) {
+          for (let i = 0; i < result.length; i++) {
+            if (typeof result[i] === 'string') {
+              try {
+                result[i] = JSON.parse(result[i])
+              } catch (e) {
+                // Oh 🐋
+              }
+            }
+          }
+        }
+      }
+      result = JSON.stringify(result, null, 2)
+      return `Response: ${result}`
+    },
   },
   methods: {
     commandKeydown: function ($event) {
@@ -129,6 +170,9 @@ export default {
 <style scoped>
 .monospace {
   font-family: monospace;
-  font-size: 20px;
+  font-size: 14px;
+}
+pre {
+  font-size: 14px;
 }
 </style>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RedisTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RedisTab.vue
@@ -48,11 +48,7 @@
           class="mb-2"
         />
         <template v-if="redisResponse">
-          <pre
-            v-if="prettyPrint"
-            class="monospace"
-            v-text="formattedResponse"
-          />
+          <pre v-if="prettyPrint" v-text="formattedResponse" />
           <span v-else class="monospace"> Response: {{ redisResponse }} </span>
         </template>
       </v-card-text>
@@ -170,9 +166,6 @@ export default {
 <style scoped>
 .monospace {
   font-family: monospace;
-  font-size: 14px;
-}
-pre {
   font-size: 14px;
 }
 </style>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/InformationDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/InformationDialog.vue
@@ -26,13 +26,13 @@
     <v-card>
       <v-toolbar height="24">
         <v-spacer />
-        <span style="white-space: pre-line" v-text="title" />
+        <span style="white-space: pre" v-text="title" />
         <v-spacer />
       </v-toolbar>
       <div class="pa-2">
         <v-card-text>
           <v-row no-gutters v-for="(line, index) in text" :key="index">
-            <span style="white-space: pre-line" v-text="line" />
+            <span style="white-space: pre" v-text="line" />
           </v-row>
         </v-card-text>
       </div>


### PR DESCRIPTION
I use the redis tab all the time and this has been bugging me so hard lol

Before:
<img width="1211" height="543" alt="image" src="https://github.com/user-attachments/assets/28bd4abf-86a3-49ac-be8a-4953819f15b1" />
After:
<img width="1208" height="550" alt="image" src="https://github.com/user-attachments/assets/a6918bef-36a0-4195-b389-84d18ec12bdf" />
