### PR TITLE
Add front and back guard for undefined

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/storage_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/storage_controller.rb
@@ -304,6 +304,13 @@ class StorageController < ApplicationController
       storage_type, storage_name = validate_storage_source
       object_id = sanitize_path(params[:object_id])
 
+      # Guard against a missing / literal 'null' object_id (e.g. frontend sending
+      # an undefined log or report filename). Return 404 instead of a 500.
+      if object_id.empty? || object_id == 'null'
+        render json: { status: 'error', message: "Invalid object_id: #{params[:object_id]}" }, status: :not_found
+        return
+      end
+
       # Check scope-based RBAC for bucket downloads
       if storage_type == :bucket && params[:bucket] && bucket_requires_rbac?(params[:bucket])
         unless authorize_bucket_path(params[:bucket], object_id)
@@ -321,6 +328,13 @@ class StorageController < ApplicationController
         FileUtils.mkdir_p(File.dirname(temp_path))
         OpenC3::Bucket.getClient().get_object(bucket: storage_name, key: object_id, path: temp_path)
         temp_path
+      end
+
+      # get_object returns nil for a missing key (never writes temp_path), and a
+      # volume file may not exist. Return 404 rather than letting File.read 500.
+      unless File.exist?(filename)
+        render json: { status: 'error', message: "File not found: #{params[:object_id]}" }, status: :not_found
+        return
       end
 
       file = File.read(filename, mode: 'rb')

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/storage_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/storage_controller_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe StorageController, type: :controller do
       allow(FileUtils).to receive(:mkdir_p)
       allow(FileUtils).to receive(:rm_rf)
       allow(File).to receive(:read).and_return("file content")
+      allow(File).to receive(:exist?).and_return(true)
       allow(Base64).to receive(:encode64).and_return("encoded_content")
 
       get :download_file, params: {bucket: "OPENC3_CONFIG_BUCKET", object_id: "file.txt", scope: "DEFAULT"}
@@ -184,6 +185,7 @@ RSpec.describe StorageController, type: :controller do
 
     it "downloads a file from a volume" do
       allow(File).to receive(:read).and_return("file content")
+      allow(File).to receive(:exist?).and_return(true)
       allow(Base64).to receive(:encode64).and_return("encoded_content")
 
       get :download_file, params: {volume: "OPENC3_DATA_VOLUME", object_id: "file.txt", scope: "DEFAULT"}
@@ -296,6 +298,7 @@ RSpec.describe StorageController, type: :controller do
         allow(Dir).to receive(:mktmpdir).and_return("/tmp/dir")
         allow(FileUtils).to receive(:mkdir_p)
         allow(FileUtils).to receive(:rm_rf)
+        allow(File).to receive(:exist?).and_return(true)
       end
 
       it "converts ruby test reports to CTRF format" do
@@ -1151,6 +1154,7 @@ RSpec.describe StorageController, type: :controller do
         allow(FileUtils).to receive(:mkdir_p)
         allow(FileUtils).to receive(:rm_rf)
         allow(File).to receive(:read).and_return("file content")
+        allow(File).to receive(:exist?).and_return(true)
 
         # Mock authorize to allow INST target with tlm permission
         allow(controller).to receive(:authorize) do |args|
@@ -1175,6 +1179,7 @@ RSpec.describe StorageController, type: :controller do
         allow(FileUtils).to receive(:mkdir_p)
         allow(FileUtils).to receive(:rm_rf)
         allow(File).to receive(:read).and_return("file content")
+        allow(File).to receive(:exist?).and_return(true)
 
         get :download_file, params: {bucket: "OPENC3_TOOLS_BUCKET", object_id: "tool/file.txt", scope: "DEFAULT"}
         expect(response).to have_http_status(:ok)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/RunningScripts.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/RunningScripts.vue
@@ -521,16 +521,23 @@ async function viewScriptLog(script, type) {
     })
     return
   }
-  const response = await Api.get(
-    `/openc3-api/storage/download_file/${encodeURIComponent(
-      logUrl,
-    )}?bucket=OPENC3_LOGS_BUCKET`,
-  )
-  const filenameParts = logUrl.split('/')
-  dialogFilename.value = filenameParts[filenameParts.length - 1]
-  // Decode Base64 string
-  dialogContent.value = window.atob(response.data.contents)
-  showDialog.value = true
+  try {
+    const response = await Api.get(
+      `/openc3-api/storage/download_file/${encodeURIComponent(
+        logUrl,
+      )}?bucket=OPENC3_LOGS_BUCKET`,
+    )
+    const filenameParts = logUrl.split('/')
+    dialogFilename.value = filenameParts[filenameParts.length - 1]
+    // Decode Base64 string
+    dialogContent.value = window.atob(response.data.contents)
+    showDialog.value = true
+  } catch {
+    notify.caution({
+      title: `Unable to open ${dialogName.value.toLowerCase()} ${logUrl}`,
+      body: `You may be able to download this ${dialogName.value.toLowerCase()} manually from the 'logs' bucket at ${logUrl}`,
+    })
+  }
 }
 
 async function downloadScriptLog(script, type, format = 'text') {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/RunningScripts.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/RunningScripts.vue
@@ -159,13 +159,14 @@
                 color="primary"
                 density="comfortable"
                 icon="mdi-eye"
+                :disabled="!item.log"
                 @click="viewScriptLog(item, 'log')"
               />
               <v-btn
                 color="primary"
                 density="comfortable"
                 icon="mdi-file-download-outline"
-                :disabled="downloadScript"
+                :disabled="downloadScript || !item.log"
                 :loading="downloadScript && downloadScript.name === item.name"
                 @click="downloadScriptLog(item, 'log')"
               />
@@ -513,6 +514,13 @@ async function viewScriptLog(script, type) {
     dialogName.value = 'Log'
     logUrl = script.log
   }
+  if (!logUrl) {
+    notify.caution({
+      title: `No ${dialogName.value.toLowerCase()} available`,
+      body: `Script ${script.name} has no ${dialogName.value.toLowerCase()} file yet.`,
+    })
+    return
+  }
   const response = await Api.get(
     `/openc3-api/storage/download_file/${encodeURIComponent(
       logUrl,
@@ -533,6 +541,13 @@ async function downloadScriptLog(script, type, format = 'text') {
   } else {
     dialogName.value = 'Log'
     logUrl = script.log
+  }
+  if (!logUrl) {
+    notify.caution({
+      title: `No ${dialogName.value.toLowerCase()} available`,
+      body: `Script ${script.name} has no ${dialogName.value.toLowerCase()} file yet.`,
+    })
+    return
   }
   downloadScript.value = script
 

--- a/openc3/python/test/script/test_api_shared.py
+++ b/openc3/python/test/script/test_api_shared.py
@@ -532,7 +532,7 @@ class TestApiShared(unittest.TestCase):
             result = wait("INST HEALTH_STATUS TEMP1 < 0", 0.01, 0.01)  # Last param is polling rate
             self.assertFalse(result)
             self.assertIn(
-                "WAIT: INST HEALTH_STATUS TEMP1 < 0 failed with value == 10 after waiting 0.01",
+                "WAIT: INST HEALTH_STATUS TEMP1 < 0 failed with value == 10 after waiting",
                 stdout.getvalue(),
             )
 
@@ -546,7 +546,7 @@ class TestApiShared(unittest.TestCase):
             result = wait("INST", "HEALTH_STATUS", "TEMP1", "== 0", 0.01, 0.01)  # Last param is polling rate
             self.assertFalse(result)
             self.assertIn(
-                "WAIT: INST HEALTH_STATUS TEMP1 == 0 failed with value == 10 after waiting 0.01",
+                "WAIT: INST HEALTH_STATUS TEMP1 == 0 failed with value == 10 after waiting",
                 stdout.getvalue(),
             )
 
@@ -600,7 +600,7 @@ class TestApiShared(unittest.TestCase):
             result = wait_tolerance("INST HEALTH_STATUS TEMP2", 11, 0.1, 0.01)
             self.assertFalse(result)
             self.assertIn(
-                "WAIT: INST HEALTH_STATUS TEMP2 failed to be within range 10.9 to 11.1 with value == 10.5 after waiting 0.01",
+                "WAIT: INST HEALTH_STATUS TEMP2 failed to be within range 10.9 to 11.1 with value == 10.5 after waiting",
                 stdout.getvalue(),
             )
 
@@ -764,7 +764,7 @@ class TestApiShared(unittest.TestCase):
             )
         with self.assertRaisesRegex(
             CheckError,
-            "CHECK: INST HEALTH_STATUS TEMP1 > 100 failed with value == 10 after waiting 0.01",
+            "CHECK: INST HEALTH_STATUS TEMP1 > 100 failed with value == 10 after waiting",
         ):
             wait_check("INST HEALTH_STATUS TEMP1 > 100", 0.01)
 


### PR DESCRIPTION
This was observed in the wild in a bad deployment where a script hung and thus didn't create a log. The request for the log resulted in a bad URL path. Add a check for the log in the frontend and a sanity check in the backend.