### PR TITLE
Set required_ruby_version in all gemspecs

### DIFF
--- a/docs.openc3.com/openc3-cosmos-tool-docs.gemspec
+++ b/docs.openc3.com/openc3-cosmos-tool-docs.gemspec
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2024 OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/examples/openc3-cosmos-accessor-test/openc3-cosmos-accessor-test.gemspec
+++ b/examples/openc3-cosmos-accessor-test/openc3-cosmos-accessor-test.gemspec
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2022 OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -27,6 +27,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/examples/openc3-cosmos-erb-test/openc3-cosmos-erb-test.gemspec
+++ b/examples/openc3-cosmos-erb-test/openc3-cosmos-erb-test.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/examples/openc3-cosmos-http-example/openc3-cosmos-http-example.gemspec
+++ b/examples/openc3-cosmos-http-example/openc3-cosmos-http-example.gemspec
@@ -1,6 +1,21 @@
 # encoding: ascii-8bit
 
-# Create the overall gemspec
+# Copyright 2025 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can modify and/or redistribute it
+# under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation; version 3 with
+# attribution addendums as found in the LICENSE.txt
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
 spec = Gem::Specification.new do |s|
   s.name = 'openc3-cosmos-http-example'
   s.summary = 'OpenC3 COSMOS Http Example'
@@ -12,6 +27,7 @@ spec = Gem::Specification.new do |s|
   s.email = ['ryan@openc3.com']
   s.homepage = 'https://github.com/OpenC3/cosmos'
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/examples/openc3-cosmos-mqtt-test/openc3-cosmos-mqtt-test.gemspec
+++ b/examples/openc3-cosmos-mqtt-test/openc3-cosmos-mqtt-test.gemspec
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2022 OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -27,6 +27,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/openc3-cosmos-demo.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/openc3-cosmos-demo.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -33,6 +33,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-admin/openc3-cosmos-tool-admin.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-admin/openc3-cosmos-tool-admin.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/openc3-cosmos-tool-bucketexplorer.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/openc3-cosmos-tool-bucketexplorer.gemspec
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -28,6 +28,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/openc3-cosmos-tool-cmdsender.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/openc3-cosmos-tool-cmdsender.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/openc3-cosmos-tool-cmdtlmserver.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/openc3-cosmos-tool-cmdtlmserver.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/openc3-cosmos-tool-dataextractor.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/openc3-cosmos-tool-dataextractor.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/openc3-cosmos-tool-dataviewer.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/openc3-cosmos-tool-dataviewer.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-handbooks/openc3-cosmos-tool-handbooks.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-handbooks/openc3-cosmos-tool-handbooks.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/openc3-cosmos-tool-iframe.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/openc3-cosmos-tool-iframe.gemspec
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023, OpenC3, Inc.
+# Copyright 2025, OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is free software; you can modify and/or redistribute it
@@ -28,6 +28,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/openc3-cosmos-tool-limitsmonitor.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/openc3-cosmos-tool-limitsmonitor.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/openc3-cosmos-tool-packetviewer.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/openc3-cosmos-tool-packetviewer.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/openc3-cosmos-tool-scriptrunner.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-scriptrunner/openc3-cosmos-tool-scriptrunner.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/openc3-cosmos-tool-tablemanager.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/openc3-cosmos-tool-tablemanager.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmgrapher/openc3-cosmos-tool-tlmgrapher.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmgrapher/openc3-cosmos-tool-tlmgrapher.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/openc3-cosmos-tool-tlmviewer.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/openc3-cosmos-tool-tlmviewer.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/openc3-tool-base.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/openc3-tool-base.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -32,6 +32,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/OpenC3/cosmos'
 
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup

--- a/openc3/openc3.gemspec
+++ b/openc3/openc3.gemspec
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -44,6 +44,7 @@ spec = Gem::Specification.new do |s|
   else
     s.platform = Gem::Platform::CURRENT
   end
+  s.required_ruby_version = '>= 3.0'
 
   s.version = '6.8.1.pre.beta0'
   s.licenses = ['AGPL-3.0-only', 'Nonstandard']
@@ -72,8 +73,6 @@ spec = Gem::Specification.new do |s|
 
   # Files are defined in Manifest.txt
   s.files = Dir.glob("{bin,data,ext,lib,spec,tasks,templates,test}/**/*", File::FNM_DOTMATCH) + %w(Gemfile Guardfile LICENSE.txt Rakefile README.md)
-
-  s.required_ruby_version = '>= 3.0'
 
   # Runtime Dependencies
   s.add_runtime_dependency 'bundler',   '~> 2.3'

--- a/openc3/templates/plugin/plugin.gemspec
+++ b/openc3/templates/plugin/plugin.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.email = ['name@domain.com']
   s.homepage = 'https://github.com/OpenC3/cosmos'
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 3.0'
 
   if ENV['VERSION']
     s.version = ENV['VERSION'].dup


### PR DESCRIPTION
There is a warning when you create gems:

```
WARNING:  make sure you specify the oldest ruby version constraint (like ">= 3.0") that you want your gem to support by setting the `required_ruby_version` gemspec attribute
```

So this adds `s.required_ruby_version = '>= 3.0'` to all the gemspecs