### PR TITLE
Add Disable Command Validation in Command Sender

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -294,6 +294,7 @@ export default {
       statesInHex: false,
       showIgnoredParams: false,
       cmdRaw: false,
+      disableCommandValidation: false,
       ignoredParams: [],
       rows: [],
       interfaces: [],
@@ -384,6 +385,14 @@ export default {
               checked: this.cmdRaw,
               command: () => {
                 this.cmdRaw = !this.cmdRaw.checked
+              },
+            },
+            {
+              label: 'Disable Command Validation',
+              checkbox: true,
+              checked: this.disableCommandValidation,
+              command: () => {
+                this.disableCommandValidation = !this.disableCommandValidation
               },
             },
           ],
@@ -700,6 +709,7 @@ export default {
             this.displaySendHazardous = true
           } else {
             let obs
+            let kwparams = this.disableCommandValidation ? { validate: false } : {}
             if (this.cmdRaw) {
               if (this.ignoreRangeChecks) {
                 cmd = 'cmd_raw_no_range_check'
@@ -710,6 +720,7 @@ export default {
                   {
                     'Ignore-Errors': '428',
                   },
+                  kwparams,
                 )
               } else {
                 cmd = 'cmd_raw'
@@ -717,7 +728,7 @@ export default {
                   // This request could be denied due to out of range but since
                   // we're explicitly handling it we don't want the interceptor to fire
                   'Ignore-Errors': '428 500',
-                })
+                }, kwparams)
               }
             } else {
               if (this.ignoreRangeChecks) {
@@ -729,6 +740,7 @@ export default {
                   {
                     'Ignore-Errors': '428',
                   },
+                  kwparams,
                 )
               } else {
                 cmd = 'cmd'
@@ -736,7 +748,7 @@ export default {
                   // This request could be denied due to out of range but since
                   // we're explicitly handling it we don't want the interceptor to fire
                   'Ignore-Errors': '428 500',
-                })
+                }, kwparams)
               }
             }
 
@@ -772,6 +784,7 @@ export default {
       this.displaySendHazardous = false
       let obs = ''
       let cmd = ''
+      let kwparams = this.disableCommandValidation ? { validate: false } : {}
       if (this.cmdRaw) {
         if (this.ignoreRangeChecks) {
           cmd = 'cmd_raw_no_range_check'
@@ -782,6 +795,7 @@ export default {
             {
               'Ignore-Errors': '428',
             },
+            kwparams,
           )
         } else {
           cmd = 'cmd_raw'
@@ -794,6 +808,7 @@ export default {
               // we're explicitly handling it we don't want the interceptor to fire
               'Ignore-Errors': '428 500',
             },
+            kwparams,
           )
         }
       } else {
@@ -806,6 +821,7 @@ export default {
             {
               'Ignore-Errors': '428',
             },
+            kwparams,
           )
         } else {
           cmd = 'cmd'
@@ -818,6 +834,7 @@ export default {
               // we're explicitly handling it we don't want the interceptor to fire
               'Ignore-Errors': '428 500',
             },
+            kwparams,
           )
         }
       }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -900,7 +900,11 @@ export default {
             }
           }
         }
-        msg += '")'
+        if (this.disableCommandValidation) {
+          msg += '", validate: false)'
+        } else {
+          msg += '")'
+        }
         if (!this.history.includes(msg)) {
           let value = msg
           if (this.history.length !== 0) {

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/openc3Api.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/openc3Api.js
@@ -482,7 +482,7 @@ export default class OpenC3Api {
   }
 
   // Implementation of functionality shared by cmd methods with param_lists.
-  _cmd(method, target_name, command_name, param_list, headerOptions) {
+  _cmd(method, target_name, command_name, param_list, headerOptions, kwparams = {}) {
     let converted = null
     for (let key in param_list) {
       if (Object.prototype.hasOwnProperty.call(param_list, key)) {
@@ -495,7 +495,7 @@ export default class OpenC3Api {
     return this.exec(
       method,
       [target_name, command_name, param_list],
-      {},
+      kwparams,
       headerOptions,
     )
   }
@@ -514,7 +514,7 @@ export default class OpenC3Api {
     }
   }
 
-  cmd(target_name, command_name, param_list, headerOptions = {}) {
+  cmd(target_name, command_name, param_list, headerOptions = {}, kwparams = {}) {
     if (command_name === undefined) {
       return this.exec('cmd', target_name, {}, headerOptions)
     } else {
@@ -524,6 +524,7 @@ export default class OpenC3Api {
         command_name,
         param_list,
         headerOptions,
+        kwparams
       )
     }
   }
@@ -533,9 +534,10 @@ export default class OpenC3Api {
     command_name,
     param_list,
     headerOptions = {},
+    kwparams = {},
   ) {
     if (command_name === undefined) {
-      return this.exec('cmd_no_range_check', target_name, {}, headerOptions)
+      return this.exec('cmd_no_range_check', target_name, {}, headerOptions, kwparams)
     } else {
       return this._cmd(
         'cmd_no_range_check',
@@ -543,13 +545,14 @@ export default class OpenC3Api {
         command_name,
         param_list,
         headerOptions,
+        kwparams
       )
     }
   }
 
-  cmd_raw(target_name, command_name, param_list, headerOptions = {}) {
+  cmd_raw(target_name, command_name, param_list, headerOptions = {}, kwparams = {}) {
     if (command_name === undefined) {
-      return this.exec('cmd_raw', target_name, {}, headerOptions)
+      return this.exec('cmd_raw', target_name, {}, headerOptions, kwparams)
     } else {
       return this._cmd(
         'cmd_raw',
@@ -557,6 +560,7 @@ export default class OpenC3Api {
         command_name,
         param_list,
         headerOptions,
+        kwparams,
       )
     }
   }
@@ -566,9 +570,10 @@ export default class OpenC3Api {
     command_name,
     param_list,
     headerOptions = {},
+    kwparams = {},
   ) {
     if (command_name === undefined) {
-      return this.exec('cmd_raw_no_range_check', target_name, {}, headerOptions)
+      return this.exec('cmd_raw_no_range_check', target_name, {}, headerOptions, kwparams)
     } else {
       return this._cmd(
         'cmd_raw_no_range_check',
@@ -576,6 +581,7 @@ export default class OpenC3Api {
         command_name,
         param_list,
         headerOptions,
+        kwparams,
       )
     }
   }
@@ -585,9 +591,10 @@ export default class OpenC3Api {
     command_name,
     param_list,
     headerOptions = {},
+    kwparams = {}
   ) {
     if (command_name === undefined) {
-      return this.exec('cmd_no_hazardous_check', target_name, {}, headerOptions)
+      return this.exec('cmd_no_hazardous_check', target_name, {}, headerOptions, kwparams)
     } else {
       return this._cmd(
         'cmd_no_hazardous_check',
@@ -595,13 +602,14 @@ export default class OpenC3Api {
         command_name,
         param_list,
         headerOptions,
+        kwparams,
       )
     }
   }
 
-  cmd_no_checks(target_name, command_name, param_list, headerOptions = {}) {
+  cmd_no_checks(target_name, command_name, param_list, headerOptions = {}, kwparams = {}) {
     if (command_name === undefined) {
-      return this.exec('cmd_no_checks', target_name, {}, headerOptions)
+      return this.exec('cmd_no_checks', target_name, {}, headerOptions, kwparams)
     } else {
       return this._cmd(
         'cmd_no_checks',
@@ -609,6 +617,7 @@ export default class OpenC3Api {
         command_name,
         param_list,
         headerOptions,
+        kwparams,
       )
     }
   }
@@ -618,6 +627,7 @@ export default class OpenC3Api {
     command_name,
     param_list,
     headerOptions = {},
+    kwparams = {}
   ) {
     if (command_name === undefined) {
       return this.exec(
@@ -625,6 +635,7 @@ export default class OpenC3Api {
         target_name,
         {},
         headerOptions,
+        kwparams,
       )
     } else {
       return this._cmd(
@@ -633,13 +644,14 @@ export default class OpenC3Api {
         command_name,
         param_list,
         headerOptions,
+        kwparams,
       )
     }
   }
 
-  cmd_raw_no_checks(target_name, command_name, param_list, headerOptions = {}) {
+  cmd_raw_no_checks(target_name, command_name, param_list, headerOptions = {}, kwparams = {}) {
     if (command_name === undefined) {
-      return this.exec('cmd_raw_no_checks', target_name, {}, headerOptions)
+      return this.exec('cmd_raw_no_checks', target_name, {}, headerOptions, kwparams)
     } else {
       return this._cmd(
         'cmd_raw_no_checks',
@@ -647,23 +659,24 @@ export default class OpenC3Api {
         command_name,
         param_list,
         headerOptions,
+        kwparams,
       )
     }
   }
 
-  build_cmd(target_name, command_name, param_list) {
+  build_cmd(target_name, command_name, param_list, headerOptions = {}, kwparams = {}) {
     if (command_name === undefined) {
       return this.exec('build_cmd', target_name)
     } else {
-      return this._cmd('build_cmd', target_name, command_name, param_list)
+      return this._cmd('build_cmd', target_name, command_name, param_list, headerOptions, kwparams)
     }
   }
   // DEPRECATED for build_cmd
-  build_command(target_name, command_name, param_list) {
+  build_command(target_name, command_name, param_list, headerOptions = {}, kwparams = {}) {
     if (command_name === undefined) {
       return this.exec('build_cmd', target_name)
     } else {
-      return this._cmd('build_cmd', target_name, command_name, param_list)
+      return this._cmd('build_cmd', target_name, command_name, param_list, headerOptions, kwparams)
     }
   }
 

--- a/playwright/tests/command-sender.p.spec.ts
+++ b/playwright/tests/command-sender.p.spec.ts
@@ -675,3 +675,16 @@ test('disable parameter conversions', async ({ page, utils }) => {
     '00000010: 01 00',
   )
 })
+
+test('disables command validation', async ({ page, utils }) => {
+  await page.locator('[data-test="clear-history"]').click()
+  await utils.selectTargetPacketItem('INST', 'TIME_OFFSET')
+  
+  await page.locator('[data-test=command-sender-mode]').click()
+  await page.getByText('Disable Command Validation').click()
+  
+  await page.locator('[data-test="select-send"]').click()
+  await expect(page.locator('main')).toContainText(
+    'cmd("INST TIME_OFFSET with SECONDS 0, IP_ADDRESS \'127.0.0.1\'") sent',
+  )
+})


### PR DESCRIPTION
Adds a "Disable Command Validation" option in Command Sender. Most changes is including `kwargs` as an option in the openc3Api.js. With `kwargs` added, any kwargs can also be added through the openc3Api.js

closes #2106 

<img width="1069" height="508" alt="Screenshot 2025-08-24 at 3 50 52 PM" src="https://github.com/user-attachments/assets/3154caff-e944-4c0a-81ca-6f439fec568c" />
