### PR TITLE
Script runner debugger can't print object properties directly #2302

### DIFF
--- a/openc3/python/openc3/utilities/running_script.py
+++ b/openc3/python/openc3/utilities/running_script.py
@@ -586,7 +586,7 @@ class RunningScript:
             if not use_script_engine:
                 if self.script_binding:
                     # Check for accessing an instance variable or local
-                    if debug_text in self.script_binding[1]:  # In local variables
+                    if debug_text.split(".")[0] in self.script_binding[1]:  # In local variables
                         debug_text = (
                             f"print({debug_text})"  # Automatically add print to print it
                         )


### PR DESCRIPTION
Closes #2302

Using the example in the linked issue, the problem in the current logic is that `self.script_binding[1]` contains kv's like:
```
{
    ...,
    'Foo': <class 'openc3.utilities.running_script.Foo'>,
    'foo': <openc3.utilities.running_script.Foo object at 0xffff97102990>,
    'baz': 123
}
```
The `print` is added and the statement eval'd only if the `debug_text` is directly found as a key in that dict. So `foo` will print, `baz` with print after `baz = foo.bar`, but `foo.bar` is not a dict key and therefore will not eval. By splitting the `debug_text` by dot and taking the first element, that at least checks if the base instance variable exists.

If you try `foo.baz` (an attribute that doesn't exist), you get `AttributeError : 'Foo' object has no attribute 'baz'` which is useful and expected.

## Validation

Following the same repro steps, you can now type `foo.bar` and it will correctly eval to `123`:

<img width="1407" height="796" alt="image" src="https://github.com/user-attachments/assets/0c857e5f-6088-44a4-a186-b1642777377a" />