### PR TITLE
fix(binary_accessor): guard nil length in variable_bit_size decom

### DIFF
--- a/openc3/lib/openc3/accessors/binary_accessor.rb
+++ b/openc3/lib/openc3/accessors/binary_accessor.rb
@@ -108,6 +108,10 @@ module OpenC3
 
     def handle_read_variable_bit_size(item, _buffer)
       length_value = @packet.read(item.variable_bit_size['length_item_name'], :CONVERTED)
+      # length_value can be nil when reading an undersized packet where the length
+      # item falls outside the buffer bounds
+      raise "Length value #{item.variable_bit_size['length_item_name']} for item #{item.name} is nil" if length_value.nil?
+
       if item.array_size
         item.array_size = (length_value * item.variable_bit_size['length_bits_per_count']) + item.variable_bit_size['length_value_bit_offset']
       else

--- a/openc3/python/openc3/accessors/binary_accessor.py
+++ b/openc3/python/openc3/accessors/binary_accessor.py
@@ -100,6 +100,10 @@ class BinaryAccessor(Accessor):
 
     def handle_read_variable_bit_size(self, item, _buffer):
         length_value = self.packet.read(item.variable_bit_size["length_item_name"], "CONVERTED")
+        # length_value can be None when reading an undersized packet where the length
+        # item falls outside the buffer bounds
+        if length_value is None:
+            raise RuntimeError(f"Length value {item.variable_bit_size['length_item_name']} for item {item.name} is None")
         if item.array_size is not None:
             item.array_size = (length_value * item.variable_bit_size["length_bits_per_count"]) + item.variable_bit_size[
                 "length_value_bit_offset"

--- a/openc3/python/openc3/accessors/binary_accessor.py
+++ b/openc3/python/openc3/accessors/binary_accessor.py
@@ -103,7 +103,9 @@ class BinaryAccessor(Accessor):
         # length_value can be None when reading an undersized packet where the length
         # item falls outside the buffer bounds
         if length_value is None:
-            raise RuntimeError(f"Length value {item.variable_bit_size['length_item_name']} for item {item.name} is None")
+            raise RuntimeError(
+                f"Length value {item.variable_bit_size['length_item_name']} for item {item.name} is None"
+            )
         if item.array_size is not None:
             item.array_size = (length_value * item.variable_bit_size["length_bits_per_count"]) + item.variable_bit_size[
                 "length_value_bit_offset"

--- a/openc3/python/openc3/packets/packet.py
+++ b/openc3/python/openc3/packets/packet.py
@@ -287,7 +287,10 @@ class Packet(Structure):
             # Catch and re-raise the TypeError thrown by internal_buffer_equals
             except TypeError as error:
                 raise error
-            except ValueError:
+            # RuntimeError is raised when a variable_bit_size length item falls
+            # outside an undersized buffer. Swallow it here (matching Ruby) so the
+            # error surfaces at read time rather than on buffer assignment.
+            except (ValueError, RuntimeError):
                 Logger.error(
                     f"{self.target_name} {self.packet_name} buffer ({type(buffer)}) received with actual packet length of {len(buffer)} but defined length of {self.defined_length}"
                 )

--- a/openc3/python/test/accessors/test_binary_accessor_read.py
+++ b/openc3/python/test/accessors/test_binary_accessor_read.py
@@ -13,6 +13,7 @@ import unittest
 from unittest.mock import *
 
 from openc3.accessors.binary_accessor import BinaryAccessor
+from openc3.packets.packet import Packet
 from test.test_helper import *
 
 
@@ -1112,3 +1113,21 @@ class TestBinaryAccessorReadItemUndersizedBuffer(unittest.TestCase):
         buffer = bytearray(b"\x00\x01\x02\x03")  # 4 bytes = 32 bits
         item = StructureItem("TEST", 16, 32, "UINT", "BIG_ENDIAN")
         self.assertIsNone(BinaryAccessor.class_read_item(item, buffer))
+
+    def test_raises_a_clear_error_when_the_length_item_is_none_in_an_undersized_packet(self):
+        packet = Packet()
+        packet.append_item("item1_length", 32, "UINT")
+        item1 = packet.append_item("item1", 8, "UINT", 0)
+        item1.variable_bit_size = {
+            "length_item_name": "item1_length",
+            "length_value_bit_offset": 0,
+            "length_bits_per_count": 8,
+        }
+        # Buffer is too short to contain the length item, so reading it returns None.
+        # Setting the buffer logs and swallows the error (matching Ruby); the
+        # descriptive error surfaces at read time rather than a TypeError on None.
+        packet.short_buffer_allowed = True
+        packet.buffer = b"\x00\x00"
+        self.assertIsNone(packet.read("item1_length"))
+        with self.assertRaisesRegex(RuntimeError, "Length value item1_length for item ITEM1 is None"):
+            packet.read("item1")

--- a/openc3/spec/accessors/binary_accessor_spec.rb
+++ b/openc3/spec/accessors/binary_accessor_spec.rb
@@ -278,6 +278,18 @@ module OpenC3
         expect(@packet.read("item1")).to eql [17]
         expect(item1.array_size).to eq(8)
       end
+
+      it "raises a clear error when the length item is nil in an undersized packet" do
+        @packet.append_item("item1_length", 32, :UINT)
+        item1 = @packet.append_item("item1", 8, :UINT, 0)
+        item1.variable_bit_size = {'length_item_name' => 'item1_length', 'length_value_bit_offset' => 0, 'length_bits_per_count' => 8}
+        # Buffer is too short to contain the length item, so reading it returns nil.
+        # This must raise a descriptive error rather than a NoMethodError on nil.
+        @packet.short_buffer_allowed = true
+        @packet.buffer = "\x00\x00"
+        expect(@packet.read("item1_length")).to be_nil
+        expect { @packet.read("item1") }.to raise_error(/Length value item1_length for item ITEM1 is nil/)
+      end
     end
 
     describe "read only" do


### PR DESCRIPTION
Reading an undersized packet returns nil for a variable_bit_size length item that falls outside the buffer, causing a cryptic "undefined method '*' for nil" during decom. PR #3503 guarded Structure#calculate_total_bit_size but not the accessor read path used by bulk decom, so the crash persisted.

Add the same guard to BinaryAccessor#handle_read_variable_bit_size (Ruby and Python) and align the Python buffer setter to swallow the RuntimeError like Ruby, deferring the descriptive error to read time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)