### PR TITLE
Limits Monitor wider item column

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/src/tools/LimitsMonitor/LimitsControl.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/src/tools/LimitsMonitor/LimitsControl.vue
@@ -230,7 +230,7 @@ export default {
           sortable: true,
           minWidth: '100px',
           width: '200px',
-          maxWidth: '300px',
+          maxWidth: '410px', // Widest without overflow at 100% zoom
         },
         {
           title: 'Value',
@@ -595,4 +595,5 @@ export default {
   font-weight: bold;
   background-color: var(--color-background-base-default);
 }
+
 </style>


### PR DESCRIPTION
closes #2398

Vuetify does not support resizing columns via the UI. Tried some percent-based header widths but between the widgets with defined widths, it got tricky. Landed with extending the max-width value, 410px being the widest at 100% zoom and side bar open without causing the data-table to overflow-x scroll.