### PR TITLE
Fix uploaded filename in script

### DIFF
--- a/openc3/python/openc3/utilities/running_script.py
+++ b/openc3/python/openc3/utilities/running_script.py
@@ -160,13 +160,13 @@ def running_script_method(method, *args, **kwargs):
                         file = _get_storage_file(
                             f"tmp/{theFilename}", scope=RunningScript.instance.scope()
                         )
-
-                        def filename(self):
-                            return theFilename
-
-                        type(file).filename = filename
+                        file._filename = theFilename
                         files.append(file)
-                        pass
+
+                    def filename(self):
+                        return self._filename
+                    type(files[0]).filename = filename
+
                     if method == "open_file_dialog":  # Simply return the only file
                         files = files[0]
                     return files


### PR DESCRIPTION
Because we were setting `.filename` on the type and it got set in each loop iteration, every `NamedTemporaryFile.filename()` would always return the last filename in `input`. There might still be a cleaner way to do this, but you're not really supposed to define arbitrary methods on python objects, so... at least this works now