### PR TITLE
fix(streaming-api): make websocket client subscribe before actions

### DIFF
--- a/docs.openc3.com/docs/development/streaming-api.md
+++ b/docs.openc3.com/docs/development/streaming-api.md
@@ -133,9 +133,59 @@ For raw packets, each packet is represented as a JSON object with a time field h
 ]
 ```
 
-## Ruby Example
+## Examples
 
-Below is a simple Ruby example for using the streaming API to retrieve telemetry data:
+Below is a simple example for using the streaming API to retrieve telemetry data:
+
+<Tabs groupId="script-language">
+<TabItem value="python" label="Python">
+
+```python
+import os
+from datetime import datetime, timedelta, timezone
+from openc3.script.web_socket_api import StreamingWebSocketApi
+from openc3.utilities.time import to_nsec_from_epoch
+
+os.environ["OPENC3_SCOPE"] = "DEFAULT"
+os.environ["OPENC3_API_HOSTNAME"] = "127.0.0.1"
+os.environ["OPENC3_API_PORT"] = "2900"
+os.environ["OPENC3_API_PASSWORD"] = "password"
+# The following are needed for Enterprise (change user/pass as necessary)
+# os.environ["OPENC3_API_USER"] = "operator"
+# os.environ["OPENC3_API_PASSWORD"] = "operator"
+# os.environ["OPENC3_KEYCLOAK_REALM"] = "openc3"
+# os.environ["OPENC3_KEYCLOAK_URL"] = "http://127.0.0.1:2900/auth"
+
+now = datetime.now(timezone.utc)
+# Open a file to write CSV data
+with open("telemetry_data.csv", "w") as csv:
+    # Connect to the streaming API
+    with StreamingWebSocketApi() as api:
+        # Add items to stream - request data from yesterday to 1 minute ago
+        api.add(
+            items=[
+                "DECOM__TLM__INST__HEALTH_STATUS__TEMP1__CONVERTED",
+                "DECOM__TLM__INST__HEALTH_STATUS__TEMP2__CONVERTED",
+            ],
+            start_time=to_nsec_from_epoch(now - timedelta(days=1)),  # 24 hours ago
+            end_time=to_nsec_from_epoch(now - timedelta(seconds=60)),  # 1 minute ago
+        )
+
+        # Write CSV header
+        csv.write("Time,TEMP1,TEMP2\n")
+
+        # Read all data from the stream
+        data = api.read()
+
+        # Process each data point
+        for item in data:
+            temp1 = item["DECOM__TLM__INST__HEALTH_STATUS__TEMP1__CONVERTED"]
+            temp2 = item["DECOM__TLM__INST__HEALTH_STATUS__TEMP2__CONVERTED"]
+            csv.write(f"{item['__time'] / 1_000_000_000.0},{temp1},{temp2}\n")
+```
+
+</TabItem>
+<TabItem value="ruby" label="Ruby">
 
 ```ruby
 require 'openc3'
@@ -177,6 +227,115 @@ OpenC3::StreamingWebSocketApi.new() do |api|
 end
 csv.close()
 ```
+
+</TabItem>
+</Tabs>
+
+## Wildcards and Globs
+
+The streaming API can expand a single request key into many concrete keys, so you don't have to enumerate every target, packet, or item yourself. Packet keys support the `COSMOS_ALL` wildcard; item keys support shell-style globs. Expansion happens server-side when the `add` (or `remove`) request is processed, and keys you are not authorized for are silently skipped.
+
+### COSMOS_ALL packet wildcard
+
+<span class="badge badge--secondary since-right">Since 7.0.0</span>
+
+Use `COSMOS_ALL` in a **packet** key (the `packets` array) in place of the target name, the packet name, or both:
+
+| Key form                                          | Expands to                      |
+| ------------------------------------------------- | ------------------------------- |
+| `MODE__CMDORTLM__COSMOS_ALL[__VALUETYPE]`         | Every packet of every target    |
+| `MODE__CMDORTLM__TARGET__COSMOS_ALL[__VALUETYPE]` | Every packet of a single target |
+
+When the **target** is `COSMOS_ALL`, the value type takes the packet-name position, e.g. `DECOM__TLM__COSMOS_ALL__CONVERTED` means "all telemetry packets of all targets, converted values". Omit the trailing value type to receive all value types as stored.
+
+Examples:
+
+- `DECOM__CMD__COSMOS_ALL__CONVERTED` — every command packet of every target (decommutated, converted)
+- `DECOM__TLM__COSMOS_ALL` — every telemetry packet of every target (all value types)
+- `RAW__TLM__INST__COSMOS_ALL` — every raw telemetry packet of the `INST` target
+- `DECOM__TLM__INST__COSMOS_ALL__CONVERTED` — every telemetry packet of `INST`, converted
+
+Notes:
+
+- The `UNKNOWN` target is skipped except in `RAW` mode.
+- `COSMOS_ALL` is only expanded in **packet** keys, not item keys.
+
+<Tabs groupId="script-language">
+<TabItem value="python" label="Python">
+
+```python
+from openc3.script.web_socket_api import StreamingWebSocketApi
+
+# Stream every command sent by any target, in realtime
+with StreamingWebSocketApi() as api:
+    api.add(packets=["DECOM__CMD__COSMOS_ALL__CONVERTED"])
+    while True:
+        for cmd in api.read():
+            print(cmd)
+```
+
+</TabItem>
+<TabItem value="ruby" label="Ruby">
+
+```ruby
+require 'openc3'
+require 'openc3/script/web_socket_api'
+
+# Stream every command sent by any target, in realtime
+OpenC3::StreamingWebSocketApi.new do |api|
+  api.add(packets: ['DECOM__CMD__COSMOS_ALL__CONVERTED'])
+  while true
+    api.read.each { |cmd| puts cmd }
+  end
+end
+```
+
+</TabItem>
+</Tabs>
+
+### Item globs
+
+<span class="badge badge--secondary since-right">Since 7.1.0</span>
+
+**Item** keys (the `items` array) may use shell-style glob patterns (`*`, `?`, `[...]`) in the packet-name and item-name positions. Matching is case-insensitive.
+
+Examples:
+
+- `DECOM__TLM__INST__HEALTH_STATUS__TEMP*__CONVERTED` — all items in `HEALTH_STATUS` whose name starts with `TEMP`
+- `DECOM__TLM__INST__*__RECEIVED_COUNT__CONVERTED` — the `RECEIVED_COUNT` item from every `INST` packet that has one
+- `DECOM__TLM__INST__LATEST__TEMP*__CONVERTED` — `LATEST` resolves each matching item to the packet that most recently updated it
+
+Array subscripts are treated literally: `ARY[0]` matches the element `ARY[0]`, while a range like `ARY[1-3]` is still interpreted as a glob character class.
+
+<Tabs groupId="script-language">
+<TabItem value="python" label="Python">
+
+```python
+from openc3.script.web_socket_api import StreamingWebSocketApi
+
+with StreamingWebSocketApi() as api:
+    api.add(items=["DECOM__TLM__INST__HEALTH_STATUS__TEMP*__CONVERTED"])
+    for _ in range(5):
+        print(api.read())
+```
+
+</TabItem>
+<TabItem value="ruby" label="Ruby">
+
+```ruby
+require 'openc3'
+require 'openc3/script/web_socket_api'
+
+OpenC3::StreamingWebSocketApi.new do |api|
+  api.add(items: ['DECOM__TLM__INST__HEALTH_STATUS__TEMP*__CONVERTED'])
+  5.times do
+    puts api.read
+  end
+end
+```
+
+</TabItem>
+</Tabs>
 
 ## StreamingApi Architecture
 

--- a/openc3/lib/openc3/script/web_socket_api.rb
+++ b/openc3/lib/openc3/script/web_socket_api.rb
@@ -22,7 +22,10 @@ module OpenC3
 
     # Create the WebsocketApi object. If a block is given will automatically connect/disconnect
     def initialize(url:, write_timeout: 10.0, read_timeout: 10.0, connect_timeout: 5.0, authentication: nil, scope: $openc3_scope, &block)
-      @scope = scope
+      # $openc3_scope is only set inside the Script Runner / microservice
+      # environment. Fall back to OPENC3_SCOPE (mirrors the Python client) so a
+      # bare `ruby script.rb` doesn't send a nil scope that the server rejects.
+      @scope = scope || ENV['OPENC3_SCOPE'] || 'DEFAULT'
       @authentication = authentication.nil? ? generate_auth() : authentication
       @url = url
       @write_timeout = write_timeout
@@ -100,6 +103,32 @@ module OpenC3
         json_hash['identifier'] = JSON.generate(@identifier, allow_nan: true)
         @stream.write(JSON.generate(json_hash, allow_nan: true))
         @subscribed = true
+        wait_for_subscribed()
+      end
+    end
+
+    # Block until the server confirms the subscription. ActionCable / anycable-go
+    # process 'subscribe' and 'message' commands as independent RPCs, so an action
+    # (add/remove) written immediately after subscribe can reach
+    # StreamingChannel#add before the subscription's broadcaster exists, where it
+    # is silently dropped (a no-op) and no data ever streams. Waiting for
+    # confirm_subscription guarantees the broadcaster is ready before any action
+    # is written.
+    def wait_for_subscribed
+      while true
+        message = @stream.read
+        raise "WebSocket closed before subscription was confirmed" if message.nil? || message.empty?
+
+        json_hash = JSON.parse(message, allow_nan: true, create_additions: true)
+        case json_hash['type']
+        when 'confirm_subscription'
+          return
+        when 'reject_subscription'
+          raise "Subscription Rejected"
+        when 'disconnect'
+          raise "Unauthorized" if json_hash['reason'] == 'unauthorized'
+        end
+        # Ignore welcome / ping and keep waiting for confirmation
       end
     end
 
@@ -116,6 +145,13 @@ module OpenC3
 
     # Send an ActionCable command
     def write_action(data_hash)
+      # Subscribe first so the token is present in @identifier before we
+      # serialize it below. ActionCable matches a 'message' command to its
+      # subscription by the exact identifier string; if subscribe() injected the
+      # token only afterward, the message identifier (no token) would not match
+      # the subscription identifier (with token) and the server would silently
+      # ignore the action.
+      subscribe()
       json_hash = {}
       json_hash['command'] = 'message'
       json_hash['identifier'] = JSON.generate(@identifier, allow_nan: true)
@@ -354,7 +390,8 @@ module OpenC3
     #   PACKET - Packet name
     #   VALUETYPE - RAW, CONVERTED, FORMATTED, or PURE (pure means all types as stored in log)
     #
-    def add(items: nil, packets: nil, start_time: nil, end_time: nil, scope: $openc3_scope)
+    def add(items: nil, packets: nil, start_time: nil, end_time: nil, scope: nil)
+      scope ||= @scope
       data_hash = {}
       data_hash['action'] = 'add'
       if start_time
@@ -395,7 +432,8 @@ module OpenC3
     #   PACKET - Packet name
     #   VALUETYPE - RAW, CONVERTED, FORMATTED, or PURE (pure means all types as stored in log)
     #
-    def remove(items: nil, packets: nil, scope: $openc3_scope)
+    def remove(items: nil, packets: nil, scope: nil)
+      scope ||= @scope
       data_hash = {}
       data_hash['action'] = 'remove'
       data_hash['items'] = items if items
@@ -407,7 +445,7 @@ module OpenC3
 
     # Convenience method to read all data until end marker is received.
     # Warning: DATA IS STORED IN RAM.  Do not use this with large queries
-    def self.read_all(items: nil, packets: nil, start_time: nil, end_time:, scope: $openc3_scope, timeout: nil)
+    def self.read_all(items: nil, packets: nil, start_time: nil, end_time:, scope: nil, timeout: nil)
       read_all_start_time = Time.now
       data = []
       self.new do |api|

--- a/openc3/lib/openc3/script/web_socket_api.rb
+++ b/openc3/lib/openc3/script/web_socket_api.rb
@@ -25,7 +25,7 @@ module OpenC3
       # $openc3_scope is only set inside the Script Runner / microservice
       # environment. Fall back to OPENC3_SCOPE (mirrors the Python client) so a
       # bare `ruby script.rb` doesn't send a nil scope that the server rejects.
-      @scope = scope || ENV['OPENC3_SCOPE'] || 'DEFAULT'
+      @scope = scope || ENV.fetch('OPENC3_SCOPE', 'DEFAULT')
       @authentication = authentication.nil? ? generate_auth() : authentication
       @url = url
       @write_timeout = write_timeout
@@ -127,8 +127,10 @@ module OpenC3
           raise "Subscription Rejected"
         when 'disconnect'
           raise "Unauthorized" if json_hash['reason'] == 'unauthorized'
+        else
+          # Ignore welcome / ping and keep waiting for confirmation
+          next
         end
-        # Ignore welcome / ping and keep waiting for confirmation
       end
     end
 

--- a/openc3/python/openc3/script/web_socket_api.py
+++ b/openc3/python/openc3/script/web_socket_api.py
@@ -110,6 +110,31 @@ class WebSocketApi:
             json_hash["identifier"] = json.dumps(self.identifier)
             self.stream.write(json.dumps(json_hash))
             self.subscribed = True
+            self._wait_for_subscribed()
+
+    def _wait_for_subscribed(self):
+        """Block until the server confirms the subscription.
+
+        ActionCable / anycable-go process 'subscribe' and 'message' commands as
+        independent RPCs, so an action (add/remove) written immediately after
+        subscribe can reach StreamingChannel#add before the subscription's
+        broadcaster exists, where it is silently dropped (a no-op) and no data
+        ever streams. Waiting for confirm_subscription guarantees the broadcaster
+        is ready before any action is written.
+        """
+        while True:
+            message = self.stream.read()
+            if not message:
+                raise RuntimeError("WebSocket closed before subscription was confirmed")
+            json_hash = json.loads(message)
+            msg_type = json_hash.get("type")
+            if msg_type == "confirm_subscription":
+                return
+            if msg_type == "reject_subscription":
+                raise RuntimeError("Subscription Rejected")
+            if msg_type == "disconnect" and json_hash.get("reason") == "unauthorized":
+                raise RuntimeError("Unauthorized")
+            # Ignore welcome / ping and keep waiting for confirmation
 
     def unsubscribe(self):
         """Will unsubscribe to the channel based on @identifier"""
@@ -122,6 +147,13 @@ class WebSocketApi:
 
     def write_action(self, data_hash):
         """Send an ActionCable command"""
+        # Subscribe first so the token is present in self.identifier before we
+        # serialize it below. ActionCable matches a 'message' command to its
+        # subscription by the exact identifier string; if subscribe() injected
+        # the token only afterward, the message identifier (no token) would not
+        # match the subscription identifier (with token) and the server would
+        # silently ignore the action.
+        self.subscribe()
         json_hash = {}
         json_hash["command"] = "message"
         json_hash["identifier"] = json.dumps(self.identifier)

--- a/openc3/python/test/script/test_web_socket_api.py
+++ b/openc3/python/test/script/test_web_socket_api.py
@@ -84,6 +84,9 @@ class TestWebSocketApiEdgeCases(unittest.TestCase):
         )
         api.identifier = {"channel": "TestChannel"}
         api.stream = Mock()
+        # Skip the subscribe handshake; this test exercises read() timeout during
+        # the data phase, not subscription confirmation.
+        api.subscribed = True
 
         # Simulate slow responses - return multiple ping messages
         call_count = [0]
@@ -117,6 +120,8 @@ class TestWebSocketApiSubscribe(unittest.TestCase):
         api = WebSocketApi(url="ws://test.com/cable", authentication=mock_auth)
         api.identifier = {"channel": "TestChannel"}
         api.stream = Mock()
+        # subscribe() now blocks until the server confirms the subscription
+        api.stream.read.return_value = '{"type":"confirm_subscription"}'
         return api
 
     # ActionCable derives `params` (which the server uses for
@@ -140,6 +145,18 @@ class TestWebSocketApiSubscribe(unittest.TestCase):
         api.subscribe()
         api.subscribe()
         self.assertEqual(api.stream.write.call_count, 1)
+
+    # Regression: write_action must subscribe (which injects the token into the
+    # identifier) BEFORE serializing the identifier, so the message command's
+    # identifier matches the subscription's. Otherwise ActionCable silently
+    # ignores the action and no data ever streams.
+    def test_action_identifier_includes_token(self):
+        api = self._make_api()
+        api.write_action({"action": "add"})
+        frames = [json.loads(c.args[0]) for c in api.stream.write.call_args_list]
+        message = next(f for f in frames if f["command"] == "message")
+        identifier = json.loads(message["identifier"])
+        self.assertEqual(identifier["token"], "test_token")
 
 
 if __name__ == "__main__":

--- a/openc3/spec/script/web_socket_api_spec.rb
+++ b/openc3/spec/script/web_socket_api_spec.rb
@@ -155,6 +155,8 @@ module OpenC3
 
       before do
         api.instance_variable_set(:@stream, mock_stream)
+        # subscribe() now blocks until the server confirms the subscription
+        allow(mock_stream).to receive(:read).and_return('{"type":"confirm_subscription"}')
       end
 
       # ActionCable derives `params` (which the server uses for
@@ -177,6 +179,19 @@ module OpenC3
         expect(mock_stream).to receive(:write).once
         api.subscribe
         api.subscribe
+      end
+
+      # Regression: write_action must subscribe (which injects the token into the
+      # identifier) BEFORE serializing the identifier, so the message command's
+      # identifier matches the subscription's. Otherwise ActionCable silently
+      # ignores the action and no data ever streams.
+      it "includes the token in the action identifier so it matches the subscription" do
+        writes = []
+        allow(mock_stream).to receive(:write) { |msg| writes << msg }
+        api.write_action({ 'action' => 'add' })
+        message = writes.map { |w| JSON.parse(w) }.find { |f| f['command'] == 'message' }
+        identifier = JSON.parse(message['identifier'])
+        expect(identifier['token']).to eq('test_token')
       end
     end
   end


### PR DESCRIPTION
subscribe() now blocks until confirm_subscription and write_action subscribes before serializing the identifier, so add/remove aren't silently dropped by a subscription race or an identifier that lacks the token. Ruby scope falls back to OPENC3_SCOPE like Python. Adds regression tests and documents the COSMOS_ALL packet wildcard and item globs.

closes #3570