### PR TITLE
STORED_LIMITS_MODE

### DIFF
--- a/docs.openc3.com/docs/configuration/_target.md
+++ b/docs.openc3.com/docs/configuration/_target.md
@@ -14,6 +14,39 @@ Targets are the external embedded systems that COSMOS connects to. Targets are d
 
 A target communicates with COSMOS through an [Interface](interfaces). Targets are typically mapped to an interface using the [MAP_TARGET](plugins.md#map_target), [MAP_CMD_TARGET](plugins.md#map_cmd_target), and [MAP_TLM_TARGET](plugins.md#map_tlm_target) keywords beneath the [INTERFACE](plugins.md#interface-1) definition. Targets and interfaces are a many-to-many relationship; see [Mapping Targets to Interfaces](interfaces#mapping-targets-to-interfaces) for details.
 
+## Stored Limits Mode
+
+When COSMOS receives telemetry through a normal real-time interface, limits are evaluated, state changes are logged, and any configured [limits responses](limits-response) are triggered. However, when telemetry arrives with the **stored** flag set (e.g. from a [File Interface](interfaces#file-interface) or historical data replay), you may not want limits processing to behave the same way. The `STORED_LIMITS_MODE` plugin.txt setting controls this behavior per target.
+
+### Modes
+
+| Mode | Limits Evaluated | Changes Logged | Limits Reactions | Updates Current State |
+|------|:----------------:|:--------------:|:----------------:|:---------------------:|
+| **NORMAL** (default) | Yes | Yes | Yes | Yes |
+| **LOG** | Yes | Yes | No | No |
+| **DISABLE** | No | No | No | No |
+
+**NORMAL** -- The default. Stored packets are processed exactly like real-time packets. Limits are evaluated, state changes are logged and published, limits responses fire, and the system-wide current limits state (used by `get_overall_limits_state` and the Limits Monitor) is updated.
+
+**LOG** -- Limits are evaluated and state changes are logged and published to the limits event stream, but limits responses (automated reactions) are **not** triggered. The current limits state hash is **not** updated, so stored data cannot cause the overall system limits state to change. This is useful when you want visibility into historical limits behavior without side effects.
+
+**DISABLE** -- Limits processing is skipped entirely for stored packets. No limits are evaluated, no state changes are logged, no events are published, and no limits responses fire. Additionally, the decommutated output for stored packets will not contain limits state (`__L`) values. This is useful when replaying large volumes of historical data where limits are irrelevant.
+
+:::info
+Non-stored (real-time) packets are always processed normally regardless of this setting.
+:::
+
+### Configuration
+
+`STORED_LIMITS_MODE` is set as a modifier under the [TARGET](plugins.md#target-1) keyword in `plugin.txt`:
+
+```cosmos
+TARGET INST INST
+  STORED_LIMITS_MODE LOG
+```
+
+See the [STORED_LIMITS_MODE](plugins.md#stored_limits_mode) reference for parameter details.
+
 ## target.txt Keywords
 
 COSMOS_META

--- a/docs.openc3.com/docs/configuration/_target.md
+++ b/docs.openc3.com/docs/configuration/_target.md
@@ -18,15 +18,19 @@ A target communicates with COSMOS through an [Interface](interfaces). Targets ar
 
 When COSMOS receives telemetry through a normal real-time interface, limits are evaluated, state changes are logged, and any configured [limits responses](limits-response) are triggered. However, when telemetry arrives with the **stored** flag set (e.g. from a [File Interface](interfaces#file-interface) or historical data replay), you may not want limits processing to behave the same way. The `STORED_LIMITS_MODE` plugin.txt setting controls this behavior per target.
 
+:::info
+Please see [Historical Data Ingest](/docs/guides/historical-data.md) for how to handle historical data in COSMOS.
+:::
+
 ### Modes
 
 | Mode | Limits Evaluated | Changes Logged | Limits Reactions | Updates Current State |
 |------|:----------------:|:--------------:|:----------------:|:---------------------:|
-| **NORMAL** (default) | Yes | Yes | Yes | Yes |
+| **PROCESS** (default) | Yes | Yes | Yes | Yes |
 | **LOG** | Yes | Yes | No | No |
 | **DISABLE** | No | No | No | No |
 
-**NORMAL** -- The default. Stored packets are processed exactly like real-time packets. Limits are evaluated, state changes are logged and published, limits responses fire, and the system-wide current limits state (used by `get_overall_limits_state` and the Limits Monitor) is updated.
+**PROCESS** -- The default. Stored packets are processed exactly like real-time packets. Limits are evaluated, state changes are logged and published, limits responses fire, and the system-wide current limits state (used by `get_overall_limits_state` and the Limits Monitor) is updated.
 
 **LOG** -- Limits are evaluated and state changes are logged and published to the limits event stream, but limits responses (automated reactions) are **not** triggered. The current limits state hash is **not** updated, so stored data cannot cause the overall system limits state to change. This is useful when you want visibility into historical limits behavior without side effects.
 

--- a/docs.openc3.com/docs/configuration/plugins.md
+++ b/docs.openc3.com/docs/configuration/plugins.md
@@ -626,20 +626,6 @@ Example Usage:
 DB_SHARD 0
 ```
 
-### STORED_LIMITS_MODE
-<span class="badge badge--secondary since-right">Since 6.3.0</span>**Controls how limits are evaluated for stored (non-real-time) telemetry packets**
-
-Sets the limits handling policy for packets where the stored flag is true (e.g., packets from file interfaces or historical data replay). NORMAL processes limits normally including logging and reactions. LOG evaluates limits and logs state changes but does not trigger limits reactions or update the current limits state used by the API. DISABLE skips limits processing entirely for stored packets.
-
-| Parameter | Description | Required |
-|-----------|-------------|----------|
-| Mode | NORMAL (default), LOG, or DISABLE | True |
-
-Example Usage:
-```cosmos
-STORED_LIMITS_MODE DISABLE
-```
-
 ## MICROSERVICE
 **Defines a new microservice**
 

--- a/docs.openc3.com/docs/configuration/plugins.md
+++ b/docs.openc3.com/docs/configuration/plugins.md
@@ -626,6 +626,20 @@ Example Usage:
 DB_SHARD 0
 ```
 
+### STORED_LIMITS_MODE
+<span class="badge badge--secondary since-right">Since 6.3.0</span>**Controls how limits are evaluated for stored (non-real-time) telemetry packets**
+
+Sets the limits handling policy for packets where the stored flag is true (e.g., packets from file interfaces or historical data replay). NORMAL processes limits normally including logging and reactions. LOG evaluates limits and logs state changes but does not trigger limits reactions or update the current limits state used by the API. DISABLE skips limits processing entirely for stored packets.
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| Mode | NORMAL (default), LOG, or DISABLE | True |
+
+Example Usage:
+```cosmos
+STORED_LIMITS_MODE DISABLE
+```
+
 ## MICROSERVICE
 **Defines a new microservice**
 

--- a/docs.openc3.com/docs/configuration/target.md
+++ b/docs.openc3.com/docs/configuration/target.md
@@ -14,6 +14,39 @@ Targets are the external embedded systems that COSMOS connects to. Targets are d
 
 A target communicates with COSMOS through an [Interface](interfaces). Targets are typically mapped to an interface using the [MAP_TARGET](plugins.md#map_target), [MAP_CMD_TARGET](plugins.md#map_cmd_target), and [MAP_TLM_TARGET](plugins.md#map_tlm_target) keywords beneath the [INTERFACE](plugins.md#interface-1) definition. Targets and interfaces are a many-to-many relationship; see [Mapping Targets to Interfaces](interfaces#mapping-targets-to-interfaces) for details.
 
+## Stored Limits Mode
+
+When COSMOS receives telemetry through a normal real-time interface, limits are evaluated, state changes are logged, and any configured [limits responses](limits-response) are triggered. However, when telemetry arrives with the **stored** flag set (e.g. from a [File Interface](interfaces#file-interface) or historical data replay), you may not want limits processing to behave the same way. The `STORED_LIMITS_MODE` plugin.txt setting controls this behavior per target.
+
+### Modes
+
+| Mode | Limits Evaluated | Changes Logged | Limits Reactions | Updates Current State |
+|------|:----------------:|:--------------:|:----------------:|:---------------------:|
+| **NORMAL** (default) | Yes | Yes | Yes | Yes |
+| **LOG** | Yes | Yes | No | No |
+| **DISABLE** | No | No | No | No |
+
+**NORMAL** -- The default. Stored packets are processed exactly like real-time packets. Limits are evaluated, state changes are logged and published, limits responses fire, and the system-wide current limits state (used by `get_overall_limits_state` and the Limits Monitor) is updated.
+
+**LOG** -- Limits are evaluated and state changes are logged and published to the limits event stream, but limits responses (automated reactions) are **not** triggered. The current limits state hash is **not** updated, so stored data cannot cause the overall system limits state to change. This is useful when you want visibility into historical limits behavior without side effects.
+
+**DISABLE** -- Limits processing is skipped entirely for stored packets. No limits are evaluated, no state changes are logged, no events are published, and no limits responses fire. Additionally, the decommutated output for stored packets will not contain limits state (`__L`) values. This is useful when replaying large volumes of historical data where limits are irrelevant.
+
+:::info
+Non-stored (real-time) packets are always processed normally regardless of this setting.
+:::
+
+### Configuration
+
+`STORED_LIMITS_MODE` is set as a modifier under the [TARGET](plugins.md#target-1) keyword in `plugin.txt`:
+
+```cosmos
+TARGET INST INST
+  STORED_LIMITS_MODE LOG
+```
+
+See the [STORED_LIMITS_MODE](plugins.md#stored_limits_mode) reference for parameter details.
+
 ## target.txt Keywords
 
 

--- a/docs.openc3.com/docs/configuration/target.md
+++ b/docs.openc3.com/docs/configuration/target.md
@@ -14,39 +14,6 @@ Targets are the external embedded systems that COSMOS connects to. Targets are d
 
 A target communicates with COSMOS through an [Interface](interfaces). Targets are typically mapped to an interface using the [MAP_TARGET](plugins.md#map_target), [MAP_CMD_TARGET](plugins.md#map_cmd_target), and [MAP_TLM_TARGET](plugins.md#map_tlm_target) keywords beneath the [INTERFACE](plugins.md#interface-1) definition. Targets and interfaces are a many-to-many relationship; see [Mapping Targets to Interfaces](interfaces#mapping-targets-to-interfaces) for details.
 
-## Stored Limits Mode
-
-When COSMOS receives telemetry through a normal real-time interface, limits are evaluated, state changes are logged, and any configured [limits responses](limits-response) are triggered. However, when telemetry arrives with the **stored** flag set (e.g. from a [File Interface](interfaces#file-interface) or historical data replay), you may not want limits processing to behave the same way. The `STORED_LIMITS_MODE` plugin.txt setting controls this behavior per target.
-
-### Modes
-
-| Mode | Limits Evaluated | Changes Logged | Limits Reactions | Updates Current State |
-|------|:----------------:|:--------------:|:----------------:|:---------------------:|
-| **NORMAL** (default) | Yes | Yes | Yes | Yes |
-| **LOG** | Yes | Yes | No | No |
-| **DISABLE** | No | No | No | No |
-
-**NORMAL** -- The default. Stored packets are processed exactly like real-time packets. Limits are evaluated, state changes are logged and published, limits responses fire, and the system-wide current limits state (used by `get_overall_limits_state` and the Limits Monitor) is updated.
-
-**LOG** -- Limits are evaluated and state changes are logged and published to the limits event stream, but limits responses (automated reactions) are **not** triggered. The current limits state hash is **not** updated, so stored data cannot cause the overall system limits state to change. This is useful when you want visibility into historical limits behavior without side effects.
-
-**DISABLE** -- Limits processing is skipped entirely for stored packets. No limits are evaluated, no state changes are logged, no events are published, and no limits responses fire. Additionally, the decommutated output for stored packets will not contain limits state (`__L`) values. This is useful when replaying large volumes of historical data where limits are irrelevant.
-
-:::info
-Non-stored (real-time) packets are always processed normally regardless of this setting.
-:::
-
-### Configuration
-
-`STORED_LIMITS_MODE` is set as a modifier under the [TARGET](plugins.md#target-1) keyword in `plugin.txt`:
-
-```cosmos
-TARGET INST INST
-  STORED_LIMITS_MODE LOG
-```
-
-See the [STORED_LIMITS_MODE](plugins.md#stored_limits_mode) reference for parameter details.
-
 ## target.txt Keywords
 
 

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/plugin.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/plugin.txt
@@ -6,6 +6,10 @@ VARIABLE inst_target_name INST
   VARIABLE_DESCRIPTION "Name for the primary INST target (leave blank to exclude)"
 VARIABLE inst2_target_name INST2
   VARIABLE_DESCRIPTION "Name for the secondary INST2 target (leave blank to exclude)"
+VARIABLE inst2_stored false
+  VARIABLE_DESCRIPTION "Mark INST2 telemetry as stored (demonstrates STORED_LIMITS_MODE)"
+  VARIABLE_STATE "No" false
+  VARIABLE_STATE "Yes" true
 VARIABLE example_target_name EXAMPLE
   VARIABLE_DESCRIPTION "Name for the EXAMPLE target (leave blank to exclude)"
 VARIABLE templated_target_name TEMPLATED
@@ -89,6 +93,7 @@ VARIABLE inst2_throughput_port 7780
   TARGET INST2 <%= inst2_target_name %>
     LOG_RETAIN_TIME <%= log_retain_time %>
     TLM_LOG_CYCLE_TIME 600
+    STORED_LIMITS_MODE DISABLE
 <% end %>
 
 <% if include_example %>
@@ -125,7 +130,7 @@ VARIABLE inst2_throughput_port 7780
     INTERFACE <%= inst2_int_name %> openc3/interfaces/tcpip_client_interface.py <%= throughput_server_host %> <%= inst2_throughput_port %> <%= inst2_throughput_port %> 10.0 None LENGTH 32 16 7 1 BIG_ENDIAN 0 None None True
       MAP_TARGET <%= inst2_target_name %>
   <% else %>
-    INTERFACE <%= inst2_int_name %> openc3/interfaces/simulated_target_interface.py sim_inst.py
+    INTERFACE <%= inst2_int_name %> sim_inst_interface.py sim_inst.py <%= inst2_stored %>
       MAP_TARGET <%= inst2_target_name %>
   <% end %>
 <% end %>

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/lib/sim_inst_interface.py
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/lib/sim_inst_interface.py
@@ -1,0 +1,34 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+from openc3.config.config_parser import ConfigParser
+from openc3.interfaces.simulated_target_interface import SimulatedTargetInterface
+
+
+class SimInstInterface(SimulatedTargetInterface):
+    """Thin wrapper around SimulatedTargetInterface that optionally marks all
+    telemetry packets as stored.  This is used by the INST2 demo target to
+    exercise the STORED_LIMITS_MODE feature.
+
+    Extra constructor parameter (all others forwarded to super):
+        stored  - "true" or "false" (default "false").  When true every
+                  packet returned by read() will have its stored flag set.
+    """
+
+    def __init__(self, sim_target_file, stored="false"):
+        super().__init__(sim_target_file)
+        self.mark_stored = ConfigParser.handle_true_false(stored)
+
+    def first_pending_packet(self):
+        packet = super().first_pending_packet()
+        if packet and self.mark_stored:
+            packet.stored = True
+        return packet

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/src/tools/LimitsMonitor/LimitsControl.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-limitsmonitor/src/tools/LimitsMonitor/LimitsControl.vue
@@ -509,6 +509,11 @@ export default {
         if (message.type != 'LIMITS_CHANGE') {
           continue
         }
+        // Skip events from stored packets where limits are suppressed
+        // (STORED_LIMITS_MODE LOG or DISABLE) so they don't affect the UI state
+        if (message.suppress_stored) {
+          continue
+        }
 
         let itemName = `${message.target_name}__${message.packet_name}__${message.item_name}`
         const index = this.itemList.findIndex((arrayItem) =>

--- a/openc3/data/config/target.yaml
+++ b/openc3/data/config/target.yaml
@@ -170,3 +170,20 @@ TARGET:
           values: \d+
       example: |
         DB_SHARD 0
+    STORED_LIMITS_MODE:
+      summary: Controls how limits are evaluated for stored (non-real-time) telemetry packets
+      description:
+        Sets the limits handling policy for packets where the stored flag is true
+        (e.g., packets from file interfaces or historical data replay).
+        NORMAL processes limits normally including logging and reactions.
+        LOG evaluates limits and logs state changes but does not trigger limits reactions
+        or update the current limits state used by the API.
+        DISABLE skips limits processing entirely for stored packets.
+      since: 6.3.0
+      parameters:
+        - name: Mode
+          required: true
+          description: "NORMAL (default), LOG, or DISABLE"
+          values: ^(NORMAL|LOG|DISABLE)$
+      example: |
+        STORED_LIMITS_MODE DISABLE

--- a/openc3/data/config/target.yaml
+++ b/openc3/data/config/target.yaml
@@ -175,15 +175,15 @@ TARGET:
       description:
         Sets the limits handling policy for packets where the stored flag is true
         (e.g., packets from file interfaces or historical data replay).
-        NORMAL processes limits normally including logging and reactions.
+        PROCESS processes limits normally including logging and reactions.
         LOG evaluates limits and logs state changes but does not trigger limits reactions
         or update the current limits state used by the API.
         DISABLE skips limits processing entirely for stored packets.
-      since: 6.3.0
+      since: 7.3.0
       parameters:
         - name: Mode
           required: true
-          description: "NORMAL (default), LOG, or DISABLE"
-          values: ^(NORMAL|LOG|DISABLE)$
+          description: "PROCESS (default), LOG, or DISABLE"
+          values: ^(PROCESS|LOG|DISABLE)$
       example: |
         STORED_LIMITS_MODE DISABLE

--- a/openc3/lib/openc3/microservices/decom_common.rb
+++ b/openc3/lib/openc3/microservices/decom_common.rb
@@ -35,13 +35,19 @@ module OpenC3
     #   (microservice name, or "REINGEST:<job_id>").
     # @param check_limits [Boolean] When false, skips the Packet#check_limits call.
     #   Reingest passes false so historical data does not re-fire limits events.
+    # @param stored_limits_mode [String] Controls limits handling for stored packets.
+    #   'NORMAL' (default) processes limits normally.
+    #   'LOG' still evaluates limits (callback handles suppressing reactions).
+    #   'DISABLE' skips limits evaluation entirely for stored packets and omits
+    #   limits states from the decommutated output.
     # @param metric [Metric, nil] Optional; when set, records decom_duration_seconds.
     # @param error_callback [Proc, nil] Called as error_callback.call(exception) when
     #   Packet#process or Packet#check_limits raises. The microservice uses this to
     #   bump its decom_error_total metric.
     # @return [Integer] Number of (sub)packets published.
     def decom_and_publish(packet, scope:, target_names:, logger:, name:,
-                          check_limits: true, metric: nil, error_callback: nil)
+                          check_limits: true, stored_limits_mode: 'NORMAL',
+                          metric: nil, error_callback: nil)
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC) if metric
       published = 0
 
@@ -62,9 +68,14 @@ module OpenC3
           logger.error e.message
         end
 
-        packet_or_subpacket.check_limits(System.limits_set) if check_limits
+        disable_stored_limits = packet_or_subpacket.stored && stored_limits_mode == 'DISABLE'
+        if check_limits && !disable_stored_limits
+          packet_or_subpacket.check_limits(System.limits_set)
+        end
 
-        TelemetryDecomTopic.write_packet(packet_or_subpacket, scope: scope)
+        TelemetryDecomTopic.write_packet(packet_or_subpacket,
+                                         include_limits_states: !disable_stored_limits,
+                                         scope: scope)
         published += 1
       end
 

--- a/openc3/lib/openc3/microservices/decom_common.rb
+++ b/openc3/lib/openc3/microservices/decom_common.rb
@@ -36,7 +36,7 @@ module OpenC3
     # @param check_limits [Boolean] When false, skips the Packet#check_limits call.
     #   Reingest passes false so historical data does not re-fire limits events.
     # @param stored_limits_mode [String] Controls limits handling for stored packets.
-    #   'NORMAL' (default) processes limits normally.
+    #   'PROCESS' (default) processes limits normally.
     #   'LOG' still evaluates limits (callback handles suppressing reactions).
     #   'DISABLE' skips limits evaluation entirely for stored packets and omits
     #   limits states from the decommutated output.
@@ -46,7 +46,7 @@ module OpenC3
     #   bump its decom_error_total metric.
     # @return [Integer] Number of (sub)packets published.
     def decom_and_publish(packet, scope:, target_names:, logger:, name:,
-                          check_limits: true, stored_limits_mode: 'NORMAL',
+                          check_limits: true, stored_limits_mode: 'PROCESS',
                           metric: nil, error_callback: nil)
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC) if metric
       published = 0

--- a/openc3/lib/openc3/microservices/decom_microservice.rb
+++ b/openc3/lib/openc3/microservices/decom_microservice.rb
@@ -256,11 +256,11 @@ module OpenC3
       event = { type: :LIMITS_CHANGE, target_name: packet.target_name, packet_name: packet.packet_name,
                 item_name: item.name, old_limits_state: old_limits_state.to_s, new_limits_state: item.limits.state.to_s,
                 time_nsec: packet_time.to_nsec_from_epoch, message: message.to_s }
-      stored_log_mode = packet.stored && @stored_limits_mode == 'LOG'
-      event[:stored] = true if stored_log_mode
+      suppress_stored = packet.stored && @stored_limits_mode != 'PROCESS'
+      event[:stored] = true if suppress_stored
       LimitsEventTopic.write(event, scope: @scope)
 
-      if item.limits.response && !stored_log_mode
+      if item.limits.response && !suppress_stored
         copied_packet = packet.deep_copy
         copied_item = packet.items[item.name]
         @limits_response_queue << [copied_packet, copied_item, old_limits_state]

--- a/openc3/lib/openc3/microservices/decom_microservice.rb
+++ b/openc3/lib/openc3/microservices/decom_microservice.rb
@@ -101,7 +101,7 @@ module OpenC3
       System.telemetry.limits_change_callback = method(:limits_change_callback)
       LimitsEventTopic.sync_system(scope: @scope)
       target_model = TargetModel.get_model(name: @target_names[0], scope: @scope)
-      @stored_limits_mode = target_model ? (target_model.stored_limits_mode || 'NORMAL') : 'NORMAL'
+      @stored_limits_mode = target_model ? (target_model.stored_limits_mode || 'PROCESS') : 'PROCESS'
       @error_count = 0
       @metric.set(name: 'decom_total', value: @count, type: 'counter')
       @metric.set(name: 'decom_error_total', value: @error_count, type: 'counter')

--- a/openc3/lib/openc3/microservices/decom_microservice.rb
+++ b/openc3/lib/openc3/microservices/decom_microservice.rb
@@ -100,6 +100,8 @@ module OpenC3
       @limits_response_thread = nil
       System.telemetry.limits_change_callback = method(:limits_change_callback)
       LimitsEventTopic.sync_system(scope: @scope)
+      target_model = TargetModel.get_model(name: @target_names[0], scope: @scope)
+      @stored_limits_mode = target_model ? (target_model.stored_limits_mode || 'NORMAL') : 'NORMAL'
       @error_count = 0
       @metric.set(name: 'decom_total', value: @count, type: 'counter')
       @metric.set(name: 'decom_error_total', value: @error_count, type: 'counter')
@@ -184,6 +186,7 @@ module OpenC3
           logger: @logger,
           name: @name,
           check_limits: true,
+          stored_limits_mode: @stored_limits_mode,
           metric: @metric,
           error_callback: ->(e) {
             @error_count += 1
@@ -253,9 +256,11 @@ module OpenC3
       event = { type: :LIMITS_CHANGE, target_name: packet.target_name, packet_name: packet.packet_name,
                 item_name: item.name, old_limits_state: old_limits_state.to_s, new_limits_state: item.limits.state.to_s,
                 time_nsec: packet_time.to_nsec_from_epoch, message: message.to_s }
+      stored_log_mode = packet.stored && @stored_limits_mode == 'LOG'
+      event[:stored] = true if stored_log_mode
       LimitsEventTopic.write(event, scope: @scope)
 
-      if item.limits.response
+      if item.limits.response && !stored_log_mode
         copied_packet = packet.deep_copy
         copied_item = packet.items[item.name]
         @limits_response_queue << [copied_packet, copied_item, old_limits_state]

--- a/openc3/lib/openc3/microservices/decom_microservice.rb
+++ b/openc3/lib/openc3/microservices/decom_microservice.rb
@@ -257,7 +257,7 @@ module OpenC3
                 item_name: item.name, old_limits_state: old_limits_state.to_s, new_limits_state: item.limits.state.to_s,
                 time_nsec: packet_time.to_nsec_from_epoch, message: message.to_s }
       suppress_stored = packet.stored && @stored_limits_mode != 'PROCESS'
-      event[:stored] = true if suppress_stored
+      event[:suppress_stored] = true if suppress_stored
       LimitsEventTopic.write(event, scope: @scope)
 
       if item.limits.response && !suppress_stored

--- a/openc3/lib/openc3/models/cvt_model.rb
+++ b/openc3/lib/openc3/models/cvt_model.rb
@@ -26,8 +26,8 @@ module OpenC3
     @@override_cache = {}
 
     VALUE_TYPES = [:RAW, :CONVERTED, :FORMATTED]
-    def self.build_json_from_packet(packet)
-      packet.decom
+    def self.build_json_from_packet(packet, include_limits_states: true)
+      packet.decom(include_limits_states: include_limits_states)
     end
 
     # Get a Store instance routed to the correct db_shard for a target

--- a/openc3/lib/openc3/models/target_model.rb
+++ b/openc3/lib/openc3/models/target_model.rb
@@ -63,6 +63,7 @@ module OpenC3
     attr_accessor :ignored_parameters
     attr_accessor :ignored_items
     attr_accessor :limits_groups
+    attr_accessor :stored_limits_mode
     attr_accessor :cmd_tlm_files
     attr_accessor :id
     attr_accessor :cmd_buffer_depth
@@ -384,6 +385,7 @@ module OpenC3
       ignored_parameters: [],
       ignored_items: [],
       limits_groups: [],
+      stored_limits_mode: 'NORMAL',
       cmd_tlm_files: [],
       id: nil,
       updated_at: nil,
@@ -412,6 +414,8 @@ module OpenC3
       @ignored_parameters = ignored_parameters
       @ignored_items = ignored_items
       @limits_groups = limits_groups
+      @stored_limits_mode = stored_limits_mode.to_s.upcase
+      @stored_limits_mode = 'NORMAL' unless %w(NORMAL LOG DISABLE).include?(@stored_limits_mode)
       @cmd_tlm_files = cmd_tlm_files
       @id = id
       @cmd_buffer_depth = cmd_buffer_depth
@@ -442,6 +446,7 @@ module OpenC3
         'ignored_parameters' => @ignored_parameters,
         'ignored_items' => @ignored_items,
         'limits_groups' => @limits_groups,
+        'stored_limits_mode' => @stored_limits_mode,
         'cmd_tlm_files' => @cmd_tlm_files,
         'id' => @id,
         'updated_at' => @updated_at,
@@ -556,6 +561,14 @@ module OpenC3
       when 'DB_SHARD'
         parser.verify_num_parameters(1, 1, "#{keyword} <Shard Number Starting from 0>")
         @db_shard = Integer(parameters[0])
+
+      when 'STORED_LIMITS_MODE'
+        parser.verify_num_parameters(1, 1, "#{keyword} <NORMAL, LOG, or DISABLE>")
+        mode = parameters[0].to_s.upcase
+        unless %w(NORMAL LOG DISABLE).include?(mode)
+          raise ConfigParser::Error.new(parser, "STORED_LIMITS_MODE must be one of NORMAL, LOG, or DISABLE")
+        end
+        @stored_limits_mode = mode
 
       else
         raise ConfigParser::Error.new(parser, "Unknown keyword and parameters for Target: #{keyword} #{parameters.join(" ")}")

--- a/openc3/lib/openc3/models/target_model.rb
+++ b/openc3/lib/openc3/models/target_model.rb
@@ -385,7 +385,7 @@ module OpenC3
       ignored_parameters: [],
       ignored_items: [],
       limits_groups: [],
-      stored_limits_mode: 'NORMAL',
+      stored_limits_mode: 'PROCESS',
       cmd_tlm_files: [],
       id: nil,
       updated_at: nil,
@@ -415,7 +415,7 @@ module OpenC3
       @ignored_items = ignored_items
       @limits_groups = limits_groups
       @stored_limits_mode = stored_limits_mode.to_s.upcase
-      @stored_limits_mode = 'NORMAL' unless %w(NORMAL LOG DISABLE).include?(@stored_limits_mode)
+      @stored_limits_mode = 'PROCESS' unless %w(PROCESS LOG DISABLE).include?(@stored_limits_mode)
       @cmd_tlm_files = cmd_tlm_files
       @id = id
       @cmd_buffer_depth = cmd_buffer_depth
@@ -563,10 +563,10 @@ module OpenC3
         @db_shard = Integer(parameters[0])
 
       when 'STORED_LIMITS_MODE'
-        parser.verify_num_parameters(1, 1, "#{keyword} <NORMAL, LOG, or DISABLE>")
+        parser.verify_num_parameters(1, 1, "#{keyword} <PROCESS, LOG, or DISABLE>")
         mode = parameters[0].to_s.upcase
-        unless %w(NORMAL LOG DISABLE).include?(mode)
-          raise ConfigParser::Error.new(parser, "STORED_LIMITS_MODE must be one of NORMAL, LOG, or DISABLE")
+        unless %w(PROCESS LOG DISABLE).include?(mode)
+          raise ConfigParser::Error.new(parser, "STORED_LIMITS_MODE must be one of PROCESS, LOG, or DISABLE")
         end
         @stored_limits_mode = mode
 

--- a/openc3/lib/openc3/packets/packet.rb
+++ b/openc3/lib/openc3/packets/packet.rb
@@ -1285,7 +1285,7 @@ module OpenC3
       config
     end
 
-    def decom
+    def decom(include_limits_states: true)
       # Read all the RAW at once because this could be optimized by the accessor
       json_hash = read_items(@sorted_items)
 
@@ -1301,7 +1301,9 @@ module OpenC3
           if item.format_string or item.units
             json_hash["#{item.name}__F"] = read_item(item, :FORMATTED, @buffer, given_raw)
           end
-          limits_state = item.limits.state
+          if include_limits_states
+            limits_state = item.limits.state
+          end
           if limits_state
             json_hash["#{item.name}__L"] = limits_state
           end

--- a/openc3/lib/openc3/topics/limits_event_topic.rb
+++ b/openc3/lib/openc3/topics/limits_event_topic.rb
@@ -40,9 +40,10 @@ module OpenC3
       when :LIMITS_CHANGE
         # The current_limits hash keeps only the current limits state of items
         # It is used by the API to determine the overall limits state.
-        # When the event originates from a stored packet in LOG mode, skip updating
-        # current_limits so that historical data does not affect the real-time
-        # overall limits state or the out_of_limits API response.
+        # When the event originates from a stored packet in a non-PROCESS mode
+        # (LOG or DISABLE), skip updating current_limits so that historical
+        # data does not affect the real-time overall limits state or the
+        # out_of_limits API response.
         unless event[:stored]
           field = "#{event[:target_name]}__#{event[:packet_name]}__#{event[:item_name]}"
           Store.hset("#{scope}__current_limits", field, event[:new_limits_state])

--- a/openc3/lib/openc3/topics/limits_event_topic.rb
+++ b/openc3/lib/openc3/topics/limits_event_topic.rb
@@ -39,9 +39,14 @@ module OpenC3
       case event[:type]
       when :LIMITS_CHANGE
         # The current_limits hash keeps only the current limits state of items
-        # It is used by the API to determine the overall limits state
-        field = "#{event[:target_name]}__#{event[:packet_name]}__#{event[:item_name]}"
-        Store.hset("#{scope}__current_limits", field, event[:new_limits_state])
+        # It is used by the API to determine the overall limits state.
+        # When the event originates from a stored packet in LOG mode, skip updating
+        # current_limits so that historical data does not affect the real-time
+        # overall limits state or the out_of_limits API response.
+        unless event[:stored]
+          field = "#{event[:target_name]}__#{event[:packet_name]}__#{event[:item_name]}"
+          Store.hset("#{scope}__current_limits", field, event[:new_limits_state])
+        end
 
       when :LIMITS_SETTINGS
         # Limits updated in limits_api.rb to avoid circular reference to TargetModel

--- a/openc3/lib/openc3/topics/limits_event_topic.rb
+++ b/openc3/lib/openc3/topics/limits_event_topic.rb
@@ -44,7 +44,7 @@ module OpenC3
         # (LOG or DISABLE), skip updating current_limits so that historical
         # data does not affect the real-time overall limits state or the
         # out_of_limits API response.
-        unless event[:stored]
+        unless event[:suppress_stored]
           field = "#{event[:target_name]}__#{event[:packet_name]}__#{event[:item_name]}"
           Store.hset("#{scope}__current_limits", field, event[:new_limits_state])
         end

--- a/openc3/lib/openc3/topics/telemetry_decom_topic.rb
+++ b/openc3/lib/openc3/topics/telemetry_decom_topic.rb
@@ -20,7 +20,7 @@ require 'openc3/utilities/open_telemetry'
 
 module OpenC3
   class TelemetryDecomTopic < Topic
-    def self.write_packet(packet, id: nil, scope:)
+    def self.write_packet(packet, id: nil, include_limits_states: true, scope:)
       OpenC3.in_span("write_packet") do
         # Need to build a JSON hash of the decommutated data
         # Support "downward typing"
@@ -29,7 +29,7 @@ module OpenC3
         # If nothing - item does not exist - nil
         # __ as separators ITEM1, ITEM1__C, ITEM1__F
 
-        json_hash = CvtModel.build_json_from_packet(packet)
+        json_hash = CvtModel.build_json_from_packet(packet, include_limits_states: include_limits_states)
         # Convert to JSON-safe types once and reuse for both topic write and CVT set
         json_safe_hash = json_hash.as_json
         json_data = JSON.generate(json_safe_hash, allow_nan: true)

--- a/openc3/python/openc3/microservices/decom_microservice.py
+++ b/openc3/python/openc3/microservices/decom_microservice.py
@@ -117,7 +117,7 @@ class DecomMicroservice(Microservice):
         System.telemetry.set_limits_change_callback(self.limits_change_callback)
         LimitsEventTopic.sync_system(scope=self.scope)
         target_model = TargetModel.get_model(name=self.target_names[0], scope=self.scope)
-        self.stored_limits_mode = target_model.stored_limits_mode if target_model else 'PROCESS'
+        self.stored_limits_mode = target_model.stored_limits_mode if target_model else "PROCESS"
         self.error_count = 0
         self.metric.set(name="decom_total", value=self.count, type="counter")
         self.metric.set(name="decom_error_total", value=self.error_count, type="counter")
@@ -224,7 +224,7 @@ class DecomMicroservice(Microservice):
             # Process all the limits and call the limits_change_callback (as necessary)
             # This must be before the full decom so that limits states are available
             #############################################################################
-            disable_stored_limits = packet_or_subpacket.stored and self.stored_limits_mode == 'DISABLE'
+            disable_stored_limits = packet_or_subpacket.stored and self.stored_limits_mode == "DISABLE"
             if not disable_stored_limits:
                 packet_or_subpacket.check_limits(System.limits_set())
 
@@ -353,16 +353,15 @@ class DecomMicroservice(Microservice):
             "time_nsec": to_nsec_from_epoch(packet_time),
             "message": str(message),
         }
-        suppress_stored = packet.stored and self.stored_limits_mode != 'PROCESS'
+        suppress_stored = packet.stored and self.stored_limits_mode != "PROCESS"
         if suppress_stored:
             event["stored"] = True
         LimitsEventTopic.write(event, scope=self.scope)
 
-        if item.limits.response is not None:
-            if not suppress_stored:
-                copied_packet = packet.deep_copy()
-                copied_item = packet.items[item.name]
-                self.limits_response_queue.put([copied_packet, copied_item, old_limits_state])
+        if item.limits.response is not None and not suppress_stored:
+            copied_packet = packet.deep_copy()
+            copied_item = packet.items[item.name]
+            self.limits_response_queue.put([copied_packet, copied_item, old_limits_state])
 
 
 if os.path.basename(__file__) == os.path.basename(sys.argv[0]):

--- a/openc3/python/openc3/microservices/decom_microservice.py
+++ b/openc3/python/openc3/microservices/decom_microservice.py
@@ -116,6 +116,8 @@ class DecomMicroservice(Microservice):
         self.limits_response_thread = None
         System.telemetry.set_limits_change_callback(self.limits_change_callback)
         LimitsEventTopic.sync_system(scope=self.scope)
+        target_model = TargetModel.get_model(name=self.target_names[0], scope=self.scope)
+        self.stored_limits_mode = target_model.stored_limits_mode if target_model else 'NORMAL'
         self.error_count = 0
         self.metric.set(name="decom_total", value=self.count, type="counter")
         self.metric.set(name="decom_error_total", value=self.error_count, type="counter")
@@ -222,10 +224,16 @@ class DecomMicroservice(Microservice):
             # Process all the limits and call the limits_change_callback (as necessary)
             # This must be before the full decom so that limits states are available
             #############################################################################
-            packet_or_subpacket.check_limits(System.limits_set())
+            disable_stored_limits = packet_or_subpacket.stored and self.stored_limits_mode == 'DISABLE'
+            if not disable_stored_limits:
+                packet_or_subpacket.check_limits(System.limits_set())
 
             # This is what actually decommutates the packet and updates the CVT
-            TelemetryDecomTopic.write_packet(packet_or_subpacket, scope=self.scope)
+            TelemetryDecomTopic.write_packet(
+                packet_or_subpacket,
+                include_limits_states=not disable_stored_limits,
+                scope=self.scope,
+            )
         diff = time.time() - start  # seconds as a float
         self.metric.set(name="decom_duration_seconds", value=diff, type="gauge", unit="seconds")
 
@@ -345,12 +353,16 @@ class DecomMicroservice(Microservice):
             "time_nsec": to_nsec_from_epoch(packet_time),
             "message": str(message),
         }
+        stored_log_mode = packet.stored and self.stored_limits_mode == 'LOG'
+        if stored_log_mode:
+            event["stored"] = True
         LimitsEventTopic.write(event, scope=self.scope)
 
         if item.limits.response is not None:
-            copied_packet = packet.deep_copy()
-            copied_item = packet.items[item.name]
-            self.limits_response_queue.put([copied_packet, copied_item, old_limits_state])
+            if not stored_log_mode:
+                copied_packet = packet.deep_copy()
+                copied_item = packet.items[item.name]
+                self.limits_response_queue.put([copied_packet, copied_item, old_limits_state])
 
 
 if os.path.basename(__file__) == os.path.basename(sys.argv[0]):

--- a/openc3/python/openc3/microservices/decom_microservice.py
+++ b/openc3/python/openc3/microservices/decom_microservice.py
@@ -353,13 +353,13 @@ class DecomMicroservice(Microservice):
             "time_nsec": to_nsec_from_epoch(packet_time),
             "message": str(message),
         }
-        stored_log_mode = packet.stored and self.stored_limits_mode == 'LOG'
-        if stored_log_mode:
+        suppress_stored = packet.stored and self.stored_limits_mode != 'PROCESS'
+        if suppress_stored:
             event["stored"] = True
         LimitsEventTopic.write(event, scope=self.scope)
 
         if item.limits.response is not None:
-            if not stored_log_mode:
+            if not suppress_stored:
                 copied_packet = packet.deep_copy()
                 copied_item = packet.items[item.name]
                 self.limits_response_queue.put([copied_packet, copied_item, old_limits_state])

--- a/openc3/python/openc3/microservices/decom_microservice.py
+++ b/openc3/python/openc3/microservices/decom_microservice.py
@@ -117,7 +117,7 @@ class DecomMicroservice(Microservice):
         System.telemetry.set_limits_change_callback(self.limits_change_callback)
         LimitsEventTopic.sync_system(scope=self.scope)
         target_model = TargetModel.get_model(name=self.target_names[0], scope=self.scope)
-        self.stored_limits_mode = target_model.stored_limits_mode if target_model else 'NORMAL'
+        self.stored_limits_mode = target_model.stored_limits_mode if target_model else 'PROCESS'
         self.error_count = 0
         self.metric.set(name="decom_total", value=self.count, type="counter")
         self.metric.set(name="decom_error_total", value=self.error_count, type="counter")

--- a/openc3/python/openc3/microservices/decom_microservice.py
+++ b/openc3/python/openc3/microservices/decom_microservice.py
@@ -355,7 +355,7 @@ class DecomMicroservice(Microservice):
         }
         suppress_stored = packet.stored and self.stored_limits_mode != "PROCESS"
         if suppress_stored:
-            event["stored"] = True
+            event["suppress_stored"] = True
         LimitsEventTopic.write(event, scope=self.scope)
 
         if item.limits.response is not None and not suppress_stored:

--- a/openc3/python/openc3/models/cvt_model.py
+++ b/openc3/python/openc3/models/cvt_model.py
@@ -29,8 +29,8 @@ class CvtModel(Model):
     VALUE_TYPES = {"RAW", "CONVERTED", "FORMATTED"}
 
     @classmethod
-    def build_json_from_packet(cls, packet):
-        return packet.decom()
+    def build_json_from_packet(cls, packet, include_limits_states=True):
+        return packet.decom(include_limits_states=include_limits_states)
 
     @classmethod
     def _store_for_target(cls, target_name, scope):

--- a/openc3/python/openc3/models/target_model.py
+++ b/openc3/python/openc3/models/target_model.py
@@ -491,7 +491,7 @@ class TargetModel(Model):
         disable_erb=None,
         shard=0,
         db_shard=0,
-        stored_limits_mode="NORMAL",
+        stored_limits_mode="PROCESS",
         scope: str = OPENC3_SCOPE,
     ):
         if target_microservices is None:
@@ -508,8 +508,8 @@ class TargetModel(Model):
             requires = []
         self.shard = int(shard) if shard is not None else 0
         self.db_shard = int(db_shard) if db_shard is not None else 0
-        mode = str(stored_limits_mode).upper() if stored_limits_mode else "NORMAL"
-        self.stored_limits_mode = mode if mode in ("NORMAL", "LOG", "DISABLE") else "NORMAL"
+        mode = str(stored_limits_mode).upper() if stored_limits_mode else "PROCESS"
+        self.stored_limits_mode = mode if mode in ("PROCESS", "LOG", "DISABLE") else "PROCESS"
         super().__init__(
             f"{scope}__{self.PRIMARY_KEY}",
             name=name,

--- a/openc3/python/openc3/models/target_model.py
+++ b/openc3/python/openc3/models/target_model.py
@@ -491,6 +491,7 @@ class TargetModel(Model):
         disable_erb=None,
         shard=0,
         db_shard=0,
+        stored_limits_mode="NORMAL",
         scope: str = OPENC3_SCOPE,
     ):
         if target_microservices is None:
@@ -507,6 +508,8 @@ class TargetModel(Model):
             requires = []
         self.shard = int(shard) if shard is not None else 0
         self.db_shard = int(db_shard) if db_shard is not None else 0
+        mode = str(stored_limits_mode).upper() if stored_limits_mode else "NORMAL"
+        self.stored_limits_mode = mode if mode in ("NORMAL", "LOG", "DISABLE") else "NORMAL"
         super().__init__(
             f"{scope}__{self.PRIMARY_KEY}",
             name=name,

--- a/openc3/python/openc3/packets/packet.py
+++ b/openc3/python/openc3/packets/packet.py
@@ -1195,7 +1195,7 @@ class Packet(Structure):
 
         return config
 
-    def decom(self):
+    def decom(self, include_limits_states=True):
         # Read all the RAW at once because this could be optimized by the accessor
         json_hash = self.read_items(self.sorted_items)
 
@@ -1206,9 +1206,10 @@ class Packet(Structure):
                 json_hash[f"{item.name}__C"] = self.read_item(item, "CONVERTED", self.buffer, given_raw)
             if item.format_string or item.units:
                 json_hash[f"{item.name}__F"] = self.read_item(item, "FORMATTED", self.buffer, given_raw)
-            limits_state = item.limits.state
-            if limits_state:
-                json_hash[f"{item.name}__L"] = limits_state
+            if include_limits_states:
+                limits_state = item.limits.state
+                if limits_state:
+                    json_hash[f"{item.name}__L"] = limits_state
 
         return json_hash
 

--- a/openc3/python/openc3/topics/limits_event_topic.py
+++ b/openc3/python/openc3/topics/limits_event_topic.py
@@ -39,9 +39,13 @@ class LimitsEventTopic(Topic):
         match event["type"]:
             case "LIMITS_CHANGE":
                 # The current_limits hash keeps only the current limits state of items
-                # It is used by the API to determine the overall limits state
-                field = f"{event['target_name']}__{event['packet_name']}__{event['item_name']}"
-                Store.hset(f"{scope}__current_limits", field, event["new_limits_state"])
+                # It is used by the API to determine the overall limits state.
+                # When the event originates from a stored packet in LOG mode, skip updating
+                # current_limits so that historical data does not affect the real-time
+                # overall limits state or the out_of_limits API response.
+                if not event.get("stored"):
+                    field = f"{event['target_name']}__{event['packet_name']}__{event['item_name']}"
+                    Store.hset(f"{scope}__current_limits", field, event["new_limits_state"])
 
             case "LIMITS_SETTINGS":
                 # Limits updated in limits_api.rb to avoid circular reference to TargetModel

--- a/openc3/python/openc3/topics/limits_event_topic.py
+++ b/openc3/python/openc3/topics/limits_event_topic.py
@@ -40,9 +40,10 @@ class LimitsEventTopic(Topic):
             case "LIMITS_CHANGE":
                 # The current_limits hash keeps only the current limits state of items
                 # It is used by the API to determine the overall limits state.
-                # When the event originates from a stored packet in LOG mode, skip updating
-                # current_limits so that historical data does not affect the real-time
-                # overall limits state or the out_of_limits API response.
+                # When the event originates from a stored packet in a non-PROCESS mode
+                # (LOG or DISABLE), skip updating current_limits so that historical
+                # data does not affect the real-time overall limits state or the
+                # out_of_limits API response.
                 if not event.get("stored"):
                     field = f"{event['target_name']}__{event['packet_name']}__{event['item_name']}"
                     Store.hset(f"{scope}__current_limits", field, event["new_limits_state"])

--- a/openc3/python/openc3/topics/limits_event_topic.py
+++ b/openc3/python/openc3/topics/limits_event_topic.py
@@ -44,7 +44,7 @@ class LimitsEventTopic(Topic):
                 # (LOG or DISABLE), skip updating current_limits so that historical
                 # data does not affect the real-time overall limits state or the
                 # out_of_limits API response.
-                if not event.get("stored"):
+                if not event.get("suppress_stored"):
                     field = f"{event['target_name']}__{event['packet_name']}__{event['item_name']}"
                     Store.hset(f"{scope}__current_limits", field, event["new_limits_state"])
 

--- a/openc3/python/openc3/topics/telemetry_decom_topic.py
+++ b/openc3/python/openc3/topics/telemetry_decom_topic.py
@@ -20,7 +20,7 @@ from openc3.utilities.time import to_nsec_from_epoch
 
 class TelemetryDecomTopic(Topic):
     @classmethod
-    def write_packet(cls, packet, id=None, scope=None):
+    def write_packet(cls, packet, id=None, include_limits_states=True, scope=None):
         # OpenC3.in_span("write_packet") do
         # Need to build a JSON hash of the decommutated data
         # Support "downward typing"
@@ -29,7 +29,7 @@ class TelemetryDecomTopic(Topic):
         # If nothing - item does not exist - nil
         # __ as separators ITEM1, ITEM1__C, ITEM1__F
 
-        json_hash = CvtModel.build_json_from_packet(packet)
+        json_hash = CvtModel.build_json_from_packet(packet, include_limits_states=include_limits_states)
         # Serialize JSON once and reuse for both topic write and CVT set
         json_data = json.dumps(json_hash, cls=JsonEncoder)
         # Write to stream

--- a/openc3/python/test/microservices/test_decom_microservice.py
+++ b/openc3/python/test/microservices/test_decom_microservice.py
@@ -380,8 +380,8 @@ class TestDecomMicroservice(unittest.TestCase):
             1,
         )
 
-    def test_defaults_stored_limits_mode_to_normal(self):
-        self.assertEqual(self.dm.stored_limits_mode, "NORMAL")
+    def test_defaults_stored_limits_mode_to_process(self):
+        self.assertEqual(self.dm.stored_limits_mode, "PROCESS")
 
 
 class TestDecomMicroserviceStoredLimitsMode(unittest.TestCase):

--- a/openc3/python/test/microservices/test_decom_microservice.py
+++ b/openc3/python/test/microservices/test_decom_microservice.py
@@ -379,3 +379,122 @@ class TestDecomMicroservice(unittest.TestCase):
             self.dm.limits_response_thread.metric.data["limits_response_error_total"]["value"],
             1,
         )
+
+    def test_defaults_stored_limits_mode_to_normal(self):
+        self.assertEqual(self.dm.stored_limits_mode, "NORMAL")
+
+
+class TestDecomMicroserviceStoredLimitsMode(unittest.TestCase):
+    """Tests for the STORED_LIMITS_MODE target setting."""
+
+    def _start_decom_with_mode(self, mode):
+        redis = mock_redis(self)
+        setup_system()
+
+        orig_xread = redis.xread
+
+        def xread_side_effect(*args, **kwargs):
+            if "block" in kwargs:
+                kwargs.pop("block")
+            result = None
+            with contextlib.suppress(Exception):
+                result = orig_xread(*args, **kwargs)
+            if result and len(result) == 0:
+                time.sleep(0.01)
+            return result
+
+        redis.xread = Mock()
+        redis.xread.side_effect = xread_side_effect
+
+        # Create the target model. Python TargetModel doesn't override as_json, so
+        # stored_limits_mode isn't persisted by create(). We manually update the
+        # Redis hash to include it, mirroring what Ruby's as_json would store.
+        model = TargetModel(name="INST", stored_limits_mode=mode, scope="DEFAULT")
+        model.create()
+        existing = json.loads(Store.hget("DEFAULT__openc3_targets", "INST"))
+        existing["stored_limits_mode"] = mode
+        Store.hset("DEFAULT__openc3_targets", "INST", json.dumps(existing))
+
+        model = TargetModel(name="SYSTEM", scope="DEFAULT")
+        model.create()
+        model = MicroserviceModel(
+            "DEFAULT__DECOM__INST_INT",
+            scope="DEFAULT",
+            topics=["DEFAULT__TELEMETRY__{INST}__HEALTH_STATUS"],
+            target_names=["INST"],
+        )
+        model.create()
+
+        with patch("openc3.microservices.microservice.System"):
+            self.dm = DecomMicroservice("DEFAULT__DECOM__INST_INT")
+        self.dm_thread = threading.Thread(target=self.dm.run)
+        self.dm_thread.start()
+        time.sleep(0.01)
+
+    def tearDown(self):
+        if hasattr(self, "dm"):
+            self.dm.shutdown()
+            self.dm_thread.join()
+
+    def test_loads_stored_limits_mode_from_target_model(self):
+        self._start_decom_with_mode("DISABLE")
+        self.assertEqual(self.dm.stored_limits_mode, "DISABLE")
+
+    @patch("openc3.system.system.System.limits_set")
+    def test_log_mode_logs_but_skips_reactions_for_stored_packets(self, limits_set):
+        limits_set.return_value = "DEFAULT"
+        self._start_decom_with_mode("LOG")
+
+        class TrackingLimitsResponse(LimitsResponse):
+            called = False
+
+            def call(self, packet, item, old_limits_state):
+                TrackingLimitsResponse.called = True
+
+        TrackingLimitsResponse.called = False
+        packet = System.telemetry.packet("INST", "HEALTH_STATUS")
+        temp1 = packet.get_item("TEMP1")
+        temp1.limits.response = TrackingLimitsResponse()
+        packet.received_time = datetime.now(timezone.utc)
+        packet.stored = True
+
+        for stdout in capture_io():
+            TelemetryTopic.write_packet(packet, scope="DEFAULT")
+            for _ in range(10):
+                time.sleep(0.01)
+                if "RED_LOW" in stdout.getvalue():
+                    break
+            # Limits changes are still logged
+            self.assertIn("INST HEALTH_STATUS TEMP1", stdout.getvalue())
+            self.assertIn("RED_LOW", stdout.getvalue())
+
+        # Limits response should NOT be called
+        self.assertFalse(TrackingLimitsResponse.called)
+
+        # Events are published but current_limits is NOT updated
+        out = LimitsEventTopic.out_of_limits(scope="DEFAULT")
+        self.assertEqual(len(out), 0)
+
+    @patch("openc3.system.system.System.limits_set")
+    def test_disable_mode_skips_limits_for_stored_packets(self, limits_set):
+        limits_set.return_value = "DEFAULT"
+        self._start_decom_with_mode("DISABLE")
+
+        packet = System.telemetry.packet("INST", "HEALTH_STATUS")
+        packet.received_time = datetime.now(timezone.utc)
+        packet.stored = True
+
+        for stdout in capture_io():
+            TelemetryTopic.write_packet(packet, scope="DEFAULT")
+            time.sleep(0.1)
+            # No limits change messages should be logged
+            self.assertNotIn("RED_LOW", stdout.getvalue())
+            self.assertNotIn("YELLOW", stdout.getvalue())
+
+        # No limits events
+        events = LimitsEventTopic.read(0, scope="DEFAULT")
+        self.assertEqual(len(events), 0)
+
+        # current_limits not updated
+        out = LimitsEventTopic.out_of_limits(scope="DEFAULT")
+        self.assertEqual(len(out), 0)

--- a/openc3/python/test/models/test_cvt_model.py
+++ b/openc3/python/test/models/test_cvt_model.py
@@ -98,6 +98,18 @@ class TestCvtModel(unittest.TestCase):
             b"\x00\x01\x02\x03\x04",
         )
 
+    def test_build_json_from_packet_passes_include_limits_states(self):
+        packet = Packet("TGT", "PKT", "BIG_ENDIAN", "packet", b"\x01\x02")
+        item = packet.append_item("val", 16, "UINT")
+        item.limits.state = "RED_HIGH"
+
+        json_hash = CvtModel.build_json_from_packet(packet)
+        self.assertEqual(json_hash["VAL__L"], "RED_HIGH")
+
+        json_hash = CvtModel.build_json_from_packet(packet, include_limits_states=False)
+        self.assertNotIn("VAL__L", json_hash)
+        self.assertEqual(json_hash["VAL"], 0x0102)
+
     def test_deletes_a_target_packet_from_the_cvt(self):
         self.update_temp1()
         self.assertIn(b"HEALTH_STATUS", Store.hkeys("DEFAULT__tlm__INST"))

--- a/openc3/python/test/models/test_target_model.py
+++ b/openc3/python/test/models/test_target_model.py
@@ -115,13 +115,17 @@ class TestTargetModelPackets(unittest.TestCase):
         TargetModel.set_packet("INST", "ADCS", pkts[1], type="TLM", scope="DEFAULT")
         with self.assertRaisesRegex(RuntimeError, "Unknown type OTHER for INST ADCS"):
             TargetModel.set_packet("INST", "ADCS", pkts[0], type="OTHER", scope="DEFAULT")
+        raised = False
         for stdout in capture_io():
-            with self.assertRaises(TypeError):
+            try:
                 TargetModel.set_packet("INST", "HEALTH_STATUS", set("data"), type="TLM", scope="DEFAULT")
+            except TypeError:
+                raised = True
             self.assertIn(
                 "Invalid text present in INST HEALTH_STATUS tlm packet",
                 stdout.getvalue(),
             )
+        self.assertTrue(raised, "Expected TypeError was not raised")
 
     def test_calls_limits_groups(self):
         lgs = TargetModel.limits_groups(scope="DEFAULT")

--- a/openc3/python/test/models/test_target_model.py
+++ b/openc3/python/test/models/test_target_model.py
@@ -59,6 +59,47 @@ class TestTargetModel(unittest.TestCase):
         self.assertIn("TEST", all_targs.keys())
         self.assertIn("SPEC", all_targs.keys())
 
+    def test_stored_limits_mode_defaults_to_normal(self):
+        model = TargetModel(folder_name="TEST", name="TEST", scope="DEFAULT")
+        self.assertEqual(model.stored_limits_mode, "NORMAL")
+
+    def test_stored_limits_mode_accepts_valid_modes(self):
+        for mode in ("NORMAL", "LOG", "DISABLE"):
+            model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode=mode, scope="DEFAULT")
+            self.assertEqual(model.stored_limits_mode, mode)
+
+    def test_stored_limits_mode_uppercases_input(self):
+        model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode="log", scope="DEFAULT")
+        self.assertEqual(model.stored_limits_mode, "LOG")
+        model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode="disable", scope="DEFAULT")
+        self.assertEqual(model.stored_limits_mode, "DISABLE")
+
+    def test_stored_limits_mode_falls_back_to_normal_for_invalid(self):
+        model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode="INVALID", scope="DEFAULT")
+        self.assertEqual(model.stored_limits_mode, "NORMAL")
+        model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode="", scope="DEFAULT")
+        self.assertEqual(model.stored_limits_mode, "NORMAL")
+
+    def test_stored_limits_mode_handles_none(self):
+        model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode=None, scope="DEFAULT")
+        self.assertEqual(model.stored_limits_mode, "NORMAL")
+
+    def test_stored_limits_mode_round_trips_through_redis(self):
+        # Simulate what Ruby's as_json stores in Redis (Python TargetModel doesn't
+        # override as_json, so we manually store the full JSON as Ruby would)
+        import json
+
+        json_data = {
+            "name": "TEST",
+            "folder_name": "TEST",
+            "updated_at": None,
+            "plugin": None,
+            "stored_limits_mode": "DISABLE",
+        }
+        Store.hset("DEFAULT__openc3_targets", "TEST", json.dumps(json_data))
+        retrieved = TargetModel.get_model(name="TEST", scope="DEFAULT")
+        self.assertEqual(retrieved.stored_limits_mode, "DISABLE")
+
 
 class TestTargetModelPackets(unittest.TestCase):
     def setUp(self):

--- a/openc3/python/test/models/test_target_model.py
+++ b/openc3/python/test/models/test_target_model.py
@@ -59,12 +59,12 @@ class TestTargetModel(unittest.TestCase):
         self.assertIn("TEST", all_targs.keys())
         self.assertIn("SPEC", all_targs.keys())
 
-    def test_stored_limits_mode_defaults_to_normal(self):
+    def test_stored_limits_mode_defaults_to_process(self):
         model = TargetModel(folder_name="TEST", name="TEST", scope="DEFAULT")
-        self.assertEqual(model.stored_limits_mode, "NORMAL")
+        self.assertEqual(model.stored_limits_mode, "PROCESS")
 
     def test_stored_limits_mode_accepts_valid_modes(self):
-        for mode in ("NORMAL", "LOG", "DISABLE"):
+        for mode in ("PROCESS", "LOG", "DISABLE"):
             model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode=mode, scope="DEFAULT")
             self.assertEqual(model.stored_limits_mode, mode)
 
@@ -74,15 +74,15 @@ class TestTargetModel(unittest.TestCase):
         model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode="disable", scope="DEFAULT")
         self.assertEqual(model.stored_limits_mode, "DISABLE")
 
-    def test_stored_limits_mode_falls_back_to_normal_for_invalid(self):
+    def test_stored_limits_mode_falls_back_to_process_for_invalid(self):
         model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode="INVALID", scope="DEFAULT")
-        self.assertEqual(model.stored_limits_mode, "NORMAL")
+        self.assertEqual(model.stored_limits_mode, "PROCESS")
         model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode="", scope="DEFAULT")
-        self.assertEqual(model.stored_limits_mode, "NORMAL")
+        self.assertEqual(model.stored_limits_mode, "PROCESS")
 
     def test_stored_limits_mode_handles_none(self):
         model = TargetModel(folder_name="TEST", name="TEST", stored_limits_mode=None, scope="DEFAULT")
-        self.assertEqual(model.stored_limits_mode, "NORMAL")
+        self.assertEqual(model.stored_limits_mode, "PROCESS")
 
     def test_stored_limits_mode_round_trips_through_redis(self):
         # Simulate what Ruby's as_json stores in Redis (Python TargetModel doesn't

--- a/openc3/python/test/packets/test_packet.py
+++ b/openc3/python/test/packets/test_packet.py
@@ -1862,6 +1862,39 @@ class PacketDecom(unittest.TestCase):
 
         self.assertEqual(vals.get("TEST3__L"), "RED")
 
+    def test_decom_omits_limits_states_when_include_limits_states_is_false(self):
+        p = Packet("tgt", "pkt")
+        i1 = p.append_item("test1", 8, "UINT")
+        i1.limits.state = "GREEN"
+        i2 = p.append_item("test2", 16, "UINT")
+        i2.read_conversion = GenericConversion("value * 2")
+        i2.limits.state = "RED_HIGH"
+
+        p.buffer = b"\x01\x00\x03"
+
+        # Default: limits states included
+        vals = p.decom()
+        self.assertEqual(vals["TEST1__L"], "GREEN")
+        self.assertEqual(vals["TEST2__L"], "RED_HIGH")
+
+        # With include_limits_states=False, __L keys are omitted
+        vals = p.decom(include_limits_states=False)
+        self.assertNotIn("TEST1__L", vals)
+        self.assertNotIn("TEST2__L", vals)
+        # Other value types are still present
+        self.assertEqual(vals["TEST1"], 1)
+        self.assertEqual(vals["TEST2"], 3)
+        self.assertEqual(vals["TEST2__C"], 6)
+
+    def test_decom_includes_limits_states_by_default(self):
+        p = Packet("tgt", "pkt")
+        i1 = p.append_item("test1", 8, "UINT")
+        i1.limits.state = "YELLOW_LOW"
+
+        p.buffer = b"\x05"
+        vals = p.decom()
+        self.assertEqual(vals["TEST1__L"], "YELLOW_LOW")
+
 
 class PacketObfuscation(unittest.TestCase):
     def test_does_nothing_if_no_buffer_exists(self):

--- a/openc3/python/test/topics/test_limits_event_topic.py
+++ b/openc3/python/test/topics/test_limits_event_topic.py
@@ -45,7 +45,7 @@ class TestLimitsEventTopic(unittest.TestCase):
         self.assertEqual(out[0][2], "ITEM")
         self.assertEqual(out[0][3], "YELLOW_LOW")
 
-    def test_skips_current_limits_update_when_event_has_stored_true(self):
+    def test_skips_current_limits_update_when_event_has_suppress_stored_true(self):
         event = {
             "type": "LIMITS_CHANGE",
             "target_name": "TGT",
@@ -55,7 +55,7 @@ class TestLimitsEventTopic(unittest.TestCase):
             "new_limits_state": "RED_HIGH",
             "time_nsec": 123456789,
             "message": "stored change",
-            "stored": True,
+            "suppress_stored": True,
         }
         LimitsEventTopic.write(event, scope="DEFAULT")
 
@@ -63,13 +63,13 @@ class TestLimitsEventTopic(unittest.TestCase):
         events = LimitsEventTopic.read(scope="DEFAULT")
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0][1]["type"], "LIMITS_CHANGE")
-        self.assertTrue(events[0][1]["stored"])
+        self.assertTrue(events[0][1]["suppress_stored"])
 
         # But current_limits hash is NOT updated
         out = LimitsEventTopic.out_of_limits(scope="DEFAULT")
         self.assertEqual(len(out), 0)
 
-    def test_updates_current_limits_when_event_has_no_stored_flag(self):
+    def test_updates_current_limits_when_event_has_no_suppress_stored_flag(self):
         event = {
             "type": "LIMITS_CHANGE",
             "target_name": "TGT",

--- a/openc3/python/test/topics/test_limits_event_topic.py
+++ b/openc3/python/test/topics/test_limits_event_topic.py
@@ -45,6 +45,47 @@ class TestLimitsEventTopic(unittest.TestCase):
         self.assertEqual(out[0][2], "ITEM")
         self.assertEqual(out[0][3], "YELLOW_LOW")
 
+    def test_skips_current_limits_update_when_event_has_stored_true(self):
+        event = {
+            "type": "LIMITS_CHANGE",
+            "target_name": "TGT",
+            "packet_name": "PKT",
+            "item_name": "ITEM",
+            "old_limits_state": "GREEN",
+            "new_limits_state": "RED_HIGH",
+            "time_nsec": 123456789,
+            "message": "stored change",
+            "stored": True,
+        }
+        LimitsEventTopic.write(event, scope="DEFAULT")
+
+        # Event is still written to the stream
+        events = LimitsEventTopic.read(scope="DEFAULT")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0][1]["type"], "LIMITS_CHANGE")
+        self.assertTrue(events[0][1]["stored"])
+
+        # But current_limits hash is NOT updated
+        out = LimitsEventTopic.out_of_limits(scope="DEFAULT")
+        self.assertEqual(len(out), 0)
+
+    def test_updates_current_limits_when_event_has_no_stored_flag(self):
+        event = {
+            "type": "LIMITS_CHANGE",
+            "target_name": "TGT",
+            "packet_name": "PKT",
+            "item_name": "ITEM",
+            "old_limits_state": "GREEN",
+            "new_limits_state": "RED_HIGH",
+            "time_nsec": 123456789,
+            "message": "realtime change",
+        }
+        LimitsEventTopic.write(event, scope="DEFAULT")
+
+        out = LimitsEventTopic.out_of_limits(scope="DEFAULT")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0][3], "RED_HIGH")
+
     def test_writes_and_reads_limits_settings_events(self):
         event = {
             "type": "LIMITS_SETTINGS",

--- a/openc3/python/test/topics/test_telemetry_decom_topic.py
+++ b/openc3/python/test/topics/test_telemetry_decom_topic.py
@@ -94,3 +94,21 @@ class TestTelemetryDecomTopic(unittest.TestCase):
     def test_skips_cvt_when_stored(self):
         TelemetryDecomTopic.write_packet(self._make_packet(stored=True), scope="DEFAULT")
         self.set_json_mock.assert_not_called()
+
+    def test_passes_include_limits_states_to_build_json_from_packet(self):
+        with patch(
+            "openc3.topics.telemetry_decom_topic.CvtModel.build_json_from_packet",
+            return_value={"TEMP1": 1.0},
+        ) as mock_build:
+            packet = self._make_packet()
+            TelemetryDecomTopic.write_packet(packet, include_limits_states=False, scope="DEFAULT")
+            mock_build.assert_called_once_with(packet, include_limits_states=False)
+
+    def test_defaults_include_limits_states_to_true(self):
+        with patch(
+            "openc3.topics.telemetry_decom_topic.CvtModel.build_json_from_packet",
+            return_value={"TEMP1": 1.0},
+        ) as mock_build:
+            packet = self._make_packet()
+            TelemetryDecomTopic.write_packet(packet, scope="DEFAULT")
+            mock_build.assert_called_once_with(packet, include_limits_states=True)

--- a/openc3/spec/microservices/decom_common_spec.rb
+++ b/openc3/spec/microservices/decom_common_spec.rb
@@ -135,7 +135,7 @@ module OpenC3
       end
 
       context 'with stored_limits_mode' do
-        it 'checks limits normally for stored packets when mode is NORMAL' do
+        it 'checks limits normally for stored packets when mode is PROCESS' do
           packet = build_packet
           packet.stored = true
           allow(TelemetryDecomTopic).to receive(:write_packet)
@@ -150,7 +150,7 @@ module OpenC3
             logger: Logger.new,
             name: 'TEST',
             check_limits: true,
-            stored_limits_mode: 'NORMAL',
+            stored_limits_mode: 'PROCESS',
           )
         end
 
@@ -245,7 +245,7 @@ module OpenC3
           )
         end
 
-        it 'passes include_limits_states: true to write_packet when mode is NORMAL' do
+        it 'passes include_limits_states: true to write_packet when mode is PROCESS' do
           packet = build_packet
           packet.stored = true
           expect(TelemetryDecomTopic).to receive(:write_packet)
@@ -258,7 +258,7 @@ module OpenC3
             logger: Logger.new,
             name: 'TEST',
             check_limits: true,
-            stored_limits_mode: 'NORMAL',
+            stored_limits_mode: 'PROCESS',
           )
         end
       end

--- a/openc3/spec/microservices/decom_common_spec.rb
+++ b/openc3/spec/microservices/decom_common_spec.rb
@@ -133,6 +133,135 @@ module OpenC3
           metric: metric,
         )
       end
+
+      context 'with stored_limits_mode' do
+        it 'checks limits normally for stored packets when mode is NORMAL' do
+          packet = build_packet
+          packet.stored = true
+          allow(TelemetryDecomTopic).to receive(:write_packet)
+          subpackets = packet.subpacketize
+          allow(packet).to receive(:subpacketize).and_return(subpackets)
+          subpackets.each { |p| expect(p).to receive(:check_limits).with(System.limits_set) }
+
+          DecomCommon.decom_and_publish(
+            packet,
+            scope: 'DEFAULT',
+            target_names: ['INST'],
+            logger: Logger.new,
+            name: 'TEST',
+            check_limits: true,
+            stored_limits_mode: 'NORMAL',
+          )
+        end
+
+        it 'checks limits for stored packets when mode is LOG' do
+          packet = build_packet
+          packet.stored = true
+          allow(TelemetryDecomTopic).to receive(:write_packet)
+          subpackets = packet.subpacketize
+          allow(packet).to receive(:subpacketize).and_return(subpackets)
+          subpackets.each { |p| expect(p).to receive(:check_limits).with(System.limits_set) }
+
+          DecomCommon.decom_and_publish(
+            packet,
+            scope: 'DEFAULT',
+            target_names: ['INST'],
+            logger: Logger.new,
+            name: 'TEST',
+            check_limits: true,
+            stored_limits_mode: 'LOG',
+          )
+        end
+
+        it 'skips limits check for stored packets when mode is DISABLE' do
+          packet = build_packet
+          packet.stored = true
+          allow(TelemetryDecomTopic).to receive(:write_packet)
+          subpackets = packet.subpacketize
+          allow(packet).to receive(:subpacketize).and_return(subpackets)
+          subpackets.each { |p| expect(p).not_to receive(:check_limits) }
+
+          DecomCommon.decom_and_publish(
+            packet,
+            scope: 'DEFAULT',
+            target_names: ['INST'],
+            logger: Logger.new,
+            name: 'TEST',
+            check_limits: true,
+            stored_limits_mode: 'DISABLE',
+          )
+        end
+
+        it 'still checks limits for non-stored packets when mode is DISABLE' do
+          packet = build_packet
+          packet.stored = false
+          allow(TelemetryDecomTopic).to receive(:write_packet)
+          subpackets = packet.subpacketize
+          allow(packet).to receive(:subpacketize).and_return(subpackets)
+          subpackets.each { |p| expect(p).to receive(:check_limits).with(System.limits_set) }
+
+          DecomCommon.decom_and_publish(
+            packet,
+            scope: 'DEFAULT',
+            target_names: ['INST'],
+            logger: Logger.new,
+            name: 'TEST',
+            check_limits: true,
+            stored_limits_mode: 'DISABLE',
+          )
+        end
+
+        it 'passes include_limits_states: false to write_packet when DISABLE and stored' do
+          packet = build_packet
+          packet.stored = true
+          expect(TelemetryDecomTopic).to receive(:write_packet)
+            .with(packet, include_limits_states: false, scope: 'DEFAULT')
+
+          DecomCommon.decom_and_publish(
+            packet,
+            scope: 'DEFAULT',
+            target_names: ['INST'],
+            logger: Logger.new,
+            name: 'TEST',
+            check_limits: true,
+            stored_limits_mode: 'DISABLE',
+          )
+        end
+
+        it 'passes include_limits_states: true to write_packet when DISABLE but not stored' do
+          packet = build_packet
+          packet.stored = false
+          expect(TelemetryDecomTopic).to receive(:write_packet)
+            .with(packet, include_limits_states: true, scope: 'DEFAULT')
+
+          DecomCommon.decom_and_publish(
+            packet,
+            scope: 'DEFAULT',
+            target_names: ['INST'],
+            logger: Logger.new,
+            name: 'TEST',
+            check_limits: true,
+            stored_limits_mode: 'DISABLE',
+          )
+        end
+
+        it 'passes include_limits_states: true to write_packet when mode is NORMAL' do
+          packet = build_packet
+          packet.stored = true
+          expect(TelemetryDecomTopic).to receive(:write_packet)
+            .with(packet, include_limits_states: true, scope: 'DEFAULT')
+
+          DecomCommon.decom_and_publish(
+            packet,
+            scope: 'DEFAULT',
+            target_names: ['INST'],
+            logger: Logger.new,
+            name: 'TEST',
+            check_limits: true,
+            stored_limits_mode: 'NORMAL',
+          )
+        end
+      end
     end
 
     describe '.handle_subpacket' do

--- a/openc3/spec/microservices/decom_microservice_spec.rb
+++ b/openc3/spec/microservices/decom_microservice_spec.rb
@@ -271,6 +271,102 @@ module OpenC3
         lrt = @dm.instance_variable_get("@limits_response_thread")
         expect(lrt.instance_variable_get("@metric").data['limits_response_error_total']['value']).to eql(1)
       end
+
+      it "defaults stored_limits_mode to NORMAL" do
+        expect(@dm.instance_variable_get("@stored_limits_mode")).to eql('NORMAL')
+      end
+    end
+
+    describe "stored_limits_mode" do
+      before(:each) do
+        # Shut down the default microservice from the outer before(:each)
+        @dm.shutdown()
+        @dm_thread.join()
+      end
+
+      after(:each) do
+        @dm.shutdown()
+        @dm_thread.join()
+      end
+
+      def start_decom_with_mode(mode)
+        # Update the target model with the desired stored_limits_mode
+        target = TargetModel.get_model(name: 'INST', scope: 'DEFAULT')
+        target.stored_limits_mode = mode
+        target.create(update: true)
+        @dm = DecomMicroservice.new("DEFAULT__DECOM__INST_INT")
+        @dm_thread = Thread.new { @dm.run }
+        sleep 0.001
+      end
+
+      it "loads stored_limits_mode from TargetModel" do
+        start_decom_with_mode('DISABLE')
+        expect(@dm.instance_variable_get("@stored_limits_mode")).to eql('DISABLE')
+      end
+
+      it "in LOG mode, logs limits changes for stored packets but skips reactions" do
+        start_decom_with_mode('LOG')
+
+        class TrackingLimitsResponse < LimitsResponse
+          @@called = false
+          def self.called?; @@called; end
+          def self.reset!; @@called = false; end
+          def call(packet, item, old_limits_state)
+            @@called = true
+          end
+        end
+
+        TrackingLimitsResponse.reset!
+        packet = System.telemetry.packet('INST', 'HEALTH_STATUS')
+        temp1 = packet.get_item("TEMP1")
+        temp1.limits.response = TrackingLimitsResponse.new
+        packet.received_time = Time.now.sys
+        packet.stored = true
+
+        capture_io do |stdout|
+          TelemetryTopic.write_packet(packet, scope: 'DEFAULT')
+          sleep 0.01
+          # Limits changes are still logged
+          expect(stdout.string).to include("INST HEALTH_STATUS TEMP1")
+          expect(stdout.string).to include("RED_LOW")
+        end
+
+        # Limits response should NOT be called
+        expect(TrackingLimitsResponse.called?).to be false
+
+        # Events should be published to the stream with stored flag
+        events = LimitsEventTopic.read(0, scope: "DEFAULT")
+        stored_events = events.select { |_id, e| e['stored'] == true }
+        expect(stored_events.length).to be > 0
+
+        # current_limits should NOT be updated (stored flag prevents it)
+        out = LimitsEventTopic.out_of_limits(scope: "DEFAULT")
+        expect(out.length).to eql 0
+      end
+
+      it "in DISABLE mode, skips limits checking entirely for stored packets" do
+        start_decom_with_mode('DISABLE')
+
+        packet = System.telemetry.packet('INST', 'HEALTH_STATUS')
+        packet.received_time = Time.now.sys
+        packet.stored = true
+
+        capture_io do |stdout|
+          TelemetryTopic.write_packet(packet, scope: 'DEFAULT')
+          sleep 0.01
+          # No limits change messages should be logged for stored packets
+          expect(stdout.string).not_to include("RED_LOW")
+          expect(stdout.string).not_to include("YELLOW")
+        end
+
+        # No limits events should be generated
+        events = LimitsEventTopic.read(0, scope: "DEFAULT")
+        expect(events.length).to eql 0
+
+        # current_limits should NOT be updated
+        out = LimitsEventTopic.out_of_limits(scope: "DEFAULT")
+        expect(out.length).to eql 0
+      end
     end
   end
 end

--- a/openc3/spec/microservices/decom_microservice_spec.rb
+++ b/openc3/spec/microservices/decom_microservice_spec.rb
@@ -272,8 +272,8 @@ module OpenC3
         expect(lrt.instance_variable_get("@metric").data['limits_response_error_total']['value']).to eql(1)
       end
 
-      it "defaults stored_limits_mode to NORMAL" do
-        expect(@dm.instance_variable_get("@stored_limits_mode")).to eql('NORMAL')
+      it "defaults stored_limits_mode to PROCESS" do
+        expect(@dm.instance_variable_get("@stored_limits_mode")).to eql('PROCESS')
       end
     end
 

--- a/openc3/spec/microservices/decom_microservice_spec.rb
+++ b/openc3/spec/microservices/decom_microservice_spec.rb
@@ -311,7 +311,7 @@ module OpenC3
           @@called = false
           def self.called?; @@called; end
           def self.reset!; @@called = false; end
-          def call(packet, item, old_limits_state)
+          def call(_packet, _item, _old_limits_state)
             @@called = true
           end
         end

--- a/openc3/spec/microservices/decom_microservice_spec.rb
+++ b/openc3/spec/microservices/decom_microservice_spec.rb
@@ -336,7 +336,7 @@ module OpenC3
 
         # Events should be published to the stream with stored flag
         events = LimitsEventTopic.read(0, scope: "DEFAULT")
-        stored_events = events.select { |_id, e| e['stored'] == true }
+        stored_events = events.select { |_id, e| e['suppress_stored'] == true }
         expect(stored_events.length).to be > 0
 
         # current_limits should NOT be updated (stored flag prevents it)

--- a/openc3/spec/models/cvt_model_spec.rb
+++ b/openc3/spec/models/cvt_model_spec.rb
@@ -70,6 +70,19 @@ module OpenC3
         expect(CvtModel.get_item("TGT", "PKT", "ARY", type: :WITH_UNITS, scope: "DEFAULT")).to eql '["0x2 V", "0x4 V"]'
         expect(CvtModel.get_item("TGT", "PKT", "BLOCK", type: :RAW, scope: "DEFAULT")).to eql "\x00\x01\x02\x03\x04"
       end
+
+      it "passes include_limits_states through to packet.decom" do
+        packet = Packet.new("TGT", "PKT", :BIG_ENDIAN, 'packet', "\x01\x02")
+        item = packet.append_item("val", 16, :UINT)
+        item.limits.state = :RED_HIGH
+
+        json_hash = CvtModel.build_json_from_packet(packet)
+        expect(json_hash['VAL__L']).to eql :RED_HIGH
+
+        json_hash = CvtModel.build_json_from_packet(packet, include_limits_states: false)
+        expect(json_hash.key?('VAL__L')).to be false
+        expect(json_hash['VAL']).to eql 0x0102
+      end
     end
 
     describe "self.del" do

--- a/openc3/spec/models/target_model_spec.rb
+++ b/openc3/spec/models/target_model_spec.rb
@@ -711,7 +711,7 @@ module OpenC3
           parser.parse_file(tf.path) do |keyword, params|
             model.handle_config(parser, keyword, params)
           end
-        end.to raise_error(ConfigParser::Error, /STORED_LIMITS_MODE must be PROCESS, LOG, or DISABLE but is INVALID/)
+        end.to raise_error(ConfigParser::Error, /STORED_LIMITS_MODE must be one of PROCESS, LOG, or DISABLE/)
         tf.unlink
       end
 

--- a/openc3/spec/models/target_model_spec.rb
+++ b/openc3/spec/models/target_model_spec.rb
@@ -641,18 +641,18 @@ module OpenC3
         tf.unlink
       end
 
-      it "parses STORED_LIMITS_MODE NORMAL" do
+      it "parses STORED_LIMITS_MODE PROCESS" do
         model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
         model.create
         parser = ConfigParser.new
         tf = Tempfile.new
-        tf.puts "STORED_LIMITS_MODE NORMAL"
+        tf.puts "STORED_LIMITS_MODE PROCESS"
         tf.close
         parser.parse_file(tf.path) do |keyword, params|
           model.handle_config(parser, keyword, params)
         end
-        expect(model.stored_limits_mode).to eql 'NORMAL'
-        expect(model.as_json()['stored_limits_mode']).to eql 'NORMAL'
+        expect(model.stored_limits_mode).to eql 'PROCESS'
+        expect(model.as_json()['stored_limits_mode']).to eql 'PROCESS'
         tf.unlink
       end
 
@@ -711,14 +711,14 @@ module OpenC3
           parser.parse_file(tf.path) do |keyword, params|
             model.handle_config(parser, keyword, params)
           end
-        end.to raise_error(ConfigParser::Error, /STORED_LIMITS_MODE must be NORMAL, LOG, or DISABLE but is INVALID/)
+        end.to raise_error(ConfigParser::Error, /STORED_LIMITS_MODE must be PROCESS, LOG, or DISABLE but is INVALID/)
         tf.unlink
       end
 
-      it "defaults STORED_LIMITS_MODE to NORMAL" do
+      it "defaults STORED_LIMITS_MODE to PROCESS" do
         model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
-        expect(model.stored_limits_mode).to eql 'NORMAL'
-        expect(model.as_json()['stored_limits_mode']).to eql 'NORMAL'
+        expect(model.stored_limits_mode).to eql 'PROCESS'
+        expect(model.as_json()['stored_limits_mode']).to eql 'PROCESS'
       end
 
     end

--- a/openc3/spec/models/target_model_spec.rb
+++ b/openc3/spec/models/target_model_spec.rb
@@ -594,6 +594,7 @@ module OpenC3
         tf.puts "TARGET_MICROSERVICE CLEANUP"
         tf.puts "TLM_LOG_CYCLE_TIME 5"
         tf.puts "TLM_LOG_CYCLE_SIZE 6"
+        tf.puts "STORED_LIMITS_MODE DISABLE"
         tf.close
         parser.parse_file(tf.path) do |keyword, params|
           model.handle_config(parser, keyword, params)
@@ -606,6 +607,7 @@ module OpenC3
         expect(json['cmd_decom_retain_time']).to eql '30d'
         expect(json['tlm_decom_retain_time']).to eql '60d'
         expect(json['shard']).to eql 9
+        expect(json['stored_limits_mode']).to eql 'DISABLE'
         tf.unlink
       end
 
@@ -637,6 +639,86 @@ module OpenC3
           end
         end.to raise_error(ConfigParser::Error, /TLM_DECOM_RETAIN_TIME must be a number followed by h, d, w, M, or y/)
         tf.unlink
+      end
+
+      it "parses STORED_LIMITS_MODE NORMAL" do
+        model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
+        model.create
+        parser = ConfigParser.new
+        tf = Tempfile.new
+        tf.puts "STORED_LIMITS_MODE NORMAL"
+        tf.close
+        parser.parse_file(tf.path) do |keyword, params|
+          model.handle_config(parser, keyword, params)
+        end
+        expect(model.stored_limits_mode).to eql 'NORMAL'
+        expect(model.as_json()['stored_limits_mode']).to eql 'NORMAL'
+        tf.unlink
+      end
+
+      it "parses STORED_LIMITS_MODE LOG" do
+        model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
+        model.create
+        parser = ConfigParser.new
+        tf = Tempfile.new
+        tf.puts "STORED_LIMITS_MODE LOG"
+        tf.close
+        parser.parse_file(tf.path) do |keyword, params|
+          model.handle_config(parser, keyword, params)
+        end
+        expect(model.stored_limits_mode).to eql 'LOG'
+        expect(model.as_json()['stored_limits_mode']).to eql 'LOG'
+        tf.unlink
+      end
+
+      it "parses STORED_LIMITS_MODE DISABLE" do
+        model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
+        model.create
+        parser = ConfigParser.new
+        tf = Tempfile.new
+        tf.puts "STORED_LIMITS_MODE DISABLE"
+        tf.close
+        parser.parse_file(tf.path) do |keyword, params|
+          model.handle_config(parser, keyword, params)
+        end
+        expect(model.stored_limits_mode).to eql 'DISABLE'
+        expect(model.as_json()['stored_limits_mode']).to eql 'DISABLE'
+        tf.unlink
+      end
+
+      it "parses STORED_LIMITS_MODE case-insensitively" do
+        model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
+        model.create
+        parser = ConfigParser.new
+        tf = Tempfile.new
+        tf.puts "STORED_LIMITS_MODE log"
+        tf.close
+        parser.parse_file(tf.path) do |keyword, params|
+          model.handle_config(parser, keyword, params)
+        end
+        expect(model.stored_limits_mode).to eql 'LOG'
+        tf.unlink
+      end
+
+      it "rejects STORED_LIMITS_MODE with invalid value" do
+        model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
+        model.create
+        parser = ConfigParser.new
+        tf = Tempfile.new
+        tf.puts "STORED_LIMITS_MODE INVALID"
+        tf.close
+        expect do
+          parser.parse_file(tf.path) do |keyword, params|
+            model.handle_config(parser, keyword, params)
+          end
+        end.to raise_error(ConfigParser::Error, /STORED_LIMITS_MODE must be NORMAL, LOG, or DISABLE but is INVALID/)
+        tf.unlink
+      end
+
+      it "defaults STORED_LIMITS_MODE to NORMAL" do
+        model = TargetModel.new(folder_name: "TEST", name: "TEST", scope: "DEFAULT")
+        expect(model.stored_limits_mode).to eql 'NORMAL'
+        expect(model.as_json()['stored_limits_mode']).to eql 'NORMAL'
       end
 
     end

--- a/openc3/spec/packets/packet_spec.rb
+++ b/openc3/spec/packets/packet_spec.rb
@@ -1799,6 +1799,42 @@ module OpenC3
 
         expect(vals['TEST3__L']).to eql :RED
       end
+
+      it "omits limits states when include_limits_states is false" do
+        p = Packet.new("tgt", "pkt")
+        i1 = p.append_item("test1", 8, :UINT)
+        i1.limits.state = :GREEN
+        i2 = p.append_item("test2", 16, :UINT)
+        i2.read_conversion = GenericConversion.new("value * 2")
+        i2.limits.state = :RED_HIGH
+
+        buffer = "\x01\x00\x03"
+        p.buffer = buffer
+
+        # Default: limits states included
+        vals = p.decom
+        expect(vals['TEST1__L']).to eql :GREEN
+        expect(vals['TEST2__L']).to eql :RED_HIGH
+
+        # With include_limits_states: false, __L keys are omitted
+        vals = p.decom(include_limits_states: false)
+        expect(vals.key?('TEST1__L')).to be false
+        expect(vals.key?('TEST2__L')).to be false
+        # Other value types are still present
+        expect(vals['TEST1']).to eql 1
+        expect(vals['TEST2']).to eql 3
+        expect(vals['TEST2__C']).to eql 6
+      end
+
+      it "includes limits states by default" do
+        p = Packet.new("tgt", "pkt")
+        i1 = p.append_item("test1", 8, :UINT)
+        i1.limits.state = :YELLOW_LOW
+
+        p.buffer = "\x05"
+        vals = p.decom
+        expect(vals['TEST1__L']).to eql :YELLOW_LOW
+      end
     end
 
     describe "obfuscate" do

--- a/openc3/spec/topics/limits_event_topic_spec.rb
+++ b/openc3/spec/topics/limits_event_topic_spec.rb
@@ -40,6 +40,34 @@ module OpenC3
         expect(out[0][3]).to eql "YELLOW_LOW"
       end
 
+      it "skips current_limits update when LIMITS_CHANGE event has stored: true" do
+        event = { type: :LIMITS_CHANGE, target_name: "TGT", packet_name: "PKT",
+            item_name: "ITEM", old_limits_state: :GREEN, new_limits_state: :RED_HIGH,
+            time_nsec: 123456789, message: "stored change", stored: true }
+        LimitsEventTopic.write(event, scope: "DEFAULT")
+
+        # Event is still written to the stream
+        events = LimitsEventTopic.read(scope: "DEFAULT")
+        expect(events.length).to eql 1
+        expect(events[0][1]['type']).to eql "LIMITS_CHANGE"
+        expect(events[0][1]['stored']).to eql true
+
+        # But current_limits hash is NOT updated
+        out = LimitsEventTopic.out_of_limits(scope: "DEFAULT")
+        expect(out.length).to eql 0
+      end
+
+      it "updates current_limits when LIMITS_CHANGE event does not have stored flag" do
+        event = { type: :LIMITS_CHANGE, target_name: "TGT", packet_name: "PKT",
+            item_name: "ITEM", old_limits_state: :GREEN, new_limits_state: :RED_HIGH,
+            time_nsec: 123456789, message: "realtime change" }
+        LimitsEventTopic.write(event, scope: "DEFAULT")
+
+        out = LimitsEventTopic.out_of_limits(scope: "DEFAULT")
+        expect(out.length).to eql 1
+        expect(out[0][3]).to eql "RED_HIGH"
+      end
+
       it "writes and reads LIMITS_SETTINGS events" do
         event = { type: :LIMITS_SETTINGS, limits_set: :DEFAULT, target_name: "TGT1", packet_name: "PKT1",
             item_name: "ITEM1", red_low: -50.0, yellow_low: -40.0, yellow_high: 40.0, red_high: 50.0,

--- a/openc3/spec/topics/limits_event_topic_spec.rb
+++ b/openc3/spec/topics/limits_event_topic_spec.rb
@@ -40,24 +40,24 @@ module OpenC3
         expect(out[0][3]).to eql "YELLOW_LOW"
       end
 
-      it "skips current_limits update when LIMITS_CHANGE event has stored: true" do
+      it "skips current_limits update when LIMITS_CHANGE event has suppress_stored: true" do
         event = { type: :LIMITS_CHANGE, target_name: "TGT", packet_name: "PKT",
             item_name: "ITEM", old_limits_state: :GREEN, new_limits_state: :RED_HIGH,
-            time_nsec: 123456789, message: "stored change", stored: true }
+            time_nsec: 123456789, message: "stored change", suppress_stored: true }
         LimitsEventTopic.write(event, scope: "DEFAULT")
 
         # Event is still written to the stream
         events = LimitsEventTopic.read(scope: "DEFAULT")
         expect(events.length).to eql 1
         expect(events[0][1]['type']).to eql "LIMITS_CHANGE"
-        expect(events[0][1]['stored']).to eql true
+        expect(events[0][1]['suppress_stored']).to eql true
 
         # But current_limits hash is NOT updated
         out = LimitsEventTopic.out_of_limits(scope: "DEFAULT")
         expect(out.length).to eql 0
       end
 
-      it "updates current_limits when LIMITS_CHANGE event does not have stored flag" do
+      it "updates current_limits when LIMITS_CHANGE event does not have suppress_stored flag" do
         event = { type: :LIMITS_CHANGE, target_name: "TGT", packet_name: "PKT",
             item_name: "ITEM", old_limits_state: :GREEN, new_limits_state: :RED_HIGH,
             time_nsec: 123456789, message: "realtime change" }

--- a/openc3/spec/topics/telemetry_decom_topic_spec.rb
+++ b/openc3/spec/topics/telemetry_decom_topic_spec.rb
@@ -77,6 +77,20 @@ module OpenC3
         expect(CvtModel).not_to receive(:set_json)
         TelemetryDecomTopic.write_packet(packet, scope: 'DEFAULT')
       end
+
+      it "passes include_limits_states to CvtModel.build_json_from_packet" do
+        expect(CvtModel).to receive(:build_json_from_packet)
+          .with(packet, include_limits_states: false)
+          .and_return({ 'TEMP1' => 1.0 })
+        TelemetryDecomTopic.write_packet(packet, include_limits_states: false, scope: 'DEFAULT')
+      end
+
+      it "defaults include_limits_states to true" do
+        expect(CvtModel).to receive(:build_json_from_packet)
+          .with(packet, include_limits_states: true)
+          .and_return({ 'TEMP1' => 1.0 })
+        TelemetryDecomTopic.write_packet(packet, scope: 'DEFAULT')
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #3434 

This adds:
- New STORED_LIMITS_MODE target option that defines how to handle limits violations when packet.stored == true
  - NORMAL: old behavior
  - LOG: logs limits violations but doesn't do reactions
  - DISABLE: ignores limits violations
- Adds variable to demo to make INST2 tlm stored for testing this