### PR TITLE
fix(dataextractor): RFC 4180 quote fields containing delimiter, quote, or newline

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -1095,19 +1095,23 @@ export default {
     },
     // Quote a single field for the active delimiter following RFC 4180:
     // wrap in double quotes when the value contains the delimiter, a double
-    // quote, CR, or LF, and double any embedded double quotes.
+    // quote, CR, or LF, and double any embedded double quotes. Numbers,
+    // booleans, etc. can never contain those characters, so we return them
+    // untouched and let Array.prototype.join stringify them. Arrays are
+    // pre-stringified at the call site (as "[a,b,c]") and arrive here as
+    // strings, so they take the normal string path.
     quoteField: function (value) {
       if (value === null || value === undefined) return ''
-      const s = String(value)
+      if (typeof value !== 'string') return value
       if (
-        s.includes(this.delimiter) ||
-        s.includes('"') ||
-        s.includes('\n') ||
-        s.includes('\r')
+        value.includes(this.delimiter) ||
+        value.includes('"') ||
+        value.includes('\n') ||
+        value.includes('\r')
       ) {
-        return '"' + s.replace(/"/g, '""') + '"'
+        return '"' + value.replace(/"/g, '""') + '"'
       }
-      return s
+      return value
     },
     finished: async function () {
       this.progress = 95 // Indicate we're almost done

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -1111,7 +1111,7 @@ export default {
         s.includes('\n') ||
         s.includes('\r')
       ) {
-        return '"' + s.replace(/"/g, '""') + '"'
+        return '"' + s.replaceAll('"', '""') + '"'
       }
       return s
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -947,7 +947,9 @@ export default {
       if (this.matlabHeader) {
         headers += '% '
       }
-      headers += columnHeaders.join(this.delimiter)
+      headers += columnHeaders
+        .map((h) => this.quoteField(h))
+        .join(this.delimiter)
       outputFile.push(headers)
 
       // Sort everything by time so we can output in order
@@ -986,7 +988,7 @@ export default {
             if (packet[key] === null) {
               row[columnIndex] = ''
             } else if (Array.isArray(packet[key])) {
-              row[columnIndex] = '"[' + packet[key] + ']"'
+              row[columnIndex] = '[' + packet[key] + ']'
             } else {
               let rawVal = packet[key]['raw']
               if (Array.isArray(rawVal)) {
@@ -1051,7 +1053,9 @@ export default {
               }
             }
           }
-          outputFile.push(row.join(this.delimiter))
+          outputFile.push(
+            row.map((v) => this.quoteField(v)).join(this.delimiter),
+          )
         }
         count += 1
         if (count % 1000 == 0) {
@@ -1088,6 +1092,22 @@ export default {
       return new Promise((resolve) => {
         setTimeout(resolve, 0)
       })
+    },
+    // Quote a single field for the active delimiter following RFC 4180:
+    // wrap in double quotes when the value contains the delimiter, a double
+    // quote, CR, or LF, and double any embedded double quotes.
+    quoteField: function (value) {
+      if (value === null || value === undefined) return ''
+      const s = String(value)
+      if (
+        s.includes(this.delimiter) ||
+        s.includes('"') ||
+        s.includes('\n') ||
+        s.includes('\r')
+      ) {
+        return '"' + s.replace(/"/g, '""') + '"'
+      }
+      return s
     },
     finished: async function () {
       this.progress = 95 // Indicate we're almost done

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -1094,24 +1094,26 @@ export default {
       })
     },
     // Quote a single field for the active delimiter following RFC 4180:
-    // wrap in double quotes when the value contains the delimiter, a double
-    // quote, CR, or LF, and double any embedded double quotes. Numbers,
-    // booleans, etc. can never contain those characters, so we return them
-    // untouched and let Array.prototype.join stringify them. Arrays are
-    // pre-stringified at the call site (as "[a,b,c]") and arrive here as
-    // strings, so they take the normal string path.
+    // wrap in double quotes when the stringified value contains the
+    // delimiter, a double quote, CR, or LF, and double any embedded
+    // double quotes. Numbers, booleans, and BigInts cannot contain those
+    // characters, so we return them untouched and let Array.prototype.join
+    // stringify them at the join. Objects/arrays are stringified defensively
+    // and run through the same scan.
     quoteField: function (value) {
       if (value === null || value === undefined) return ''
-      if (typeof value !== 'string') return value
+      const t = typeof value
+      if (t === 'number' || t === 'boolean' || t === 'bigint') return value
+      const s = t === 'string' ? value : String(value)
       if (
-        value.includes(this.delimiter) ||
-        value.includes('"') ||
-        value.includes('\n') ||
-        value.includes('\r')
+        s.includes(this.delimiter) ||
+        s.includes('"') ||
+        s.includes('\n') ||
+        s.includes('\r')
       ) {
-        return '"' + value.replace(/"/g, '""') + '"'
+        return '"' + s.replace(/"/g, '""') + '"'
       }
-      return value
+      return s
     },
     finished: async function () {
       this.progress = 95 // Indicate we're almost done


### PR DESCRIPTION
## Summary

Fixes #858.

`DataExtractor` previously built each output row as `row.join(this.delimiter)` with no quoting. A string telemetry value that contained the active delimiter (typically `,`) — or `"`, `CR`, `LF` — would corrupt the CSV output. Array values were pre-wrapped as `"[…]"` by hand, which only happened to be correct in CSV mode and produced a stray quote in tab-delimited mode.

This change introduces an RFC 4180 `quoteField` helper and applies it consistently at the header and row join points, so both CSV and TSV output stay parseable when values contain the delimiter, embedded quotes, or newlines.

## Changes

- New `quoteField(value)` method that returns the value as-is unless it contains the current `delimiter`, `"`, `\r`, or `\n`, in which case it wraps in double quotes and doubles any embedded double quotes (per RFC 4180). `null`/`undefined` become empty strings.
- Apply `quoteField` to each header before `join`.
- Apply `quoteField` to each row cell before `join`.
- Drop the manual `'"[' + arr + ']"'` wrapping for array values. With the helper in place, arrays produce `[a,b,c]` raw, and the join-time helper quotes correctly for whatever delimiter is active.

## Verification

- `pnpm lint --max-warnings 0` clean in `openc3-cosmos-tool-dataextractor`.
- 17 Node-based assertions over the helper + a minimal RFC 4180 parser round-trip, covering: comma in string, embedded `"`, embedded `\n`, array brackets, plain int/string passthrough, `null`/`undefined` → `""`, `NaN`/`Infinity` passthrough, and TSV mode (no quoting on `,`, quoting on `\t`, array brackets pass through). All pass.
- Cross-checked the existing Playwright assertions in `playwright/tests/data-extractor.p.spec.ts`: `TARGET,PACKET,TEMP1,TEMP2`, `% TIME,TARGET,PACKET,Q1,Q2`, `INST HEALTH_STATUS TEMP1`, and `INST,LATEST,HTML` all produce identical bytes (no commas/quotes in those header/value strings → passthrough).

## Test plan
- [ ] Reviewer runs `pnpm lint` in `openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor`.
- [ ] Reviewer runs the existing `playwright/tests/data-extractor.p.spec.ts` suite against this branch and confirms no regression.
- [ ] (Optional manual) Add a telemetry string value containing a comma, run DataExtractor in CSV mode, and confirm the value round-trips through a CSV parser (e.g. Excel, `csv.DictReader`).
