### PR TITLE
require 'json/add/string'

### DIFF
--- a/openc3/lib/openc3/io/json_rpc.rb
+++ b/openc3/lib/openc3/io/json_rpc.rb
@@ -14,13 +14,14 @@
 # GNU Affero General Public License for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2024, OpenC3, Inc.
+# All changes Copyright 2025, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
 require 'json'
+require 'json/add/core'
 require 'date'
 require 'openc3/core_ext/string'
 

--- a/openc3/lib/openc3/io/json_rpc.rb
+++ b/openc3/lib/openc3/io/json_rpc.rb
@@ -21,7 +21,7 @@
 # if purchased from OpenC3, Inc.
 
 require 'json'
-require 'json/add/core'
+require 'json/add/string'
 require 'date'
 require 'openc3/core_ext/string'
 


### PR DESCRIPTION
This change in json https://github.com/ruby/json/pull/833 requires you to now `require 'json/add/string'` before you can call the various methods on the String object. Since [v2.14.0](https://github.com/ruby/json/releases/tag/v2.14.0).