### PR TITLE
Make plugin instance names repeatable #2282

### DIFF
--- a/openc3/lib/openc3/models/plugin_model.rb
+++ b/openc3/lib/openc3/models/plugin_model.rb
@@ -313,7 +313,12 @@ module OpenC3
     end
 
     def create(update: false, force: false, queued: false)
-      @name = @name + "__#{Time.now.utc.strftime("%Y%m%d%H%M%S")}" if not update and not @name.index("__")
+      if not update and not @name.index("__")
+        existing_names = Set.new(self.class.names(scope: @scope))
+        counter = 0
+        counter += 1 while existing_names.include?("#{@name}__#{counter}")
+        @name = "#{@name}__#{counter}"
+      end
       super(update: update, force: force, queued: queued)
     end
 


### PR DESCRIPTION
Closes https://github.com/OpenC3/cosmos/issues/2282

Instead of names like `openc3-cosmos-bob-1.0.1.gem__20250904175756`, they now increment with a counter like `openc3-cosmos-bob-1.0.1.gem__3`. Deleting one or more instances in the middle of the sequence and re-installing will fill that gap back in the sequence and then continue as expected. This is backwards compatible with the current timestamp based naming (see unit tests).

If it's more desirable to just continue after the highest counter value and don't fill in the gap, that's an easy change.

# Validation Steps

1. Create an example plugin by following the [getting started guide](https://docs.openc3.com/docs/getting-started/gettingstarted)
2. Install the same gem bundle multiple times (but make the target unique)
3. Verify expected naming behavior

<img width="1476" height="262" alt="Screenshot 2025-09-14 at 7 18 07 PM" src="https://github.com/user-attachments/assets/45af6058-8322-41d9-8159-f985e60c2f11" />

# Unit Tests

```
OPENC3_NO_EXT=1 bundle exec rspec spec/models/plugin_model_spec.rb
...................

Finished in 15.15 seconds (files took 0.36234 seconds to load)
19 examples, 0 failures

Coverage report generated for test:unit to /Users/markmiller/workdir/markmiller-cosmos/openc3/coverage.
Line Coverage: 28.07% (3388 / 12068)
```