### PR TITLE
Split screen api tests

### DIFF
--- a/playwright/tests/admin/interfaces.p.spec.ts
+++ b/playwright/tests/admin/interfaces.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/admin/microservices.p.spec.ts
+++ b/playwright/tests/admin/microservices.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/admin/packages.p.spec.ts
+++ b/playwright/tests/admin/packages.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from '../fixture'
 
 test.use({

--- a/playwright/tests/admin/plugins.p.spec.ts
+++ b/playwright/tests/admin/plugins.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 import * as fs from 'fs'
 

--- a/playwright/tests/admin/redis.p.spec.ts
+++ b/playwright/tests/admin/redis.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/admin/routers.p.spec.ts
+++ b/playwright/tests/admin/routers.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/admin/secrets.p.spec.ts
+++ b/playwright/tests/admin/secrets.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/admin/settings.p.spec.ts
+++ b/playwright/tests/admin/settings.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/admin/targets.p.spec.ts
+++ b/playwright/tests/admin/targets.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/admin/tools.p.spec.ts
+++ b/playwright/tests/admin/tools.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/bucket-explorer.p.spec.ts
+++ b/playwright/tests/bucket-explorer.p.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './fixture'
 
 test.use({

--- a/playwright/tests/cmd-tlm-server/cmd-pkts.p.spec.ts
+++ b/playwright/tests/cmd-tlm-server/cmd-pkts.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/cmd-tlm-server/file-menu.p.spec.ts
+++ b/playwright/tests/cmd-tlm-server/file-menu.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/cmd-tlm-server/interfaces.p.spec.ts
+++ b/playwright/tests/cmd-tlm-server/interfaces.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/cmd-tlm-server/targets.p.spec.ts
+++ b/playwright/tests/cmd-tlm-server/targets.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/cmd-tlm-server/tlm-pkts.p.spec.ts
+++ b/playwright/tests/cmd-tlm-server/tlm-pkts.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/command-sender.p.spec.ts
+++ b/playwright/tests/command-sender.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './fixture'
 
 test.use({

--- a/playwright/tests/command-sender.s.spec.ts
+++ b/playwright/tests/command-sender.s.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './fixture'
 
 test.use({

--- a/playwright/tests/data-viewer.p.spec.ts
+++ b/playwright/tests/data-viewer.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './fixture'
 
 test.use({

--- a/playwright/tests/script-runner/api.s.spec.ts
+++ b/playwright/tests/script-runner/api.s.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/script-runner/api.s.spec.ts
+++ b/playwright/tests/script-runner/api.s.spec.ts
@@ -12,6 +12,8 @@
 # All Rights Reserved
 */
 
+import type { Page } from '@playwright/test'
+import { Utilities } from '../../utilities'
 import { test, expect } from './../fixture'
 
 test.use({
@@ -19,7 +21,7 @@ test.use({
   toolName: 'Script Runner',
 })
 
-async function openFile(page, utils, filename) {
+async function openFile(page: Page, utils: Utilities, filename: string) {
   await page.locator('[data-test=script-runner-file]').click()
   await page.locator('text=Open File').click()
   await utils.sleep(500) // Allow background data to fetch
@@ -40,7 +42,12 @@ async function openFile(page, utils, filename) {
   }
 }
 
-async function runScript(page, utils, filename, callback = async () => {}) {
+async function runScript(
+  page: Page,
+  utils: Utilities,
+  filename: string,
+  callback = async (): Promise<any> => {},
+) {
   await openFile(page, utils, filename)
   await page.locator('[data-test=start-button]').click()
   await callback()
@@ -174,7 +181,11 @@ test('test python stash apis', async ({ page, utils }) => {
   await runScript(page, utils, 'stash.py')
 })
 
-async function testMetadataApis(page, utils, filename) {
+async function testMetadataApis(
+  page: Page,
+  utils: Utilities,
+  filename: string,
+) {
   // Clear other test data
   await page.goto('/tools/admin/redis')
   await page
@@ -258,56 +269,191 @@ test('test python metadata apis', async ({ page, utils }) => {
   )
 })
 
-async function testScreenApis(page, utils, filename, target) {
-  await runScript(page, utils, filename, async function () {
-    // script displays INST ADCS
-    await expect(
-      page.getByText(`${target} ADCS`, { exact: true }),
-    ).toBeVisible()
-    // script displays INST HS
-    await expect(page.getByText(`${target} HS`, { exact: true })).toBeVisible()
-    // script calls clear_screen("INST", "ADCS")
-    await expect(
-      page.getByText(`${target} ADCS`, { exact: true }),
-    ).not.toBeVisible()
-    // script displays INST IMAGE
-    await expect(
-      page.getByText(`${target} IMAGE`, { exact: true }),
-    ).toBeVisible()
-    // script calls clear_all_screens()
-    await expect(
-      page.getByText(`${target} HS`, { exact: true }),
-    ).not.toBeVisible()
-    await expect(
-      page.getByText(`${target} IMAGE`, { exact: true }),
-    ).not.toBeVisible()
-    // script creates local screen "TEST"
-    await expect(page.getByText('LOCAL TEST', { exact: true })).toBeVisible()
-    // script calls clear_all_screens()
-    await expect(
-      page.getByText('LOCAL TEST', { exact: true }),
-    ).not.toBeVisible()
-    // script creates local screen "INST TEST"
-    await expect(
-      page.getByText(`${target} TEST`, { exact: true }),
-    ).toBeVisible()
-    // script calls clear_all_screens()
-    await expect(
-      page.getByText(`${target} TEST`, { exact: true }),
-    ).not.toBeVisible()
-    // script deletes INST TEST and tries to display it which results in error
-    await expect(page.locator('[data-test=state] input')).toHaveValue('error')
-    await page.locator('[data-test=go-button]').click()
-  })
+// The screen APIs were originally exercised by a single long script that
+// chained ~10 transient-state assertions. Each screen was only visible for a
+// 2s window, so under load a lagged render could miss a window and fail the
+// whole test; a retry then re-ran every step (and re-triggered the file lock
+// contention in openFile). These are split into focused tests, each running a
+// small inline script so a failure is isolated, retries are cheap, and there
+// is no "<user> is editing this script" lock to work around.
+
+type ScriptLanguage = 'ruby' | 'python'
+
+// A leading marker line forces Script Runner's language auto-detection for an
+// unsaved inline script (see detectLanguage in ScriptRunner.vue): `puts ` marks
+// Ruby, an `(f"` f-string marks Python.
+function languageMarker(language: ScriptLanguage): string {
+  return language === 'ruby' ? 'puts "start"' : 'print(f"start")'
 }
 
-test('test ruby screen apis', async ({ page, utils }) => {
-  await testScreenApis(page, utils, 'screens.rb', 'INST')
-})
+function screenDefinition(language: ScriptLanguage, target: string): string {
+  const body = `
+SCREEN AUTO AUTO 1.0
 
-test('test python screen apis', async ({ page, utils }) => {
-  await testScreenApis(page, utils, 'screens.py', 'INST2')
-})
+VERTICALBOX "Test Screen"
+  LABELVALUE ${target} HEALTH_STATUS TEMP1
+END
+`
+  return language === 'ruby' ? `'${body}'` : `"""${body}"""`
+}
+
+async function startInlineScript(page: Page, script: string) {
+  await page.locator('textarea').fill(script)
+  await page.locator('[data-test=start-button]').click()
+}
+
+async function expectCompleted(page: Page) {
+  await expect(page.locator('[data-test=state] input')).toHaveValue(
+    'completed',
+    { timeout: 30000 },
+  )
+}
+
+// Generous timeout so a slow first render (fetch definition + telemetry
+// subscribe over the WebSocket) doesn't miss a screen's visibility window.
+const SCREEN_TIMEOUT = 15000
+
+async function testDisplayAndClearScreen(
+  page: Page,
+  language: ScriptLanguage,
+  target: string,
+) {
+  await startInlineScript(
+    page,
+    `${languageMarker(language)}
+display_screen("${target}", "ADCS")
+wait(3)
+display_screen("${target}", "HS", 400, 0)
+wait(3)
+clear_screen("${target}", "ADCS")
+wait(3)
+clear_all_screens()`,
+  )
+  const timeout = SCREEN_TIMEOUT
+  await expect(page.getByText(`${target} ADCS`, { exact: true })).toBeVisible({
+    timeout,
+  })
+  await expect(page.getByText(`${target} HS`, { exact: true })).toBeVisible({
+    timeout,
+  })
+  // clear_screen removes only ADCS; HS stays up
+  await expect(
+    page.getByText(`${target} ADCS`, { exact: true }),
+  ).not.toBeVisible({ timeout })
+  await expect(page.getByText(`${target} HS`, { exact: true })).toBeVisible({
+    timeout,
+  })
+  // clear_all_screens removes HS
+  await expect(page.getByText(`${target} HS`, { exact: true })).not.toBeVisible(
+    { timeout },
+  )
+  await expectCompleted(page)
+}
+
+async function testClearAllScreens(
+  page: Page,
+  language: ScriptLanguage,
+  target: string,
+) {
+  await startInlineScript(
+    page,
+    `${languageMarker(language)}
+display_screen("${target}", "IMAGE")
+wait(3)
+display_screen("${target}", "HS", 400, 0)
+wait(3)
+clear_all_screens()`,
+  )
+  const timeout = SCREEN_TIMEOUT
+  await expect(page.getByText(`${target} IMAGE`, { exact: true })).toBeVisible({
+    timeout,
+  })
+  await expect(page.getByText(`${target} HS`, { exact: true })).toBeVisible({
+    timeout,
+  })
+  await expect(
+    page.getByText(`${target} IMAGE`, { exact: true }),
+  ).not.toBeVisible({ timeout })
+  await expect(page.getByText(`${target} HS`, { exact: true })).not.toBeVisible(
+    { timeout },
+  )
+  await expectCompleted(page)
+}
+
+async function testLocalScreen(
+  page: Page,
+  language: ScriptLanguage,
+  target: string,
+) {
+  await startInlineScript(
+    page,
+    `${languageMarker(language)}
+local_screen("TEST", ${screenDefinition(language, target)})
+wait(3)
+clear_all_screens()`,
+  )
+  const timeout = SCREEN_TIMEOUT
+  await expect(page.getByText('LOCAL TEST', { exact: true })).toBeVisible({
+    timeout,
+  })
+  await expect(page.getByText('LOCAL TEST', { exact: true })).not.toBeVisible({
+    timeout,
+  })
+  await expectCompleted(page)
+}
+
+async function testCreateAndDeleteScreen(
+  page: Page,
+  language: ScriptLanguage,
+  target: string,
+) {
+  await startInlineScript(
+    page,
+    `${languageMarker(language)}
+create_screen("${target}", "TEST", ${screenDefinition(language, target)})
+display_screen("${target}", "TEST")
+wait(3)
+clear_all_screens()
+delete_screen("${target}", "TEST")
+display_screen("${target}", "TEST") # Expected to fail because the screen was deleted`,
+  )
+  const timeout = SCREEN_TIMEOUT
+  await expect(page.getByText(`${target} TEST`, { exact: true })).toBeVisible({
+    timeout,
+  })
+  await expect(
+    page.getByText(`${target} TEST`, { exact: true }),
+  ).not.toBeVisible({ timeout })
+  // Displaying the deleted screen raises an error
+  await expect(page.locator('[data-test=state] input')).toHaveValue('error', {
+    timeout,
+  })
+  await page.locator('[data-test=go-button]').click()
+  await expectCompleted(page)
+}
+
+for (const { language, target } of [
+  { language: 'ruby' as const, target: 'INST' },
+  { language: 'python' as const, target: 'INST2' },
+]) {
+  // The `utils` fixture performs the goto to the Script Runner tool, so it must
+  // be destructured (even when otherwise unused) for the page to navigate.
+  test(`test ${language} display and clear screen`, async ({ page, utils }) => {
+    await testDisplayAndClearScreen(page, language, target)
+  })
+
+  test(`test ${language} clear all screens`, async ({ page, utils }) => {
+    await testClearAllScreens(page, language, target)
+  })
+
+  test(`test ${language} local screen`, async ({ page, utils }) => {
+    await testLocalScreen(page, language, target)
+  })
+
+  test(`test ${language} create and delete screen`, async ({ page, utils }) => {
+    await testCreateAndDeleteScreen(page, language, target)
+  })
+}
 
 test('test ruby script apis', async ({ page, utils }) => {
   await runScript(page, utils, 'scripting.rb', async function () {

--- a/playwright/tests/script-runner/debug.p.spec.ts
+++ b/playwright/tests/script-runner/debug.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/script-runner/edit-menu.p.spec.ts
+++ b/playwright/tests/script-runner/edit-menu.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/script-runner/file-menu.p.spec.ts
+++ b/playwright/tests/script-runner/file-menu.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({

--- a/playwright/tests/script-runner/prompts.p.spec.ts
+++ b/playwright/tests/script-runner/prompts.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from '../fixture'
 
 test.use({

--- a/playwright/tests/script-runner/script-menu.p.spec.ts
+++ b/playwright/tests/script-runner/script-menu.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 import { format } from 'date-fns'
 

--- a/playwright/tests/script-runner/suite.p.spec.ts
+++ b/playwright/tests/script-runner/suite.p.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { Page } from '@playwright/test'
 import { Utilities } from '../../utilities'
 import { test, expect } from './../fixture'

--- a/playwright/tests/script-runner/temp-files.s.spec.ts
+++ b/playwright/tests/script-runner/temp-files.s.spec.ts
@@ -12,7 +12,6 @@
 # All Rights Reserved
 */
 
-// @ts-check
 import { test, expect } from './../fixture'
 
 test.use({


### PR DESCRIPTION
split singular screen api test into 4, allowing more room for flaky failures to pass by limiting what would be included in each retry