### PR TITLE
UV per plugin venv add scope to name

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -213,7 +213,6 @@
                     density="compact"
                     variant="outlined"
                     hide-details
-                    clearable
                     style="max-width: 200px; min-width: 160px"
                     class="mr-2"
                     data-test="python-venv-select"

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -2631,6 +2631,7 @@ export default {
       this.suiteRunner = false
       this.startOrGoDisabled = false
       this.envDisabled = false
+      this.pythonVenv = 'system'
       if (!this.inline) {
         this.$router
           .replace({
@@ -2836,6 +2837,7 @@ class TestSuite(Suite):
       // so the selection persists across runs.
       if (!newFilename.startsWith(TEMP_FOLDER)) {
         this.pythonVenv = null
+        this.tempFilename = null
       }
       if (!this.inline) {
         // Update the URL with the filename

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe RunningScript, type: :model do
         target_info = {'plugin' => 'my-demo-plugin__0'}
         allow(OpenC3::TargetModel).to receive(:get).with(name: "INST", scope: "DEFAULT").and_return(target_info)
 
-        sanitized_name = "my-demo-plugin__0"
+        sanitized_name = "DEFAULT__my-demo-plugin__0"
         venv_dir = "/gems/plugin_venvs/#{sanitized_name}/.venv"
         allow(File).to receive(:directory?).and_call_original
         allow(File).to receive(:directory?).with(venv_dir).and_return(true)
@@ -172,7 +172,7 @@ RSpec.describe RunningScript, type: :model do
         target_info = {'plugin' => 'my-plugin__0'}
         allow(OpenC3::TargetModel).to receive(:get).with(name: "INST", scope: "DEFAULT").and_return(target_info)
 
-        venv_dir = "/gems/plugin_venvs/my-plugin__0/.venv"
+        venv_dir = "/gems/plugin_venvs/DEFAULT__my-plugin__0/.venv"
         allow(File).to receive(:directory?).and_call_original
         allow(File).to receive(:directory?).with(venv_dir).and_return(false)
 

--- a/openc3/lib/openc3/models/microservice_model.rb
+++ b/openc3/lib/openc3/models/microservice_model.rb
@@ -146,7 +146,7 @@ module OpenC3
       python_bin = ENV['OPENC3_PYTHON_BIN'] || '/openc3/python/.venv/bin/python'
       result = { 'OPENC3_PYTHON_BIN' => python_bin }
       if @needs_dependencies && @plugin
-        sanitized_name = @plugin.tr('^a-zA-Z0-9_-', '_')
+        sanitized_name = "#{@scope}__#{@plugin}".tr('^a-zA-Z0-9_-', '_')
         candidate = "/gems/plugin_venvs/#{sanitized_name}/.venv"
         if File.directory?(candidate)
           result['VIRTUAL_ENV'] = candidate

--- a/openc3/lib/openc3/models/plugin_model.rb
+++ b/openc3/lib/openc3/models/plugin_model.rb
@@ -261,7 +261,7 @@ module OpenC3
             # which installs into PYTHONUSERBASE (the legacy shared environment).
             uv_installed = ENV['OPENC3_USE_UV'] != 'false' && system('which uv > /dev/null 2>&1')
             if uv_installed
-              plugin_venv_name = plugin_model.name.tr('^a-zA-Z0-9_-', '_')
+              plugin_venv_name = "#{scope}__#{plugin_model.name}".tr('^a-zA-Z0-9_-', '_')
               Logger.info "Installing python packages into per-plugin venv '#{plugin_venv_name}' with pypi_url=#{pypi_url}"
               uv_args = [plugin_venv_name, gem_path] + pypi_args
               output, status = Open3.capture2e("/openc3/bin/uvinstall", *uv_args)
@@ -486,7 +486,7 @@ module OpenC3
       # during install_phase2. This cleans up the .venv, pyproject.toml, uv.lock,
       # and .uv_managed marker so disk space is reclaimed on plugin uninstall.
       begin
-        plugin_venv_name = @name.tr('^a-zA-Z0-9_-', '_')
+        plugin_venv_name = "#{@scope}__#{@name}".tr('^a-zA-Z0-9_-', '_')
         plugin_venv_path = File.join('/gems', 'plugin_venvs', plugin_venv_name)
         if File.directory?(plugin_venv_path)
           Logger.info("Removing per-plugin Python venv: #{plugin_venv_path}")
@@ -572,7 +572,7 @@ module OpenC3
     def needs_uv_migration?
       return false unless @needs_dependencies
 
-      plugin_venv_name = @name.tr('^a-zA-Z0-9_-', '_')
+      plugin_venv_name = "#{@scope}__#{@name}".tr('^a-zA-Z0-9_-', '_')
       marker_path = File.join('/gems', 'plugin_venvs', plugin_venv_name, '.uv_managed')
       !File.exist?(marker_path)
     end
@@ -581,7 +581,7 @@ module OpenC3
     # Non-fatal: logs a warning on failure, plugin continues using the shared venv.
     # Returns true on success, false on failure.
     def migrate_to_uv!(scope:)
-      plugin_venv_name = @name.tr('^a-zA-Z0-9_-', '_')
+      plugin_venv_name = "#{@scope}__#{@name}".tr('^a-zA-Z0-9_-', '_')
       marker_path = File.join('/gems', 'plugin_venvs', plugin_venv_name, '.uv_managed')
       if File.exist?(marker_path)
         Logger.info("Plugin '#{@name}' is already migrated to a per-plugin UV venv")
@@ -612,7 +612,7 @@ module OpenC3
         pypi_args = self.class.build_pypi_args(pypi_url)
 
         # Run uvinstall for this plugin
-        plugin_venv_name = @name.tr('^a-zA-Z0-9_-', '_')
+        plugin_venv_name = "#{@scope}__#{@name}".tr('^a-zA-Z0-9_-', '_')
         Logger.info("Migrating plugin '#{@name}' to per-plugin UV venv '#{plugin_venv_name}'")
         uv_args = [plugin_venv_name, gem_path] + pypi_args
         output, status = Open3.capture2e("/openc3/bin/uvinstall", *uv_args)

--- a/openc3/lib/openc3/models/plugin_model.rb
+++ b/openc3/lib/openc3/models/plugin_model.rb
@@ -261,7 +261,7 @@ module OpenC3
             # which installs into PYTHONUSERBASE (the legacy shared environment).
             uv_installed = ENV['OPENC3_USE_UV'] != 'false' && system('which uv > /dev/null 2>&1')
             if uv_installed
-              plugin_venv_name = "#{scope}__#{plugin_model.name}".tr('^a-zA-Z0-9_-', '_')
+              plugin_venv_name = plugin_venv_name(scope: scope, plugin_name: plugin_model.name)
               Logger.info "Installing python packages into per-plugin venv '#{plugin_venv_name}' with pypi_url=#{pypi_url}"
               uv_args = [plugin_venv_name, gem_path] + pypi_args
               output, status = Open3.capture2e("/openc3/bin/uvinstall", *uv_args)
@@ -486,7 +486,7 @@ module OpenC3
       # during install_phase2. This cleans up the .venv, pyproject.toml, uv.lock,
       # and .uv_managed marker so disk space is reclaimed on plugin uninstall.
       begin
-        plugin_venv_name = "#{@scope}__#{@name}".tr('^a-zA-Z0-9_-', '_')
+        plugin_venv_name = self.class.plugin_venv_name(scope: @scope, plugin_name: @name)
         plugin_venv_path = File.join('/gems', 'plugin_venvs', plugin_venv_name)
         if File.directory?(plugin_venv_path)
           Logger.info("Removing per-plugin Python venv: #{plugin_venv_path}")
@@ -567,12 +567,18 @@ module OpenC3
       args
     end
 
+    # Build a sanitized venv directory name from scope and plugin name.
+    # Replaces characters that are not alphanumeric, underscore, or hyphen with underscores.
+    def self.plugin_venv_name(scope:, plugin_name:)
+      "#{scope}__#{plugin_name}".tr('^a-zA-Z0-9_-', '_')
+    end
+
     # Check if this plugin needs migration to a per-plugin UV virtual environment.
     # Returns true if the plugin has Python dependencies but no .uv_managed marker exists.
     def needs_uv_migration?
       return false unless @needs_dependencies
 
-      plugin_venv_name = "#{@scope}__#{@name}".tr('^a-zA-Z0-9_-', '_')
+      plugin_venv_name = self.class.plugin_venv_name(scope: @scope, plugin_name: @name)
       marker_path = File.join('/gems', 'plugin_venvs', plugin_venv_name, '.uv_managed')
       !File.exist?(marker_path)
     end
@@ -581,7 +587,7 @@ module OpenC3
     # Non-fatal: logs a warning on failure, plugin continues using the shared venv.
     # Returns true on success, false on failure.
     def migrate_to_uv!(scope:)
-      plugin_venv_name = "#{@scope}__#{@name}".tr('^a-zA-Z0-9_-', '_')
+      plugin_venv_name = self.class.plugin_venv_name(scope: scope, plugin_name: @name)
       marker_path = File.join('/gems', 'plugin_venvs', plugin_venv_name, '.uv_managed')
       if File.exist?(marker_path)
         Logger.info("Plugin '#{@name}' is already migrated to a per-plugin UV venv")
@@ -612,7 +618,7 @@ module OpenC3
         pypi_args = self.class.build_pypi_args(pypi_url)
 
         # Run uvinstall for this plugin
-        plugin_venv_name = "#{@scope}__#{@name}".tr('^a-zA-Z0-9_-', '_')
+        plugin_venv_name = self.class.plugin_venv_name(scope: @scope, plugin_name: @name)
         Logger.info("Migrating plugin '#{@name}' to per-plugin UV venv '#{plugin_venv_name}'")
         uv_args = [plugin_venv_name, gem_path] + pypi_args
         output, status = Open3.capture2e("/openc3/bin/uvinstall", *uv_args)

--- a/openc3/lib/openc3/operators/microservice_operator.rb
+++ b/openc3/lib/openc3/operators/microservice_operator.rb
@@ -55,7 +55,8 @@ module OpenC3
         plugin_name = microservice_config["plugin"]
         plugin_venv_dir = nil
         if plugin_name
-          sanitized_name = plugin_name.tr('^a-zA-Z0-9_-', '_')
+          scope = microservice_name.split("__")[0]
+          sanitized_name = "#{scope}__#{plugin_name}".tr('^a-zA-Z0-9_-', '_')
           candidate = "/gems/plugin_venvs/#{sanitized_name}/.venv"
           plugin_venv_dir = candidate if File.directory?(candidate)
         end

--- a/openc3/lib/openc3/utilities/running_script.rb
+++ b/openc3/lib/openc3/utilities/running_script.rb
@@ -564,7 +564,7 @@ class RunningScript
       else
         target_info = OpenC3::TargetModel.get(name: target_name, scope: scope)
         if target_info && target_info['plugin']
-          sanitized_name = target_info['plugin'].tr('^a-zA-Z0-9_-', '_')
+          sanitized_name = "#{scope}__#{target_info['plugin']}".tr('^a-zA-Z0-9_-', '_')
           candidate = "/gems/plugin_venvs/#{sanitized_name}/.venv"
           python_venv_dir = candidate if File.directory?(candidate)
         end

--- a/openc3/spec/models/microservice_model_spec.rb
+++ b/openc3/spec/models/microservice_model_spec.rb
@@ -288,5 +288,46 @@ module OpenC3
         expect(config[0][1]['plugin']).to eql 'PLUGIN'
       end
     end
+
+    describe "runtime_python_env" do
+      it "sets per-plugin venv env vars when plugin venv directory exists" do
+        model = MicroserviceModel.new(
+          folder_name: "TEST", name: "DEFAULT__TYPE__NAME",
+          scope: "DEFAULT", plugin: "my-plugin__0", needs_dependencies: true
+        )
+        venv_dir = "/gems/plugin_venvs/DEFAULT__my-plugin__0/.venv"
+        allow(File).to receive(:directory?).with(venv_dir).and_return(true)
+        allow(Dir).to receive(:glob).with("#{venv_dir}/lib/python*/site-packages").and_return(["#{venv_dir}/lib/python3.12/site-packages"])
+
+        env = model.runtime_python_env
+        expect(env['VIRTUAL_ENV']).to eq(venv_dir)
+        expect(env['PYTHONUSERBASE']).to eq(venv_dir)
+        expect(env['PYTHONPATH']).to eq("#{venv_dir}/lib/python3.12/site-packages")
+      end
+
+      it "falls back to shared python_packages when no plugin venv exists" do
+        model = MicroserviceModel.new(
+          folder_name: "TEST", name: "DEFAULT__TYPE__NAME",
+          scope: "DEFAULT", plugin: "my-plugin__0", needs_dependencies: true
+        )
+        venv_dir = "/gems/plugin_venvs/DEFAULT__my-plugin__0/.venv"
+        allow(File).to receive(:directory?).with(venv_dir).and_return(false)
+
+        env = model.runtime_python_env
+        expect(env['VIRTUAL_ENV']).to be_nil
+        expect(env['PYTHONUSERBASE']).to eq('/gems/python_packages')
+      end
+
+      it "does not set venv vars when needs_dependencies is false" do
+        model = MicroserviceModel.new(
+          folder_name: "TEST", name: "DEFAULT__TYPE__NAME",
+          scope: "DEFAULT", plugin: "my-plugin__0", needs_dependencies: false
+        )
+
+        env = model.runtime_python_env
+        expect(env['VIRTUAL_ENV']).to be_nil
+        expect(env['PYTHONUSERBASE']).to be_nil
+      end
+    end
   end
 end

--- a/openc3/spec/models/plugin_model_spec.rb
+++ b/openc3/spec/models/plugin_model_spec.rb
@@ -672,7 +672,7 @@ module OpenC3
 
       it "removes per-plugin Python venv directory when it exists" do
         plugin = PluginModel.new(name: "PLUG", scope: "DEFAULT")
-        venv_path = '/gems/plugin_venvs/PLUG'
+        venv_path = '/gems/plugin_venvs/DEFAULT__PLUG'
         expect(File).to receive(:directory?).with(venv_path).and_return(true)
         expect(FileUtils).to receive(:rm_rf).with(venv_path)
         plugin.undeploy
@@ -680,7 +680,7 @@ module OpenC3
 
       it "does not error when per-plugin Python venv directory does not exist" do
         plugin = PluginModel.new(name: "PLUG", scope: "DEFAULT")
-        venv_path = '/gems/plugin_venvs/PLUG'
+        venv_path = '/gems/plugin_venvs/DEFAULT__PLUG'
         expect(File).to receive(:directory?).with(venv_path).and_return(false)
         expect(FileUtils).not_to receive(:rm_rf).with(venv_path)
         expect { plugin.undeploy }.not_to raise_error
@@ -688,7 +688,7 @@ module OpenC3
 
       it "sanitizes plugin name for venv directory path" do
         plugin = PluginModel.new(name: "my.plugin@1.0__0", scope: "DEFAULT")
-        sanitized_path = '/gems/plugin_venvs/my_plugin_1_0__0'
+        sanitized_path = '/gems/plugin_venvs/DEFAULT__my_plugin_1_0__0'
         expect(File).to receive(:directory?).with(sanitized_path).and_return(true)
         expect(FileUtils).to receive(:rm_rf).with(sanitized_path)
         plugin.undeploy
@@ -822,19 +822,19 @@ module OpenC3
 
       it "returns true when needs_dependencies is true and .uv_managed marker is absent" do
         model = PluginModel.new(name: "TEST", needs_dependencies: true, scope: "DEFAULT")
-        allow(File).to receive(:exist?).with('/gems/plugin_venvs/TEST/.uv_managed').and_return(false)
+        allow(File).to receive(:exist?).with('/gems/plugin_venvs/DEFAULT__TEST/.uv_managed').and_return(false)
         expect(model.needs_uv_migration?).to be true
       end
 
       it "returns false when .uv_managed marker exists" do
         model = PluginModel.new(name: "TEST", needs_dependencies: true, scope: "DEFAULT")
-        allow(File).to receive(:exist?).with('/gems/plugin_venvs/TEST/.uv_managed').and_return(true)
+        allow(File).to receive(:exist?).with('/gems/plugin_venvs/DEFAULT__TEST/.uv_managed').and_return(true)
         expect(model.needs_uv_migration?).to be false
       end
 
       it "sanitizes plugin name for marker path" do
         model = PluginModel.new(name: "my.plugin@1.0", needs_dependencies: true, scope: "DEFAULT")
-        allow(File).to receive(:exist?).with('/gems/plugin_venvs/my_plugin_1_0/.uv_managed').and_return(false)
+        allow(File).to receive(:exist?).with('/gems/plugin_venvs/DEFAULT__my_plugin_1_0/.uv_managed').and_return(false)
         expect(model.needs_uv_migration?).to be true
       end
     end
@@ -842,7 +842,7 @@ module OpenC3
     describe "migrate_to_uv!" do
       it "returns true immediately when already migrated (marker exists)" do
         model = PluginModel.new(name: "TEST__0", needs_dependencies: true, scope: "DEFAULT")
-        allow(File).to receive(:exist?).with('/gems/plugin_venvs/TEST__0/.uv_managed').and_return(true)
+        allow(File).to receive(:exist?).with('/gems/plugin_venvs/DEFAULT__TEST__0/.uv_managed').and_return(true)
         expect(model.migrate_to_uv!(scope: "DEFAULT")).to be true
       end
 
@@ -852,7 +852,7 @@ module OpenC3
 
         # Marker doesn't exist
         allow(File).to receive(:exist?).and_call_original
-        allow(File).to receive(:exist?).with('/gems/plugin_venvs/TEST__0/.uv_managed').and_return(false)
+        allow(File).to receive(:exist?).with('/gems/plugin_venvs/DEFAULT__TEST__0/.uv_managed').and_return(false)
 
         # GemModel.get returns a path
         expect(GemModel).to receive(:get).with("TEST").and_return("/gems/cache/test.gem")
@@ -882,7 +882,7 @@ module OpenC3
         model.create
 
         allow(File).to receive(:exist?).and_call_original
-        allow(File).to receive(:exist?).with('/gems/plugin_venvs/TEST__0/.uv_managed').and_return(false)
+        allow(File).to receive(:exist?).with('/gems/plugin_venvs/DEFAULT__TEST__0/.uv_managed').and_return(false)
 
         expect(GemModel).to receive(:get).with("TEST").and_return("/gems/cache/test.gem")
 
@@ -909,7 +909,7 @@ module OpenC3
         model.create
 
         allow(File).to receive(:exist?).and_call_original
-        allow(File).to receive(:exist?).with('/gems/plugin_venvs/TEST__0/.uv_managed').and_return(false)
+        allow(File).to receive(:exist?).with('/gems/plugin_venvs/DEFAULT__TEST__0/.uv_managed').and_return(false)
 
         expect(GemModel).to receive(:get).with("TEST").and_return("/gems/cache/test.gem")
 
@@ -926,7 +926,7 @@ module OpenC3
         model.create
 
         allow(File).to receive(:exist?).and_call_original
-        allow(File).to receive(:exist?).with('/gems/plugin_venvs/TEST__0/.uv_managed').and_return(false)
+        allow(File).to receive(:exist?).with('/gems/plugin_venvs/DEFAULT__TEST__0/.uv_managed').and_return(false)
 
         expect(GemModel).to receive(:get).with("TEST").and_return("/gems/cache/test.gem")
 

--- a/openc3/spec/operators/microservice_operator_spec.rb
+++ b/openc3/spec/operators/microservice_operator_spec.rb
@@ -57,7 +57,7 @@ module OpenC3
           "needs_dependencies" => true,
           "plugin" => "my-plugin__0"
         }
-        sanitized_name = "my-plugin__0"
+        sanitized_name = "DEFAULT__my-plugin__0"
         venv_dir = "/gems/plugin_venvs/#{sanitized_name}/.venv"
         allow(File).to receive(:directory?).with(venv_dir).and_return(true)
 
@@ -75,7 +75,7 @@ module OpenC3
           "needs_dependencies" => true,
           "plugin" => "my-plugin__0"
         }
-        venv_dir = "/gems/plugin_venvs/my-plugin__0/.venv"
+        venv_dir = "/gems/plugin_venvs/DEFAULT__my-plugin__0/.venv"
         allow(File).to receive(:directory?).with(venv_dir).and_return(false)
 
         _cmd, _work_dir, env, _scope, _container = @operator.convert_microservice_to_process_definition("DEFAULT__TYPE__NAME", config)
@@ -106,7 +106,7 @@ module OpenC3
           "plugin" => "my.plugin@1.0"
         }
         # tr('^a-zA-Z0-9_-', '_') converts dots and @ to underscores
-        sanitized_name = "my_plugin_1_0"
+        sanitized_name = "DEFAULT__my_plugin_1_0"
         venv_dir = "/gems/plugin_venvs/#{sanitized_name}/.venv"
         allow(File).to receive(:directory?).with(venv_dir).and_return(true)
 


### PR DESCRIPTION
- Prefix per-plugin Python venv directory names with scope (e.g. `DEFAULT__plugin-name`) to ensure uniqueness across scopes in all code paths: plugin install, uninstall, migration, microservice operator, and script runner                                                                                
- Fix script runner falling back to system venv when running saved target scripts because the venv lookup path didn't include the scope prefix
- Fix venv dropdown persisting after opening a saved target script due to stale `tempFilename` state from a previous run
- Remove `clearable` from venv dropdown since an empty selection is not valid
- Reset venv selection to `system` when creating a new script