### PR TITLE
Display both cmd & hazardous descriptions

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue
@@ -132,10 +132,15 @@
         </v-toolbar>
         <v-card-text class="mt-6">
           Warning: Command {{ hazardousCommand }} is Hazardous. Send?
-          <br />
-          <span class="openc3-yellow">
-            Description: {{ commandDescription }}
-          </span>
+          <div class="mt-1">Description: {{ commandDescription }}</div>
+          <div
+            v-if="hazardousDescription"
+            class="openc3-yellow font-weight-bold mt-2"
+            data-test="hazardous-description"
+          >
+            <v-icon class="mr-1">mdi-alert</v-icon>
+            Hazardous: {{ hazardousDescription }}
+          </div>
         </v-card-text>
         <v-card-actions class="px-2">
           <v-spacer />
@@ -228,6 +233,7 @@ export default {
       targetName: '',
       commandName: '',
       commandDescription: '',
+      hazardousDescription: '',
       paramList: '',
       queueName: null,
       validateParameter: null,
@@ -447,6 +453,7 @@ export default {
     onCommandLoaded(command) {
       if (command) {
         this.commandDescription = command.description
+        this.hazardousDescription = command.hazardous_description || ''
         if (command.screen) {
           this.loadScreen(command.screen[0], command.screen[1]).then(
             (response) => {
@@ -474,6 +481,7 @@ export default {
         }
       } else {
         this.commandDescription = ''
+        this.hazardousDescription = ''
         this.screenTarget = null
         this.screenName = null
         this.screenDefinition = null

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
@@ -180,10 +180,16 @@
       <v-col :cols="colSize" style="max-width: 140px"> </v-col>
     </v-row>
     <v-row no-gutters class="pt-3 px-3 align-center">
-      <v-col :cols="colSize" :class="{ 'openc3-yellow': isHazardous }">
-        <v-icon v-if="isHazardous" class="mr-1">mdi-alert</v-icon>
-        Description: {{ description }}
-        <template v-if="isHazardous"> (HAZARDOUS) </template>
+      <v-col :cols="colSize">
+        <div>Description: {{ description }}</div>
+        <div
+          v-if="hazardousDescription"
+          class="openc3-yellow font-weight-bold mt-2"
+          data-test="hazardous-description"
+        >
+          <v-icon class="mr-1">mdi-alert</v-icon>
+          Hazardous: {{ hazardousDescription }}
+        </div>
       </v-col>
     </v-row>
   </div>
@@ -305,6 +311,7 @@ export default {
       selectedReducedType: 'AVG',
       description: '',
       hazardous: false,
+      hazardousDescription: '',
       internalDisabled: false,
       packetsDisabled: false,
       itemsDisabled: false,
@@ -718,6 +725,7 @@ export default {
         this.selectedPacketName = 'LATEST'
         this.description = 'Latest values from all packets'
         this.hazardous = false
+        this.hazardousDescription = ''
       } else {
         this.itemsDisabled = false
         const packet = this.packetNames.find((packet) => {
@@ -730,6 +738,7 @@ export default {
             (packet) => {
               this.description = packet.description
               this.hazardous = packet.hazardous
+              this.hazardousDescription = packet.hazardous_description || ''
             },
           )
         }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/PromptDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/PromptDialog.vue
@@ -37,6 +37,18 @@
           <v-row class="mt-1">
             <span v-text="message" />
           </v-row>
+          <v-row v-if="description" class="mt-4">
+            <span>Description: {{ description }}</span>
+          </v-row>
+          <v-row v-if="hazardous" class="mt-4">
+            <span
+              class="openc3-yellow font-weight-bold"
+              data-test="hazardous-description"
+            >
+              <v-icon class="mr-1">mdi-alert</v-icon>
+              Hazardous: {{ hazardous }}
+            </span>
+          </v-row>
           <v-row v-if="details" class="mt-3">
             <span v-text="details" />
           </v-row>
@@ -151,6 +163,14 @@ const props = defineProps({
     required: true,
   },
   details: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+  hazardous: {
     type: String,
     default: '',
   },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -588,6 +588,8 @@
     :subtitle="prompt.subtitle"
     :message="prompt.message"
     :details="prompt.details"
+    :description="prompt.description"
+    :hazardous="prompt.hazardous"
     :buttons="prompt.buttons"
     :layout="prompt.layout"
     :multiple="prompt.multiple"
@@ -876,6 +878,8 @@ export default {
         subtitle: '',
         message: '',
         details: '',
+        description: '',
+        hazardous: '',
         buttons: null,
         layout: 'horizontal',
         callback: () => {},
@@ -2300,6 +2304,8 @@ export default {
       this.prompt.title = 'Prompt'
       this.prompt.subtitle = ''
       this.prompt.details = ''
+      this.prompt.description = ''
+      this.prompt.hazardous = ''
       this.prompt.buttons = []
       this.prompt.multiple = null
       switch (data.method) {
@@ -2345,11 +2351,18 @@ export default {
           break
         case 'prompt_for_hazardous':
           this.prompt.title = 'Hazardous Command'
-          this.prompt.message = `Warning: Command ${data.args[0]} ${data.args[1]} is Hazardous. `
+          this.prompt.message = `Warning: Command ${data.args[0]} ${data.args[1]} is Hazardous. Send?`
           if (data.args[2]) {
-            this.prompt.message += data.args[2] + ' '
+            this.prompt.hazardous = data.args[2]
           }
-          this.prompt.message += 'Send?'
+          // The HazardousError only carries the hazardous description, so fetch
+          // the general command description to match Command Sender (issue #3472)
+          this.api
+            .get_cmd(data.args[0], data.args[1])
+            .then((command) => {
+              this.prompt.description = command.description || ''
+            })
+            .catch(() => {}) // Ignore - just don't show the description
           this.prompt.buttons = [{ text: 'Send', value: 'Send' }]
           this.prompt.callback = this.promptDialogCallback
           this.prompt.show = true

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1897,6 +1897,11 @@ export default {
         this.subscription = null
       }
       this.receivedEvents.length = 0 // Drop any events not yet processed
+      // Reset prompt tracking so the first prompt re-published on this fresh
+      // subscription is always processed and displayed. Without this, attaching
+      // to a running script (which reuses the component) could carry over a
+      // stale activePromptId and skip showing the dialog (see handleScript).
+      this.activePromptId = ''
       this.subscription = await this.cable.createSubscription(
         'RunningScriptChannel',
         window.openc3Scope,
@@ -2296,6 +2301,13 @@ export default {
         this.ask.show = false
         this.file.show = false
         this.bucket.show = false
+        return
+      }
+      // The running script re-publishes the active prompt about once a second
+      // while it waits for an answer. Ignore these repeats so we don't reset the
+      // dialog state and re-fetch the hazardous command description on every
+      // tick, which makes the dialog visibly bounce (issue #3472).
+      if (data.prompt_id && data.prompt_id === this.activePromptId) {
         return
       }
       this.activePromptId = data.prompt_id

--- a/playwright/tests/command-sender.p.spec.ts
+++ b/playwright/tests/command-sender.p.spec.ts
@@ -114,9 +114,21 @@ test('warns for hazardous commands', async ({ page, utils }) => {
   await page.locator('[data-test="clear-history"]').click()
   await utils.selectTargetPacketItem('INST', 'CLEAR')
   await expect(page.locator('main')).toContainText(
-    'Clears counters on the INST instrument (HAZARDOUS)',
+    'Clears counters on the INST instrument',
+  )
+  // The hazardous description is shown below the selects (see issue 3472)
+  await expect(page.locator('main')).toContainText(
+    'Hazardous: Clearing counters may lose valuable information.',
   )
   await page.locator('[data-test="select-send"]').click()
+  // The hazardous confirmation dialog shows both the command description and
+  // the hazardous description (see issue 3472)
+  await expect(page.getByRole('dialog')).toContainText(
+    'Description: Clears counters on the INST instrument',
+  )
+  await expect(page.getByRole('dialog')).toContainText(
+    'Hazardous: Clearing counters may lose valuable information.',
+  )
   await page.getByRole('button', { name: 'Cancel' }).click()
   await expect(page.locator('main')).toContainText('Hazardous command not sent')
   await page.locator('[data-test="select-send"]').click()
@@ -380,7 +392,7 @@ test('executes commands from history', async ({ page, utils }) => {
   await page.locator('[data-test="clear-history"]').click()
   await utils.selectTargetPacketItem('INST', 'CLEAR')
   await expect(page.locator('main')).toContainText(
-    'Clears counters on the INST instrument (HAZARDOUS)',
+    'Clears counters on the INST instrument',
   )
   await page.locator('[data-test="select-send"]').click()
   await page.getByRole('dialog').getByRole('button', { name: 'Send' }).click()
@@ -508,7 +520,7 @@ test('hazardous commands from history', async ({ page, utils }) => {
   await page.locator('[data-test="clear-history"]').click()
   await utils.selectTargetPacketItem('INST', 'CLEAR')
   await expect(page.locator('main')).toContainText(
-    'Clears counters on the INST instrument (HAZARDOUS)',
+    'Clears counters on the INST instrument',
   )
   await page.locator('[data-test="select-send"]').click()
   await page.getByRole('dialog').getByRole('button', { name: 'Send' }).click()

--- a/playwright/tests/script-runner/prompts.p.spec.ts
+++ b/playwright/tests/script-runner/prompts.p.spec.ts
@@ -26,6 +26,14 @@ test('prompts for hazardous commands', async ({ page, utils }) => {
   await expect(page.locator('.v-dialog')).toContainText('Hazardous Command', {
     timeout: 20000,
   })
+  // The hazardous prompt displays both the command description and the
+  // hazardous description (see issue #3472)
+  await expect(page.locator('.v-dialog')).toContainText(
+    'Description: Clears counters on the INST instrument',
+  )
+  await expect(page.locator('.v-dialog')).toContainText(
+    'Hazardous: Clearing counters may lose valuable information.',
+  )
   await page.getByRole('button', { name: 'Cancel' }).click()
   await expect(page.locator('[data-test=state] input')).toHaveValue(
     /paused \d+s/,


### PR DESCRIPTION
closes #3472 

Command Sender Before / After:
<img width="1213" height="515" alt="image" src="https://github.com/user-attachments/assets/264004b4-5c6f-46ae-a1b9-e84fffbd3ca0" />
<img width="1216" height="532" alt="image" src="https://github.com/user-attachments/assets/9a078111-edb2-4119-a559-df1a1b14f280" />

Script Runner Before / After:
<img width="1214" height="529" alt="image" src="https://github.com/user-attachments/assets/4e4ed0be-fbd8-407c-8b37-f6cfc354033e" />
<img width="1213" height="526" alt="image" src="https://github.com/user-attachments/assets/3c5f40c7-e9fb-4e37-b6a4-eff3939f25cf" />
