### PR TITLE
fix(interface): populate Queued By for Python target commands

### DIFF
--- a/openc3/python/openc3/microservices/interface_microservice.py
+++ b/openc3/python/openc3/microservices/interface_microservice.py
@@ -324,6 +324,9 @@ class InterfaceCmdHandlerThread:
             command.extra["cmd_string"] = msg_hash.get(b"cmd_string", b"").decode()
             command.extra["username"] = msg_hash.get(b"username", b"").decode()
             command.extra["interface_name"] = self.interface.name
+            # Record the original queuing user (author) shown as "Queued By" in Command History
+            if msg_hash.get(b"queue_username"):
+                command.extra["queue_username"] = msg_hash.get(b"queue_username", b"").decode()
             # Add approver info if this was a critical command that was approved
             if critical_model is not None:
                 command.extra["approver"] = critical_model.approver
@@ -512,9 +515,8 @@ class RouterTlmHandlerThread:
                 elif msg_hash.get(b"router_cmd"):
                     params = json.loads(msg_hash[b"router_cmd"])
                     try:
-                        self.logger.info(
-                            f"{self.router.name}: router_cmd: {params['cmd_name']} {' '.join(params['cmd_params'])}"
-                        )
+                        str_params = " ".join([str(i) for i in params["cmd_params"]])
+                        self.logger.info(f"{self.router.name}: router_cmd: {params['cmd_name']} {str_params}")
                         self.router.interface_cmd(params["cmd_name"], *params["cmd_params"])
                         result = "SUCCESS"
                     except Exception as error:
@@ -523,8 +525,9 @@ class RouterTlmHandlerThread:
                 elif msg_hash.get(b"protocol_cmd"):
                     params = json.loads(msg_hash[b"protocol_cmd"])
                     try:
+                        str_params = " ".join([str(i) for i in params["cmd_params"]])
                         self.logger.info(
-                            f"{self.router.name}: protocol_cmd: {params['cmd_name']} {' '.join(params['cmd_params'])} read_write: {params['read_write']} index: {params['index']}"
+                            f"{self.router.name}: protocol_cmd: {params['cmd_name']} {str_params} read_write: {params['read_write']} index: {params['index']}"
                         )
                         self.router.protocol_cmd(
                             params["cmd_name"],
@@ -596,12 +599,13 @@ class RouterTlmHandlerThread:
                     else:
                         result = None
 
-            # Send result back to generator and get next message
-            topic, msg_id, msg_hash, _redis = generator.send(result)
-
-            # Exit loop if shutdown was requested
+            # Exit loop if shutdown was requested (matches the Ruby behavior of
+            # returning immediately rather than reading another message)
             if result == "SHUTDOWN":
                 break
+
+            # Send result back to generator and get next message
+            topic, msg_id, msg_hash, _redis = generator.send(result)
 
 
 class InterfaceMicroservice(Microservice):

--- a/openc3/python/test/microservices/test_interface_microservice.py
+++ b/openc3/python/test/microservices/test_interface_microservice.py
@@ -153,7 +153,6 @@ class TestInterfaceMicroservice(unittest.TestCase):
             )
 
     def test_creates_an_interface_updates_status_and_starts_cmd_thread(self):
-        init_threads = threading.active_count()
         im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
         self.assertEqual(im.config["name"], "DEFAULT__INTERFACE__INST_INT")
         self.assertEqual(im.interface.name, "INST_INT")
@@ -165,13 +164,16 @@ class TestInterfaceMicroservice(unittest.TestCase):
         self.assertEqual(data["INST_INT"]["name"], "INST_INT")
         self.assertEqual(data["INST_INT"]["state"], "ATTEMPTING")
 
-        # Each interface microservice starts 3 threads: microservice_status_thread in microservice.rb
-        # and the InterfaceCmdHandlerThread in interface_microservice.rb
-        # and a metrics thread
-        self.assertEqual(threading.active_count() - init_threads, 3)
+        # The command handler thread is created and running. We check the handler
+        # thread directly rather than the global thread count because the metrics
+        # thread is a process-wide singleton, so the delta depends on test ordering
+        # across the full suite.
+        self.assertIsNotNone(im.handler_thread)
+        self.assertTrue(im.handler_thread.thread.is_alive())
+
         im.shutdown()
-        time.sleep(0.1)  # Allow threads to exit
-        self.assertEqual(threading.active_count(), init_threads)
+        im.handler_thread.thread.join(5)  # Wait for the handler to exit (no fixed sleep race)
+        self.assertFalse(im.handler_thread.thread.is_alive())
 
     # def test_preserves_existing_packet_counts(self):
     #     # Initialize the telemetry topic with a non-zero RECEIVED_COUNT
@@ -505,7 +507,9 @@ class TestInterfaceMicroservice(unittest.TestCase):
             self.assertIn("Stale tlmcnt Redis key detected for unknown packet INST OLD_PACKET", stdout.getvalue())
 
     def test_process_cmd_with_all_fields_and_missing_optional_fields(self):
-        """Test process_cmd succeeds with full msg_hash and with only required fields."""
+        """Test process_cmd succeeds with full msg_hash and with only required fields.
+        Also verifies queue_username (the original author, shown as "Queued By")
+        is carried through to the command extra."""
         im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
         thread = threading.Thread(target=im.run)
         thread.start()
@@ -528,12 +532,19 @@ class TestInterfaceMicroservice(unittest.TestCase):
             b"hazardous_check": b"TRUE",
             b"cmd_string": b"cmd('INST ABORT')",
             b"username": b"test_user",
+            b"queue_username": b"DEFAULT__MULTI__INST",
             b"validate": b"TRUE",
             b"manual": b"FALSE",
             b"log_message": b"TRUE",
         }
-        result = handler.process_cmd(topic, msg_id, full_msg_hash, None)
+        with patch("openc3.microservices.interface_microservice.CommandDecomTopic.write_packet") as mock_write:
+            result = handler.process_cmd(topic, msg_id, full_msg_hash, None)
         self.assertEqual(result, "SUCCESS")
+        # queue_username must be copied into the command extra so Command History
+        # can show "Queued By" for queued commands
+        command = mock_write.call_args[0][0]
+        self.assertEqual(command.extra["username"], "test_user")
+        self.assertEqual(command.extra.get("queue_username"), "DEFAULT__MULTI__INST")
 
         # Minimal msg_hash — only required fields; optional fields use .get() defaults
         minimal_msg_hash = {
@@ -556,6 +567,137 @@ class TestInterfaceMicroservice(unittest.TestCase):
         handler.interface.cmd_target_enabled["INST"] = False
         result = handler.process_cmd(topic, msg_id, full_msg_hash, None)
         self.assertIsNone(result)
+
+    def test_process_cmd_supports_interface_directives(self):
+        """Directive messages on the CMD}INTERFACE topic: interface_details and
+        target_control (enable/disable and the error path)."""
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        self.addCleanup(im.shutdown)
+        handler = im.handler_thread
+        topic = "{DEFAULT__CMD}INTERFACE__INST_INT"
+        msg_id = f"{int(time.time() * 1000)}-0"
+
+        # interface_details returns the interface details as JSON
+        result = handler.process_cmd(topic, msg_id, {b"interface_details": b"1"}, None)
+        self.assertEqual(json.loads(result)["name"], "INST_INT")
+
+        # target_control disable turns off both cmd and tlm for the target
+        disable = json.dumps(
+            {"target_name": "INST", "cmd_only": False, "tlm_only": False, "action": "disable"}
+        ).encode()
+        self.assertEqual(handler.process_cmd(topic, msg_id, {b"target_control": disable}, None), "SUCCESS")
+        self.assertFalse(im.interface.cmd_target_enabled["INST"])
+        self.assertFalse(im.interface.tlm_target_enabled["INST"])
+
+        # target_control enable turns them back on
+        enable = json.dumps({"target_name": "INST", "cmd_only": False, "tlm_only": False, "action": "enable"}).encode()
+        self.assertEqual(handler.process_cmd(topic, msg_id, {b"target_control": enable}, None), "SUCCESS")
+        self.assertTrue(im.interface.cmd_target_enabled["INST"])
+        self.assertTrue(im.interface.tlm_target_enabled["INST"])
+
+        # target_control with invalid JSON returns the error message (not SUCCESS)
+        result = handler.process_cmd(topic, msg_id, {b"target_control": b"not json"}, None)
+        self.assertNotEqual(result, "SUCCESS")
+
+        # A raw write while not connected reports that
+        result = handler.process_cmd(topic, msg_id, {b"raw": b"\x00\x01"}, None)
+        self.assertEqual(result, "Interface not connected: INST_INT")
+
+        # interface_cmd / protocol_cmd / inject_tlm error paths return the error
+        self.assertNotEqual(handler.process_cmd(topic, msg_id, {b"interface_cmd": b"{}"}, None), "SUCCESS")
+        self.assertNotEqual(handler.process_cmd(topic, msg_id, {b"protocol_cmd": b"{}"}, None), "SUCCESS")
+        self.assertNotEqual(handler.process_cmd(topic, msg_id, {b"inject_tlm": b"not valid"}, None), "SUCCESS")
+
+    def test_process_cmd_connected_interface_directives(self):
+        """Raw write and stream logging directives against a connected interface."""
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        thread = threading.Thread(target=im.run)
+        thread.start()
+        self.addCleanup(thread.join, 5)
+        self.addCleanup(im.shutdown)
+        time.sleep(0.1)
+
+        handler = im.handler_thread
+        topic = "{DEFAULT__CMD}INTERFACE__INST_INT"
+        msg_id = f"{int(time.time() * 1000)}-0"
+
+        # Raw write to a connected interface results in an UNKNOWN packet
+        self.assertEqual(handler.process_cmd(topic, msg_id, {b"raw": b"\x00\x01\x02\x03"}, None), "SUCCESS")
+
+        # Enable then disable stream logging
+        self.assertEqual(handler.process_cmd(topic, msg_id, {b"log_stream": b"true"}, None), "SUCCESS")
+        self.assertEqual(handler.process_cmd(topic, msg_id, {b"log_stream": b"false"}, None), "SUCCESS")
+
+    def test_process_cmd_command_error_and_hazardous_branches(self):
+        """Hazardous check, invalid command, and not-connected branches — none
+        of which require the interface to be connected."""
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        self.addCleanup(im.shutdown)
+        handler = im.handler_thread
+        topic = "{DEFAULT__CMD}TARGET__INST"
+        msg_id = f"{int(time.time() * 1000)}-0"
+
+        # CLEAR is HAZARDOUS: with hazardous_check enabled it returns a HazardousError
+        result = handler.process_cmd(
+            topic,
+            msg_id,
+            {
+                b"target_name": b"INST",
+                b"cmd_name": b"CLEAR",
+                b"cmd_params": json.dumps({}).encode(),
+                b"hazardous_check": b"TRUE",
+                b"cmd_string": b"cmd('INST CLEAR')",
+            },
+            None,
+        )
+        self.assertTrue(result.startswith("HazardousError"))
+
+        # Neither cmd_params nor cmd_buffer present raises "Invalid command received"
+        result = handler.process_cmd(topic, msg_id, {b"target_name": b"INST", b"cmd_name": b"ABORT"}, None)
+        self.assertIn("Invalid command received", result)
+
+        # A valid command while the interface is not connected reports that
+        result = handler.process_cmd(
+            topic,
+            msg_id,
+            {
+                b"target_name": b"INST",
+                b"cmd_name": b"ABORT",
+                b"cmd_params": json.dumps({}).encode(),
+                b"hazardous_check": b"FALSE",
+            },
+            None,
+        )
+        self.assertEqual(result, "Interface not connected: INST_INT")
+
+    def test_process_cmd_identifies_a_cmd_buffer(self):
+        """A command sent as a raw cmd_buffer is identified and written to the
+        connected interface."""
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        thread = threading.Thread(target=im.run)
+        thread.start()
+        self.addCleanup(thread.join, 5)
+        self.addCleanup(im.shutdown)
+        time.sleep(0.1)
+
+        handler = im.handler_thread
+        topic = "{DEFAULT__CMD}TARGET__INST"
+        msg_id = f"{int(time.time() * 1000)}-0"
+
+        abort = System.commands.build_cmd("INST", "ABORT")
+        result = handler.process_cmd(
+            topic,
+            msg_id,
+            {
+                b"target_name": b"INST",
+                b"cmd_name": b"ABORT",
+                b"cmd_buffer": abort.buffer,
+                b"cmd_string": b"cmd('INST ABORT')",
+                b"username": b"test_user",
+            },
+            None,
+        )
+        self.assertEqual(result, "SUCCESS")
 
     def test_run_does_not_write_status_after_cancel_thread_set(self):
         """When stop() sets cancel_thread, disconnect() and run() must not

--- a/openc3/python/test/microservices/test_router_microservice.py
+++ b/openc3/python/test/microservices/test_router_microservice.py
@@ -1,0 +1,265 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+import threading
+import time
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import *
+
+from openc3.interfaces.interface import Interface
+from openc3.microservices.router_microservice import RouterMicroservice
+from openc3.models.cvt_model import CvtModel
+from openc3.models.microservice_model import MicroserviceModel
+from openc3.models.router_model import RouterModel
+from openc3.models.router_status_model import RouterStatusModel
+from openc3.models.target_model import TargetModel
+from openc3.packets.packet import Packet
+from openc3.system.system import System
+from openc3.topics.router_topic import RouterTopic
+from openc3.topics.telemetry_topic import TelemetryTopic
+from openc3.topics.topic import Topic
+from test.test_helper import *
+
+
+# A router uses an Interface instance for its underlying connection, so we reuse
+# the same simple test interface used by the interface microservice tests.
+class MyInterface(Interface):
+    def __init__(self, hostname="default", port=12345):
+        self.hostname = hostname
+        self.port = port
+        self._connected = False
+        self.connect_count = 0
+        self.disconnect_count = 0
+        self.disconnect_delay = 0
+        self.written_packets = []
+        super().__init__()
+
+    def connect(self):
+        self.connect_count += 1
+        time.sleep(0.001)
+        super().connect()
+        self.data = b"\x00"
+        self._connected = True
+
+    def connected(self):
+        return self._connected
+
+    def disconnect(self):
+        time.sleep(0.001)
+        self.disconnect_count += 1
+        self.data = None
+        self._connected = False
+        super().disconnect()
+
+    def read_interface(self):
+        time.sleep(0.01)
+        return self.data, None
+
+    def write_interface(self, data, extra=None):
+        return data, extra
+
+    def write(self, packet):
+        self.written_packets.append(packet)
+
+    def interface_cmd(self, cmd_name, *cmd_args):
+        self.interface_cmd_name = cmd_name
+        self.interface_cmd_args = cmd_args
+
+    def protocol_cmd(self, cmd_name, *cmd_args, read_write="READ_WRITE", index=-1):
+        self.protocol_cmd_name = cmd_name
+        self.protocol_cmd_args = cmd_args
+        self.protocol_read_write = read_write
+        self.protocol_index = index
+
+
+class TestRouterMicroservice(unittest.TestCase):
+    def setUp(self):
+        mock_redis(self)
+        setup_system()
+
+        model = TargetModel(folder_name="INST", name="INST", scope="DEFAULT")
+        model.create()
+
+        packet = System.telemetry.packet("INST", "HEALTH_STATUS")
+        packet.received_time = datetime.now(timezone.utc)
+        packet.stored = False
+        packet.check_limits()
+        TelemetryTopic.write_packet(packet, scope="DEFAULT")
+        time.sleep(0.01)
+
+        mock_system = Mock(System)
+        self.patch_system = patch("openc3.system.system.System", return_value=mock_system)
+        self.patch_system.start()
+        self.addCleanup(self.patch_system.stop)
+
+        # RouterModel.build() resolves the interface class through interface_model
+        self.patch_get_class = patch(
+            "openc3.models.interface_model.get_class_from_module",
+            return_value=MyInterface,
+        )
+        self.patch_get_class.start()
+        self.addCleanup(self.patch_get_class.stop)
+
+        model = RouterModel(
+            name="TEST_INT",
+            scope="DEFAULT",
+            target_names=["INST"],
+            cmd_target_names=["INST"],
+            tlm_target_names=["INST"],
+            config_params=["test_interface.py"],
+        )
+        model.create()
+        model = MicroserviceModel(
+            folder_name="TEST",
+            name="DEFAULT__ROUTER__TEST_INT",
+            scope="DEFAULT",
+            target_names=["INST"],
+        )
+        model.create()
+
+        # Initialize the CVT so packet counts can be set
+        for _, packet in System.telemetry.packets("INST").items():
+            json_hash = CvtModel.build_json_from_packet(packet)
+            CvtModel.set(json_hash, packet.target_name, packet.packet_name, scope="DEFAULT")
+
+    def _run(self, im):
+        """Start the router read loop and register cleanup (LIFO: shutdown then join)."""
+        thread = threading.Thread(target=im.run)
+        thread.start()
+        self.addCleanup(thread.join, 5)
+        self.addCleanup(im.shutdown)
+        time.sleep(0.2)  # Allow connect + handler thread startup
+        return thread
+
+    def test_creates_a_router_updates_status_and_starts_tlm_thread(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self.assertEqual(im.config["name"], "DEFAULT__ROUTER__TEST_INT")
+        self.assertEqual(im.interface.name, "TEST_INT")
+        self.assertEqual(im.interface.state, "ATTEMPTING")
+        self.assertEqual(im.interface.target_names, ["INST"])
+        self.assertEqual(im.interface.cmd_target_names, ["INST"])
+        self.assertEqual(im.interface.tlm_target_names, ["INST"])
+
+        data = RouterStatusModel.all(scope="DEFAULT")
+        self.assertEqual(data["TEST_INT"]["name"], "TEST_INT")
+        self.assertEqual(data["TEST_INT"]["state"], "ATTEMPTING")
+
+        # The router telemetry handler thread is created and running. We check the
+        # handler thread directly rather than the global thread count because the
+        # metrics thread is a process-wide singleton, so the delta depends on test
+        # ordering across the full suite.
+        self.assertIsNotNone(im.handler_thread)
+        self.assertTrue(im.handler_thread.thread.is_alive())
+
+        # Shutdown cleanly stops the handler thread (the blocking read loop unwinds)
+        im.shutdown()
+        im.handler_thread.thread.join(5)  # Wait for the handler to exit (no fixed sleep race)
+        self.assertFalse(im.handler_thread.thread.is_alive())
+
+    def test_supports_router_cmd(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self._run(im)
+        data = RouterStatusModel.all(scope="DEFAULT")
+        self.assertEqual(data["TEST_INT"]["state"], "CONNECTED")
+
+        RouterTopic.router_cmd("TEST_INT", "DO_THE_THING", "PARAM1", 2, scope="DEFAULT")
+        time.sleep(0.2)
+        self.assertEqual("DO_THE_THING", im.interface.interface_cmd_name)
+        self.assertEqual(("PARAM1", 2), im.interface.interface_cmd_args)
+
+    def test_supports_protocol_cmd(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self._run(im)
+
+        RouterTopic.protocol_cmd(
+            "TEST_INT", "DO_THE_OTHER_THING", "PARAM2", 3, read_write="READ", index=1, scope="DEFAULT"
+        )
+        time.sleep(0.2)
+        self.assertEqual("DO_THE_OTHER_THING", im.interface.protocol_cmd_name)
+        self.assertEqual(("PARAM2", 3), im.interface.protocol_cmd_args)
+        self.assertEqual("READ", im.interface.protocol_read_write)
+        self.assertEqual(1, im.interface.protocol_index)
+
+    def test_supports_target_control(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self._run(im)
+
+        RouterTopic.router_target_disable("TEST_INT", "INST", scope="DEFAULT")
+        time.sleep(0.2)
+        self.assertFalse(im.interface.cmd_target_enabled["INST"])
+        self.assertFalse(im.interface.tlm_target_enabled["INST"])
+
+        RouterTopic.router_target_enable("TEST_INT", "INST", scope="DEFAULT")
+        time.sleep(0.2)
+        self.assertTrue(im.interface.cmd_target_enabled["INST"])
+        self.assertTrue(im.interface.tlm_target_enabled["INST"])
+
+    def test_supports_router_details(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self._run(im)
+
+        details = RouterTopic.router_details("TEST_INT", scope="DEFAULT", timeout=2.0)
+        self.assertEqual(details["name"], "TEST_INT")
+
+    def test_forwards_telemetry_to_the_router(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self._run(im)
+        data = RouterStatusModel.all(scope="DEFAULT")
+        self.assertEqual(data["TEST_INT"]["state"], "CONNECTED")
+
+        packet = System.telemetry.packet("INST", "HEALTH_STATUS")
+        packet.received_time = datetime.now(timezone.utc)
+        packet.received_count = 1
+        TelemetryTopic.write_packet(packet, scope="DEFAULT")
+        time.sleep(0.2)
+
+        # The telemetry handler saw the packet and forwarded it out the router
+        self.assertGreaterEqual(im.handler_thread.count, 1)
+        self.assertGreaterEqual(len(im.interface.written_packets), 1)
+
+    def test_handle_packet_routes_an_identified_command(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self._run(im)
+        im.interface.cmd_target_enabled["INST"] = True
+
+        command = System.commands.build_cmd("INST", "ABORT")
+        Topic.update_topic_offsets(["{DEFAULT__CMD}TARGET__INST"])
+        im.handle_packet(command)
+
+        # The command was routed to the target command topic
+        found = False
+        for _, _, msg_hash, _ in Topic.read_topics(["{DEFAULT__CMD}TARGET__INST"]):
+            if msg_hash[b"target_name"].decode() == "INST" and msg_hash[b"cmd_name"].decode() == "ABORT":
+                found = True
+        self.assertTrue(found)
+
+    def test_router_directive_disconnect_and_unknown(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self._run(im)
+
+        # An unrecognized router directive falls through to SUCCESS without error
+        Topic.write_topic("{DEFAULT__CMD}ROUTER__TEST_INT", {"unknown": "1"}, "*", 100)
+        time.sleep(0.2)
+
+        # Disconnect directive disconnects the underlying interface
+        RouterTopic.disconnect_router("TEST_INT", scope="DEFAULT")
+        time.sleep(0.2)
+        self.assertGreaterEqual(im.interface.disconnect_count, 1)
+
+    def test_handle_packet_ignores_a_disabled_unidentified_packet(self):
+        im = RouterMicroservice("DEFAULT__ROUTER__TEST_INT")
+        self._run(im)
+
+        # An unidentified packet maps to UNKNOWN which is not cmd enabled, so it
+        # is not routed and does not raise
+        packet = Packet(None, None, "BIG_ENDIAN")
+        im.handle_packet(packet)

--- a/openc3/spec/microservices/interface_microservice_spec.rb
+++ b/openc3/spec/microservices/interface_microservice_spec.rb
@@ -266,19 +266,29 @@ module OpenC3
         all = InterfaceStatusModel.all(scope: "DEFAULT")
         expect(all["INST_INT"]["state"]).to eql("ATTEMPTING")
 
-        expect(CommandDecomTopic).to receive(:write_packet) do |command, scope|
-          expect(command.target_name).to eql("INST")
-          expect(command.packet_name).to eql("ABORT")
-          expect(scope).to eql({:scope => "DEFAULT"})
+        # Capture the command in the main thread so the expectations reliably
+        # fail the example rather than raising inside the interface thread
+        # (RSpec's ExpectationNotMetError is not a StandardError and would be
+        # swallowed when the interface thread dies).
+        captured = nil
+        allow(CommandDecomTopic).to receive(:write_packet) do |command, _scope|
+          captured = command
         end
         Thread.new { im.run }
         sleep 0.01
         all = InterfaceStatusModel.all(scope: "DEFAULT")
         expect(all["INST_INT"]["state"]).to eql "CONNECTED"
 
-        @api.cmd("INST", "ABORT")
+        # queue_username is the original author (shown as "Queued By"), passed
+        # by the queue microservice when a command is released from a queue
+        @api.cmd("INST", "ABORT", queue_username: "DEFAULT__MULTI__INST")
         sleep 0.01
         im.shutdown
+
+        expect(captured).to_not be_nil
+        expect(captured.target_name).to eql("INST")
+        expect(captured.packet_name).to eql("ABORT")
+        expect(captured.extra['queue_username']).to eql("DEFAULT__MULTI__INST")
       end
 
       it "handles obfuscated params" do


### PR DESCRIPTION
The Python interface microservice never copied queue_username into the command extra, so Command History showed no "Queued By" for commands sent through Python targets (the Ruby path in interface_microservice.rb did). Also fix two Ruby-port bugs in RouterTlmHandlerThread found while adding router tests: router_cmd/protocol_cmd crashed joining non-string params, and the shutdown path blocked on another read before breaking so the handler thread never exited cleanly.

Add router microservice test harness and expand interface tests, raising interface_microservice.py coverage from 59% to 80%. Harden both test_creates thread assertions to check the handler thread directly (join on shutdown) rather than a flaky global thread count.

closes https://github.com/OpenC3/cosmos-enterprise/issues/664