### PR TITLE
Standardize and disambiguate error messages

### DIFF
--- a/openc3/ext/openc3/ext/telemetry/telemetry.c
+++ b/openc3/ext/openc3/ext/telemetry/telemetry.c
@@ -56,7 +56,7 @@ static VALUE packets(VALUE self, VALUE target_name)
 
   if (!(RTEST(target_packets)))
   {
-    rb_raise(rb_eRuntimeError, "Telemetry target '%s' does not exist", RSTRING_PTR(upcase_target_name));
+    rb_raise(rb_eRuntimeError, "Telemetry target '%s' does not exist (packets lookup)", RSTRING_PTR(upcase_target_name));
   }
 
   return target_packets;

--- a/openc3/lib/openc3/accessors/template_accessor.rb
+++ b/openc3/lib/openc3/accessors/template_accessor.rb
@@ -109,7 +109,7 @@ module OpenC3
       configure()
 
       success = buffer.gsub!("#{@left_char}#{item.key}#{@right_char}", value.to_s)
-      raise "Key #{item.key} not found in template" unless success
+      raise "Key '#{item.key}' not found in template (write_item)" unless success
       return value
     end
 
@@ -118,7 +118,7 @@ module OpenC3
       items.each_with_index do |item, index|
         next if item.data_type == :DERIVED
         success = buffer.gsub!("#{@left_char}#{item.key}#{@right_char}", values[index].to_s)
-        raise "Key #{item.key} not found in template" unless success
+        raise "Key '#{item.key}' not found in template (write_items)" unless success
       end
       return values
     end

--- a/openc3/lib/openc3/api/interface_api.rb
+++ b/openc3/lib/openc3/api/interface_api.rb
@@ -47,7 +47,7 @@ module OpenC3
     def get_interface(interface_name, manual: false, scope: $openc3_scope, token: $openc3_token)
       authorize(permission: 'system', interface_name: interface_name, manual: manual, scope: scope, token: token)
       interface = InterfaceModel.get(name: interface_name, scope: scope)
-      raise "Interface '#{interface_name}' does not exist" unless interface
+      raise "Interface '#{interface_name}' does not exist (get_interface)" unless interface
 
       interface.merge(InterfaceStatusModel.get(name: interface_name, scope: scope))
     end
@@ -160,7 +160,7 @@ module OpenC3
       # TODO: Check if they have command authority for the targets mapped to this interface
       authorize(permission: 'system_set', interface_name: interface_name, manual: manual, scope: scope, token: token)
       interface = InterfaceModel.get_model(name: interface_name, scope: scope)
-      raise "Interface '#{interface_name}' does not exist" unless interface
+      raise "Interface '#{interface_name}' does not exist (unmap_target_from_interface)" unless interface
 
       if Array === target_name
         target_names = target_name

--- a/openc3/lib/openc3/api/limits_api.rb
+++ b/openc3/lib/openc3/api/limits_api.rb
@@ -134,7 +134,7 @@ module OpenC3
           break
         end
       end
-      raise "Item '#{target_name} #{packet_name} #{item_name}' does not exist" unless found_item
+      raise "Item '#{target_name} #{packet_name} #{item_name}' does not exist while enabling limits" unless found_item
 
       TargetModel.set_packet(target_name, packet_name, packet, scope: scope)
 
@@ -167,7 +167,7 @@ module OpenC3
           break
         end
       end
-      raise "Item '#{target_name} #{packet_name} #{item_name}' does not exist" unless found_item
+      raise "Item '#{target_name} #{packet_name} #{item_name}' does not exist while disabling limits" unless found_item
 
       TargetModel.set_packet(target_name, packet_name, packet, scope: scope)
 
@@ -239,7 +239,7 @@ module OpenC3
           end
         end
       end
-      raise "Item '#{target_name} #{packet_name} #{item_name}' does not exist" unless found_item
+      raise "Item '#{target_name} #{packet_name} #{item_name}' does not exist while setting limits" unless found_item
       message = "Setting '#{target_name} #{packet_name} #{item_name}' limits to #{red_low} #{yellow_low} #{yellow_high} #{red_high}"
       message << " #{green_low} #{green_high}" if green_low && green_high
       message << " in set #{limits_set} with persistence #{persistence} as enabled #{enabled}"
@@ -286,7 +286,7 @@ module OpenC3
           break
         end
       end
-      raise "Item '#{target_name} #{packet_name} #{item_name}' does not exist" unless found_item
+      raise "Item '#{target_name} #{packet_name} #{item_name}' does not exist while setting state color" unless found_item
       message = "Setting '#{target_name} #{packet_name} #{item_name}' state #{state_name} color to #{color}"
       Logger.info(message, scope: scope)
 

--- a/openc3/lib/openc3/api/router_api.rb
+++ b/openc3/lib/openc3/api/router_api.rb
@@ -46,7 +46,7 @@ module OpenC3
     def get_router(router_name, manual: false, scope: $openc3_scope, token: $openc3_token)
       authorize(permission: 'system', router_name: router_name, manual: manual, scope: scope, token: token)
       router = RouterModel.get(name: router_name, scope: scope)
-      raise "Router '#{router_name}' does not exist" unless router
+      raise "Router '#{router_name}' does not exist (get_router)" unless router
 
       router.merge(RouterStatusModel.get(name: router_name, scope: scope))
     end
@@ -144,7 +144,7 @@ module OpenC3
       # TODO: Check if they have command authority for the targets mapped to this router
       authorize(permission: 'system_set', router_name: router_name, manual: manual, scope: scope, token: token)
       router = RouterModel.get_model(name: router_name, scope: scope)
-      raise "Router '#{router_name}' does not exist" unless router
+      raise "Router '#{router_name}' does not exist (map_target_to_router)" unless router
 
       if Array === target_name
         target_names = target_name
@@ -167,7 +167,7 @@ module OpenC3
       # TODO: Check if they have command authority for the targets mapped to this router
       authorize(permission: 'system_set', router_name: router_name, manual: manual, scope: scope, token: token)
       router = RouterModel.get_model(name: router_name, scope: scope)
-      raise "Router '#{router_name}' does not exist" unless router
+      raise "Router '#{router_name}' does not exist (unmap_target_from_router)" unless router
 
       if Array === target_name
         target_names = target_name

--- a/openc3/lib/openc3/api/tlm_api.rb
+++ b/openc3/lib/openc3/api/tlm_api.rb
@@ -123,7 +123,7 @@ module OpenC3
       target_name = target_name.upcase
       packet_name = packet_name.upcase
       unless CvtModel::VALUE_TYPES.include?(type)
-        raise "Unknown type '#{type}' for #{target_name} #{packet_name}"
+        raise "Unknown type '#{type}' for #{target_name} #{packet_name} (inject_tlm)"
       end
 
       if item_hash

--- a/openc3/lib/openc3/microservices/interface_microservice.rb
+++ b/openc3/lib/openc3/microservices/interface_microservice.rb
@@ -195,7 +195,7 @@ module OpenC3
                 msg_hash = critical_model.cmd_hash
                 release_critical = true
               else
-                next "Critical command #{msg_hash['release_critical']} not found"
+                next "Critical command '#{msg_hash['release_critical']}' not found (interface command processing)"
               end
             end
             if msg_hash.key?('target_control')

--- a/openc3/lib/openc3/models/cvt_model.rb
+++ b/openc3/lib/openc3/models/cvt_model.rb
@@ -86,7 +86,7 @@ module OpenC3
         return hash if hash and (now - cache_time) < cache_timeout
       end
       packet = store_for_target(target_name, scope: scope).hget(key, packet_name)
-      raise "Packet '#{target_name} #{packet_name}' does not exist" unless packet
+      raise "Packet '#{target_name} #{packet_name}' has no current values in CVT" unless packet
       hash = JSON.parse(packet, allow_nan: true, create_additions: true)
       @@packet_cache[tgt_pkt_key] = [now, hash]
       hash
@@ -107,7 +107,7 @@ module OpenC3
         hash["#{item_name}__C"] = value
         hash[item_name] = value
       else
-        raise "Unknown type '#{type}' for #{target_name} #{packet_name} #{item_name}"
+        raise "Unknown type '#{type}' for #{target_name} #{packet_name} #{item_name} (set_item)"
       end
       set(hash, target_name: target_name, packet_name: packet_name, queued: queued, scope: scope)
     end
@@ -252,7 +252,7 @@ module OpenC3
       when :FORMATTED, :WITH_UNITS
         hash["#{item_name}__F"] = value.to_s # Always a String
       else
-        raise "Unknown type '#{type}' for #{target_name} #{packet_name} #{item_name}"
+        raise "Unknown type '#{type}' for #{target_name} #{packet_name} #{item_name} (override)"
       end
 
       tgt_pkt_key = "#{scope}__tlm__#{target_name}__#{packet_name}"
@@ -277,7 +277,7 @@ module OpenC3
       when :FORMATTED, :WITH_UNITS
         hash.delete("#{item_name}__F")
       else
-        raise "Unknown type '#{type}' for #{target_name} #{packet_name} #{item_name}"
+        raise "Unknown type '#{type}' for #{target_name} #{packet_name} #{item_name} (normalize)"
       end
 
       tgt_pkt_key = "#{scope}__tlm__#{target_name}__#{packet_name}"
@@ -327,7 +327,7 @@ module OpenC3
       when :RAW
         types = [item_name]
       else
-        raise "Unknown type '#{type}' for #{target_name} #{packet_name} #{item_name}"
+        raise "Unknown type '#{type}' for #{target_name} #{packet_name} #{item_name} (get_item)"
       end
 
       tgt_pkt_key = "#{scope}__tlm__#{target_name}__#{packet_name}"

--- a/openc3/lib/openc3/models/gem_model.rb
+++ b/openc3/lib/openc3/models/gem_model.rb
@@ -47,7 +47,7 @@ module OpenC3
       return path if File.exist?(path)
       path = "#{ENV['GEM_HOME']}/cache/#{name}"
       return path if File.exist?(path)
-      raise "Gem #{name} not found"
+      raise "Gem '#{name}' not found"
     end
 
     def self.put(gem_file_path, gem_install: true, scope:)

--- a/openc3/lib/openc3/models/interface_model.rb
+++ b/openc3/lib/openc3/models/interface_model.rb
@@ -256,7 +256,7 @@ module OpenC3
 
     def ensure_target_exists(target_name)
       target = TargetModel.get(name: target_name, scope: @scope)
-      raise "Target #{target_name} does not exist" unless target
+      raise "Target '#{target_name}' does not exist (InterfaceModel)" unless target
       target
     end
 

--- a/openc3/lib/openc3/models/python_package_model.rb
+++ b/openc3/lib/openc3/models/python_package_model.rb
@@ -194,7 +194,7 @@ module OpenC3
       if result.length > 0
         return result[0] if File.exist?(result[0])
       end
-      raise "Package #{name} not found"
+      raise "Package '#{name}' not found"
     end
 
     def self.put(package_file_path, package_install: true, scope:, plugin: nil)

--- a/openc3/lib/openc3/models/target_model.rb
+++ b/openc3/lib/openc3/models/target_model.rb
@@ -295,7 +295,7 @@ module OpenC3
 
       # Assume it exists and just try to get it to avoid an extra call to Store.exist?
       json = store_for_target(target_name, scope: scope).hget("#{scope}__openc3#{type.to_s.downcase}__#{target_name}", packet_name)
-      raise "Packet '#{target_name} #{packet_name}' does not exist" if json.nil?
+      raise "Packet definition '#{target_name} #{packet_name}' does not exist" if json.nil?
 
       packet = JSON.parse(json, allow_nan: true, create_additions: true)
 
@@ -316,7 +316,7 @@ module OpenC3
     # @return [Array<Hash>] All packet hashes under the target_name
     def self.packets(target_name, type: :TLM, scope:)
       raise "Unknown type #{type} for #{target_name}" unless VALID_TYPES.include?(type)
-      raise "Target '#{target_name}' does not exist for scope: #{scope}" unless get(name: target_name, scope: scope)
+      raise "Target '#{target_name}' does not exist for scope: #{scope} (TargetModel)" unless get(name: target_name, scope: scope)
 
       result = []
       packets = store_for_target(target_name, scope: scope).hgetall("#{scope}__openc3#{type.to_s.downcase}__#{target_name}")
@@ -352,7 +352,7 @@ module OpenC3
     def self.packet_item(target_name, packet_name, item_name, type: :TLM, scope:)
       packet = packet(target_name, packet_name, type: type, scope: scope)
       item = packet['items'].find { |item| item['name'] == item_name.to_s }
-      raise "Item '#{packet['target_name']} #{packet['packet_name']} #{item_name}' does not exist" unless item
+      raise "Item '#{packet['target_name']} #{packet['packet_name']} #{item_name}' does not exist (TargetModel)" unless item
       item
     end
 

--- a/openc3/lib/openc3/packets/commands.rb
+++ b/openc3/lib/openc3/packets/commands.rb
@@ -61,7 +61,7 @@ module OpenC3
     #   target name keyed by the packet name
     def packets(target_name)
       target_packets = @config.commands[target_name.to_s.upcase]
-      raise "Command target '#{target_name.to_s.upcase}' does not exist" unless target_packets
+      raise "Command target '#{target_name.to_s.upcase}' does not exist (packets lookup)" unless target_packets
 
       target_packets
     end
@@ -73,7 +73,7 @@ module OpenC3
     def packet(target_name, packet_name)
       target_packets = packets(target_name)
       packet = target_packets[packet_name.to_s.upcase]
-      raise "Command packet '#{target_name.to_s.upcase} #{packet_name.to_s.upcase}' does not exist" unless packet
+      raise "Command packet '#{target_name.to_s.upcase} #{packet_name.to_s.upcase}' does not exist (packet lookup)" unless packet
 
       packet
     end
@@ -187,9 +187,9 @@ module OpenC3
 
       # Lookup the command directly - avoid redundant upcase in packet()/packets()
       target_packets = @config.commands[target_upcase]
-      raise "Command target '#{target_upcase}' does not exist" unless target_packets
+      raise "Command target '#{target_upcase}' does not exist (build_cmd)" unless target_packets
       pkt = target_packets[packet_upcase]
-      raise "Command packet '#{target_upcase} #{packet_upcase}' does not exist" unless pkt
+      raise "Command packet '#{target_upcase} #{packet_upcase}' does not exist (build_cmd)" unless pkt
       # Use deep_copy to avoid shared item modifications affecting the template
       # This is critical for variable_bit_size items where handle_write_variable_bit_size
       # modifies item.bit_offset and item.array_size during writes

--- a/openc3/lib/openc3/packets/limits.rb
+++ b/openc3/lib/openc3/packets/limits.rb
@@ -182,10 +182,10 @@ module OpenC3
       raise "LATEST packet not valid" if packet_name.upcase == LATEST_PACKET_NAME
 
       packets = @config.telemetry[target_name.to_s.upcase]
-      raise "Telemetry target '#{target_name.to_s.upcase}' does not exist" unless packets
+      raise "Telemetry target '#{target_name.to_s.upcase}' does not exist (limits lookup)" unless packets
 
       packet = packets[packet_name.to_s.upcase]
-      raise "Telemetry packet '#{target_name.to_s.upcase} #{packet_name.to_s.upcase}' does not exist" unless packet
+      raise "Telemetry packet '#{target_name.to_s.upcase} #{packet_name.to_s.upcase}' does not exist (limits lookup)" unless packet
 
       return packet
     end

--- a/openc3/lib/openc3/packets/packet.rb
+++ b/openc3/lib/openc3/packets/packet.rb
@@ -616,7 +616,7 @@ module OpenC3
     def get_item(name)
       return super(name)
     rescue ArgumentError
-      raise "Packet item '#{@target_name} #{@packet_name} #{name.upcase}' does not exist"
+      raise "Item '#{@target_name} #{@packet_name} #{name.upcase}' does not exist (Packet)"
     end
 
     # Read an item in the packet

--- a/openc3/lib/openc3/packets/parsers/xtce_parser.rb
+++ b/openc3/lib/openc3/packets/parsers/xtce_parser.rb
@@ -534,15 +534,15 @@ module OpenC3
       if /Parameter/.match?(element.name)
         # Look up the parameter and parameter type
         parameter = @parameters[element['parameterRef']]
-        raise "parameterRef #{element['parameterRef']} not found" unless parameter
+        raise "parameterRef #{element['parameterRef']} not found (parameter lookup)" unless parameter
 
         parameter_type = @parameter_types[parameter.parameterTypeRef]
-        raise "parameterTypeRef #{parameter.parameterTypeRef} not found" unless parameter_type
+        raise "parameterTypeRef #{parameter.parameterTypeRef} not found (parameter type lookup)" unless parameter_type
 
         if element.name == 'ArrayParameterRefEntry'
           array_type = parameter_type
           parameter_type = @parameter_types[array_type.arrayTypeRef]
-          raise "arrayTypeRef #{parameter.arrayTypeRef} not found" unless parameter_type
+          raise "arrayTypeRef #{parameter.arrayTypeRef} not found (array parameter type)" unless parameter_type
         end
         refName = 'parameterRef'
         object = parameter
@@ -552,22 +552,22 @@ module OpenC3
         if element.name == 'ArrayArgumentRefEntry'
           # Requiring parameterRef for argument arrays appears to be a defect in the schema
           argument = @arguments[element['parameterRef']]
-          raise "parameterRef #{element['parameterRef']} not found" unless argument
+          raise "parameterRef #{element['parameterRef']} not found (array argument lookup)" unless argument
 
           argument_type = @argument_types[argument.argumentTypeRef]
-          raise "argumentTypeRef #{argument.argumentTypeRef} not found" unless argument_type
+          raise "argumentTypeRef #{argument.argumentTypeRef} not found (array argument type lookup)" unless argument_type
 
           array_type = argument_type
           argument_type = @argument_types[array_type.arrayTypeRef]
-          raise "arrayTypeRef #{array_type.arrayTypeRef} not found" unless argument_type
+          raise "arrayTypeRef #{array_type.arrayTypeRef} not found (array argument element type)" unless argument_type
 
           refName = 'parameterRef'
         else
           argument = @arguments[element['argumentRef']]
-          raise "argumentRef #{element['argumentRef']} not found" unless argument
+          raise "argumentRef #{element['argumentRef']} not found (argument lookup)" unless argument
 
           argument_type = @argument_types[argument.argumentTypeRef]
-          raise "argumentTypeRef #{argument.argumentTypeRef} not found" unless argument_type
+          raise "argumentTypeRef #{argument.argumentTypeRef} not found (argument type lookup)" unless argument_type
 
           refName = 'argumentRef'
         end

--- a/openc3/lib/openc3/packets/structure.rb
+++ b/openc3/lib/openc3/packets/structure.rb
@@ -326,7 +326,7 @@ module OpenC3
     # @return [StructureItem] StructureItem or one of its subclasses
     def get_item(name)
       item = @items[name.upcase]
-      raise ArgumentError, "Unknown item: #{name}" unless item
+      raise ArgumentError, "Unknown item: #{name} (get_item)" unless item
 
       return item
     end
@@ -358,7 +358,7 @@ module OpenC3
     # @param name [String] Name of the item to delete in the items Hash
     def delete_item(name)
       item = @items[name.upcase]
-      raise ArgumentError, "Unknown item: #{name}" unless item
+      raise ArgumentError, "Unknown item: #{name} (delete_item)" unless item
 
       # Find the item to delete in the sorted_items array
       item_index = nil

--- a/openc3/lib/openc3/packets/telemetry.rb
+++ b/openc3/lib/openc3/packets/telemetry.rb
@@ -59,7 +59,7 @@ module OpenC3
       def packets(target_name)
         upcase_target_name = target_name.to_s.upcase
         target_packets = @config.telemetry[upcase_target_name]
-        raise "Telemetry target '#{upcase_target_name}' does not exist" unless target_packets
+        raise "Telemetry target '#{upcase_target_name}' does not exist (packets lookup)" unless target_packets
 
         target_packets
       end
@@ -177,7 +177,7 @@ module OpenC3
       if LATEST_PACKET_NAME.casecmp(packet_name).zero?
         target_upcase = target_name.to_s.upcase
         target_latest_data = @config.latest_data[target_upcase]
-        raise "Telemetry Target '#{target_upcase}' does not exist" unless target_latest_data
+        raise "Telemetry target '#{target_upcase}' does not exist (item_names lookup)" unless target_latest_data
 
         item_names = target_latest_data.keys
       else
@@ -208,7 +208,7 @@ module OpenC3
       target_upcase = target_name.to_s.upcase
       item_upcase = item_name.to_s.upcase
       target_latest_data = @config.latest_data[target_upcase]
-      raise "Telemetry target '#{target_upcase}' does not exist" unless target_latest_data
+      raise "Telemetry target '#{target_upcase}' does not exist (latest_packets lookup)" unless target_latest_data
 
       packets = @config.latest_data[target_upcase][item_upcase]
       raise "Telemetry item '#{target_upcase} #{LATEST_PACKET_NAME} #{item_upcase}' does not exist" unless packets

--- a/openc3/lib/openc3/script/commands.rb
+++ b/openc3/lib/openc3/script/commands.rb
@@ -106,7 +106,7 @@ module OpenC3
       cmd_params.each do |param_name, _param_value|
         param = command['items'].find { |item| item['name'] == param_name }
         unless param
-          raise "Packet item '#{target_name} #{cmd_name} #{param_name}' does not exist"
+          raise "Item '#{target_name} #{cmd_name} #{param_name}' does not exist (command parameter validation)"
         end
       end
       _log_cmd(command, raw, no_range, no_hazardous)

--- a/openc3/lib/openc3/topics/limits_event_topic.rb
+++ b/openc3/lib/openc3/topics/limits_event_topic.rb
@@ -100,7 +100,7 @@ module OpenC3
 
       when :LIMITS_SET
         sets = sets(scope: scope)
-        raise "Set '#{event[:set]}' does not exist!" unless sets.key?(event[:set])
+        raise "Limits set '#{event[:set]}' does not exist" unless sets.key?(event[:set])
 
         # Set all existing sets to "false"
         sets = sets.transform_values! { |_key, _value| "false" }

--- a/openc3/lib/openc3/utilities/aws_bucket.rb
+++ b/openc3/lib/openc3/utilities/aws_bucket.rb
@@ -233,7 +233,7 @@ module OpenC3
       # Array of objects with key and size methods
       result
     rescue Aws::S3::Errors::NoSuchBucket
-      raise NotFound, "Bucket '#{bucket}' does not exist."
+      raise NotFound, "Bucket '#{bucket}' does not exist (list_objects)"
     end
 
     # Lists the files under a specified path
@@ -283,7 +283,7 @@ module OpenC3
       end
       result
     rescue Aws::S3::Errors::NoSuchBucket
-      raise NotFound, "Bucket '#{bucket}' does not exist."
+      raise NotFound, "Bucket '#{bucket}' does not exist (list_files)"
     end
 
     # get metadata for a specific object

--- a/openc3/lib/openc3/utilities/csv.rb
+++ b/openc3/lib/openc3/utilities/csv.rb
@@ -59,7 +59,7 @@ module OpenC3
     # @param index [Integer] Which value to return
     # @return [Boolean] Single value converted to a boolean (true or false)
     def bool(item, index = 0)
-      raise "#{item} not found" unless keys.include?(item)
+      raise "CSV key '#{item}' not found for bool conversion" unless keys.include?(item)
 
       if Range === index
         @hash[item][index].map do |x|
@@ -91,7 +91,7 @@ module OpenC3
     # @param index [Integer] Which value to return
     # @return [Integer] Single value converted to an integer
     def int(item, index = 0)
-      raise "#{item} not found" unless keys.include?(item)
+      raise "CSV key '#{item}' not found for int conversion" unless keys.include?(item)
 
       if Range === index
         @hash[item][index].map { |x| x.to_i }
@@ -107,7 +107,7 @@ module OpenC3
     # @param index [Integer] Which value to return
     # @return [Float] Single value converted to a float
     def float(item, index = 0)
-      raise "#{item} not found" unless keys.include?(item)
+      raise "CSV key '#{item}' not found for float conversion" unless keys.include?(item)
 
       if Range === index
         @hash[item][index].map { |x| x.to_f }
@@ -122,7 +122,7 @@ module OpenC3
     # @param index [Integer] Which value to return
     # @return [String] Single value converted to a string
     def string(item, index = 0)
-      raise "#{item} not found" unless keys.include?(item)
+      raise "CSV key '#{item}' not found for string lookup" unless keys.include?(item)
 
       if Range === index
         @hash[item][index].map { |x| x.to_s }
@@ -138,7 +138,7 @@ module OpenC3
     # @param index [Integer] Which value to return
     # @return [Symbol] Single value converted to a symbol
     def symbol(item, index = 0)
-      raise "#{item} not found" unless keys.include?(item)
+      raise "CSV key '#{item}' not found for symbol lookup" unless keys.include?(item)
 
       if Range === index
         @hash[item][index].map { |x| x.intern }

--- a/openc3/lib/openc3/utilities/running_script.rb
+++ b/openc3/lib/openc3/utilities/running_script.rb
@@ -643,7 +643,7 @@ class RunningScript
 
     # Retrieve file
     @body = ::Script.body(@script_status.scope, @script_status.filename)
-    raise "Script not found: #{@script_status.filename}" if @body.nil?
+    raise "Script not found during initialization: #{@script_status.filename}" if @body.nil?
     breakpoints = @@breakpoints[@script_status.filename]&.filter { |_, present| present }&.map { |line_number, _| line_number - 1 } # -1 because frontend lines are 0-indexed
     breakpoints ||= []
     running_script_anycable_publish("running-script-channel:#{@script_status.id}", { type: :file, filename: @script_status.filename, scope: @script_status.scope, text: @body.to_utf8, breakpoints: breakpoints })
@@ -1518,7 +1518,7 @@ class RunningScript
       running_script_anycable_publish("running-script-channel:#{@script_status.id}", { type: :file, filename: filename, text: @body.to_utf8, breakpoints: breakpoints })
     else
       text = ::Script.body(@script_status.scope, filename)
-      raise "Script not found: #{filename}" if text.nil?
+      raise "Script not found during load/require: #{filename}" if text.nil?
       @@file_cache[filename] = text
       @body = text
       running_script_anycable_publish("running-script-channel:#{@script_status.id}", { type: :file, filename: filename, text: @body.to_utf8, breakpoints: breakpoints })

--- a/openc3/python/openc3/accessors/template_accessor.py
+++ b/openc3/python/openc3/accessors/template_accessor.py
@@ -130,7 +130,7 @@ class TemplateAccessor(Accessor):
         updated_buffer = buffer.decode().replace(f"{self.left_char}{key}{self.right_char}", str(value)).encode()
 
         if buffer == updated_buffer:
-            raise RuntimeError(f"Key {key} not found in template")
+            raise RuntimeError(f"Key '{key}' not found in template (write_item)")
         buffer[0:] = updated_buffer
         return value
 
@@ -146,7 +146,7 @@ class TemplateAccessor(Accessor):
             )
 
             if buffer == updated_buffer:
-                raise RuntimeError(f"Key {key} not found in template")
+                raise RuntimeError(f"Key '{key}' not found in template (write_items)")
             buffer[0:] = updated_buffer
         return values
 

--- a/openc3/python/openc3/api/limits_api.py
+++ b/openc3/python/openc3/api/limits_api.py
@@ -145,7 +145,7 @@ def enable_limits(*args, scope=OPENC3_SCOPE):
             found_item = item
             break
     if found_item is None:
-        raise RuntimeError(f"Item '{target_name} {packet_name} {item_name}' does not exist")
+        raise RuntimeError(f"Item '{target_name} {packet_name} {item_name}' does not exist while enabling limits")
 
     TargetModel.set_packet(target_name, packet_name, packet, scope=scope)
 
@@ -189,7 +189,7 @@ def disable_limits(*args, scope=OPENC3_SCOPE):
             found_item = item
             break
     if found_item is None:
-        raise RuntimeError(f"Item '{target_name} {packet_name} {item_name}' does not exist")
+        raise RuntimeError(f"Item '{target_name} {packet_name} {item_name}' does not exist while disabling limits")
 
     TargetModel.set_packet(target_name, packet_name, packet, scope=scope)
 
@@ -291,7 +291,7 @@ def set_limits(
             else:
                 raise RuntimeError("Cannot set_limits on item without any limits")
     if found_item is None:
-        raise RuntimeError(f"Item '{target_name} {packet_name} {item_name}' does not exist")
+        raise RuntimeError(f"Item '{target_name} {packet_name} {item_name}' does not exist while setting limits")
     message = (
         f"Setting '{target_name} {packet_name} {item_name}' limits to {red_low} {yellow_low} {yellow_high} {red_high}"
     )
@@ -358,7 +358,7 @@ def set_state_color(target_name, packet_name, item_name, state_name, color, scop
             found_item = item
             break
     if found_item is None:
-        raise RuntimeError(f"Item '{target_name} {packet_name} {item_name}' does not exist")
+        raise RuntimeError(f"Item '{target_name} {packet_name} {item_name}' does not exist while setting state color")
     message = f"Setting '{target_name} {packet_name} {item_name}' state {state_name} color to {color}"
     Logger.info(message, scope=scope)
 

--- a/openc3/python/openc3/api/tlm_api.py
+++ b/openc3/python/openc3/api/tlm_api.py
@@ -141,7 +141,7 @@ def inject_tlm(target_name, packet_name, item_hash=None, type="CONVERTED", store
     target_name = target_name.upper()
     packet_name = packet_name.upper()
     if type not in CvtModel.VALUE_TYPES:
-        raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name}")
+        raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} (inject_tlm)")
 
     if item_hash:
         item_hash = {k.upper(): v for k, v in item_hash.items()}
@@ -271,7 +271,7 @@ def get_tlm_packet(*args, stale_time: int = 30, type: str = "CONVERTED", scope: 
     packet = TargetModel.packet(target_name, packet_name, scope=scope)
     t = _validate_tlm_type(type)
     if t is None:
-        raise TypeError(f"Unknown type '{type}' for {target_name} {packet_name}")
+        raise TypeError(f"Unknown type '{type}' for {target_name} {packet_name} (get_tlm_packet)")
     cvt_items = []
     for item in packet["items"]:
         if not item.get("hidden", False):

--- a/openc3/python/openc3/models/cvt_model.py
+++ b/openc3/python/openc3/models/cvt_model.py
@@ -112,7 +112,7 @@ class CvtModel(Model):
                 return pkt_hash
         packet = cls._store_for_target(target_name, scope).hget(key, packet_name)
         if packet is None:
-            raise RuntimeError(f"Packet '{target_name} {packet_name}' does not exist")
+            raise RuntimeError(f"Packet '{target_name} {packet_name}' has no current values in CVT")
         pkt_hash = json.loads(packet, cls=JsonDecoder)
         CvtModel.packet_cache[tgt_pkt_key] = [now, pkt_hash]
         return pkt_hash
@@ -142,7 +142,7 @@ class CvtModel(Model):
                 pkt_hash[f"{item_name}__C"] = value
                 pkt_hash[item_name] = value
             case _:
-                raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} {item_name}")
+                raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} {item_name} (set_item)")
         cls.set(
             pkt_hash,
             target_name=target_name,
@@ -253,7 +253,9 @@ class CvtModel(Model):
                         item_result.insert(1, pkt_hash.get(f"{value_keys[-1]}__L"))
                 else:
                     if value_keys[-1] not in pkt_hash:
-                        raise RuntimeError(f"Item '{target_name} {packet_name} {value_keys[-1]}' does not exist")
+                        raise RuntimeError(
+                            f"Item '{target_name} {packet_name} {value_keys[-1]}' does not exist (get_tlm_values)"
+                        )
                     else:
                         item_result.insert(1, None)
             results.append(item_result)
@@ -313,7 +315,7 @@ class CvtModel(Model):
             case "FORMATTED" | "WITH_UNITS":
                 pkt_hash[f"{item_name}__F"] = str(value)  # Always a String
             case _:
-                raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} {item_name}")
+                raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} {item_name} (override)")
         tgt_pkt_key = f"{scope}__tlm__{target_name}__{packet_name}"
         CvtModel.override_cache[tgt_pkt_key] = [time.time(), pkt_hash]
         store.hset(f"{scope}__override__{target_name}", packet_name, json.dumps(pkt_hash))
@@ -342,7 +344,7 @@ class CvtModel(Model):
                 if f"{item_name}__F" in pkt_hash:
                     pkt_hash.pop(f"{item_name}__F")
             case _:
-                raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} {item_name}")
+                raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} {item_name} (normalize)")
         tgt_pkt_key = f"{scope}__tlm__{target_name}__{packet_name}"
         if len(pkt_hash) == 0:
             if tgt_pkt_key in CvtModel.override_cache:
@@ -398,7 +400,7 @@ class CvtModel(Model):
             case "RAW":
                 types = [item_name]
             case _:
-                raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} {item_name}")
+                raise RuntimeError(f"Unknown type '{type}' for {target_name} {packet_name} {item_name} (get_item)")
 
         tgt_pkt_key = f"{scope}__tlm__{target_name}__{packet_name}"
         overrides = cls._get_overrides(

--- a/openc3/python/openc3/models/interface_model.py
+++ b/openc3/python/openc3/models/interface_model.py
@@ -228,7 +228,7 @@ class InterfaceModel(Model):
     def ensure_target_exists(self, target_name):
         target = TargetModel.get(name=target_name, scope=self.scope)
         if not target:
-            raise RuntimeError(f"Target {target_name} does not exist")
+            raise RuntimeError(f"Target '{target_name}' does not exist (InterfaceModel)")
         return target
 
     def unmap_target(self, target_name, cmd_only=False, tlm_only=False):

--- a/openc3/python/openc3/models/target_model.py
+++ b/openc3/python/openc3/models/target_model.py
@@ -94,7 +94,7 @@ class TargetModel(Model):
             f"{scope}__openc3{type.lower()}__{target_name}", packet_name
         )
         if not json_data:
-            raise RuntimeError(f"Packet '{target_name} {packet_name}' does not exist")
+            raise RuntimeError(f"Packet definition '{target_name} {packet_name}' does not exist")
         packet = json.loads(json_data)
 
         # Store in cache
@@ -109,7 +109,7 @@ class TargetModel(Model):
         if type not in cls.VALID_TYPES:
             raise RuntimeError(f"Unknown type {type} for {target_name}")
         if not cls.get(name=target_name, scope=scope):
-            raise RuntimeError(f"Target '{target_name}' does not exist")
+            raise RuntimeError(f"Target '{target_name}' does not exist for scope: {scope} (TargetModel)")
 
         result = []
         packets = cls._store_for_target(target_name, scope).hgetall(f"{scope}__openc3{type.lower()}__{target_name}")
@@ -166,7 +166,9 @@ class TargetModel(Model):
                 found = item
                 break
         if not found:
-            raise RuntimeError(f"Item '{packet['target_name']} {packet['packet_name']} {item_name}' does not exist")
+            raise RuntimeError(
+                f"Item '{packet['target_name']} {packet['packet_name']} {item_name}' does not exist (TargetModel)"
+            )
         return found
 
     # @return [Array<Hash>] Item hash array or raises an exception

--- a/openc3/python/openc3/packets/commands.py
+++ b/openc3/python/openc3/packets/commands.py
@@ -54,7 +54,7 @@ class Commands:
     def packets(self, target_name):
         target_packets = self.config.commands.get(target_name.upper(), None)
         if target_packets is None:
-            raise RuntimeError(f"Command target '{target_name.upper()}' does not exist")
+            raise RuntimeError(f"Command target '{target_name.upper()}' does not exist (packets lookup)")
         return target_packets
 
     # @param target_name [String] The target name
@@ -65,7 +65,9 @@ class Commands:
         target_packets = self.packets(target_name)
         packet = target_packets.get(packet_name.upper(), None)
         if packet is None:
-            raise RuntimeError(f"Command packet '{target_name.upper()} {packet_name.upper()}' does not exist")
+            raise RuntimeError(
+                f"Command packet '{target_name.upper()} {packet_name.upper()}' does not exist (packet lookup)"
+            )
         return packet
 
     # @param target_name (see #packet)
@@ -184,10 +186,10 @@ class Commands:
         # Inline packet lookup to avoid redundant .upper() calls through method chain
         target_packets = self.config.commands.get(target_upcase)
         if target_packets is None:
-            raise RuntimeError(f"Command target '{target_upcase}' does not exist")
+            raise RuntimeError(f"Command target '{target_upcase}' does not exist (build_cmd)")
         pkt = target_packets.get(packet_upcase)
         if pkt is None:
-            raise RuntimeError(f"Command packet '{target_upcase} {packet_upcase}' does not exist")
+            raise RuntimeError(f"Command packet '{target_upcase} {packet_upcase}' does not exist (build_cmd)")
 
         # Use deep_copy to avoid shared item modifications affecting the template
         # This is critical for variable_bit_size items where handle_write_variable_bit_size

--- a/openc3/python/openc3/packets/limits.py
+++ b/openc3/python/openc3/packets/limits.py
@@ -190,7 +190,9 @@ class Limits:
             raise RuntimeError(f"Item {target_name} {packet_name} {item_name} does not have any states")
         state_name = str(state_name).upper()
         if state_name not in item.states:
-            raise RuntimeError(f"State {state_name} does not exist for {target_name} {packet_name} {item_name}")
+            raise RuntimeError(
+                f"State '{state_name}' does not exist for item '{target_name} {packet_name} {item_name}'"
+            )
         color = str(color).upper()
         if color not in PacketItem.VALID_STATE_COLORS:
             raise RuntimeError(
@@ -209,10 +211,12 @@ class Limits:
 
         packets = self.config.telemetry.get(target_name.upper())
         if packets is None:
-            raise RuntimeError(f"Telemetry target '{target_name.upper()}' does not exist")
+            raise RuntimeError(f"Telemetry target '{target_name.upper()}' does not exist (limits lookup)")
 
         packet = packets.get(packet_name.upper())
         if packet is None:
-            raise RuntimeError(f"Telemetry packet '{target_name.upper()} {packet_name.upper()}' does not exist")
+            raise RuntimeError(
+                f"Telemetry packet '{target_name.upper()} {packet_name.upper()}' does not exist (limits lookup)"
+            )
 
         return packet

--- a/openc3/python/openc3/packets/packet.py
+++ b/openc3/python/openc3/packets/packet.py
@@ -538,7 +538,7 @@ class Packet(Structure):
             return super().get_item(name)
         except ValueError as error:
             raise RuntimeError(
-                f"Packet item '{self.target_name} {self.packet_name} {name.upper()}' does not exist"
+                f"Item '{self.target_name} {self.packet_name} {name.upper()}' does not exist (Packet)"
             ) from error
 
     # Read an item in the packet

--- a/openc3/python/openc3/packets/structure.py
+++ b/openc3/python/openc3/packets/structure.py
@@ -302,7 +302,7 @@ class Structure:
     def get_item(self, name):
         item = self.items.get(name.upper())
         if not item:
-            raise ValueError(f"Unknown item: {name}")
+            raise ValueError(f"Unknown item: {name} (get_item)")
         return item
 
     # self.param item [#name] Instance of StructureItem or one of its subclasses.
@@ -337,7 +337,7 @@ class Structure:
     def delete_item(self, name):
         item = self.items[name.upper()]
         if not item:
-            raise RuntimeError(f"Unknown item: {name}")
+            raise RuntimeError(f"Unknown item: {name} (delete_item)")
 
         # Find the item to delete in the sorted_items array
         item_index = None

--- a/openc3/python/openc3/packets/telemetry.py
+++ b/openc3/python/openc3/packets/telemetry.py
@@ -64,7 +64,7 @@ class Telemetry:
         upcase_target_name = target_name.upper()
         target_packets = self.config.telemetry.get(upcase_target_name, None)
         if not target_packets:
-            raise RuntimeError(f"Telemetry target '{upcase_target_name}' does not exist")
+            raise RuntimeError(f"Telemetry target '{upcase_target_name}' does not exist (packets lookup)")
 
         return target_packets
 
@@ -96,7 +96,7 @@ class Telemetry:
             target_upcase = target_name.upper()
             target_latest_data = self.config.latest_data.get(target_upcase)
             if target_latest_data is None:
-                raise RuntimeError(f"Telemetry Target '{target_upcase}' does not exist")
+                raise RuntimeError(f"Telemetry target '{target_upcase}' does not exist (item_names lookup)")
 
             item_names = target_latest_data.keys()
         else:
@@ -126,7 +126,7 @@ class Telemetry:
         item_upcase = item_name.upper()
         target_latest_data = self.config.latest_data.get(target_upcase)
         if target_latest_data is None:
-            raise RuntimeError(f"Telemetry target '{target_upcase}' does not exist")
+            raise RuntimeError(f"Telemetry target '{target_upcase}' does not exist (latest_packets lookup)")
 
         packets = self.config.latest_data[target_upcase].get(item_upcase)
         if packets is None:

--- a/openc3/python/openc3/script/commands.py
+++ b/openc3/python/openc3/script/commands.py
@@ -214,7 +214,9 @@ def _cmd_disconnect(cmd, raw, no_range, no_hazardous, *args, scope):
                         found = item
                         break
             if not found:
-                raise RuntimeError(f"Packet item '{target_name} {cmd_name} {param_name}' does not exist")
+                raise RuntimeError(
+                    f"Item '{target_name} {cmd_name} {param_name}' does not exist (command parameter validation)"
+                )
     _log_cmd(command, raw, no_range, no_hazardous)
 
 

--- a/openc3/python/openc3/script/storage.py
+++ b/openc3/python/openc3/script/storage.py
@@ -153,7 +153,7 @@ def _get_download_url(path: str, scope: str = OPENC3_SCOPE):
             scope=scope,
         )
         if response.status_code != 200:
-            raise RuntimeError(f"File not found: {path} in scope: {scope}")
+            raise RuntimeError(f"File not found: '{path}' in scope: {scope} (download URL lookup)")
 
     endpoint = f"/openc3-api/storage/download/{scope}/{targets}/{path}"
     # external must be true because we're using this URL from the frontend
@@ -173,7 +173,7 @@ def _get_storage_file(path, bucket="OPENC3_CONFIG_BUCKET", scope=OPENC3_SCOPE):
     uri = _get_uri(result["url"])
     response = requests.get(uri)
     if response.status_code == 404:
-        raise RuntimeError(f"File not found: {scope}/{path}")
+        raise RuntimeError(f"File not found: '{path}' in scope: {scope} (storage download)")
     file.write(response.content)
     file.seek(0)
     return file

--- a/openc3/python/openc3/topics/limits_event_topic.py
+++ b/openc3/python/openc3/topics/limits_event_topic.py
@@ -112,7 +112,7 @@ class LimitsEventTopic(Topic):
             case "LIMITS_SET":
                 sets = cls.sets(scope=scope)
                 if sets.get(event["set"]) is None:
-                    raise RuntimeError(f"Set '{event['set']}' does not exist!")
+                    raise RuntimeError(f"Limits set '{event['set']}' does not exist")
 
                 # Set all existing sets to "false"
                 sets = dict.fromkeys(sets, "false")

--- a/openc3/python/openc3/utilities/aws_bucket.py
+++ b/openc3/python/openc3/utilities/aws_bucket.py
@@ -160,7 +160,7 @@ class AwsBucket(Bucket):
             # Array  of objects with key and size methods
             return result
         except ClientError as exc:
-            raise Bucket.NotFoundError(f"Bucket '{bucket}' does not exist.") from exc
+            raise Bucket.NotFoundError(f"Bucket '{bucket}' does not exist (list_objects)") from exc
 
     # Lists the files under a specified path
     def list_files(self, bucket, path, only_directories=False, metadata=False):
@@ -206,7 +206,7 @@ class AwsBucket(Bucket):
                 kw_args["ContinuationToken"] = resp["NextContinuationToken"]
             return result
         except ClientError as exc:
-            raise Bucket.NotFoundError(f"Bucket '{bucket}' does not exist.") from exc
+            raise Bucket.NotFoundError(f"Bucket '{bucket}' does not exist (list_files)") from exc
 
     # get metadata for a specific object
     def head_object(self, bucket, key):

--- a/openc3/python/test/api/test_cmd_api.py
+++ b/openc3/python/test/api/test_cmd_api.py
@@ -760,11 +760,11 @@ class TestCmdApi(unittest.TestCase):
         self.assertEqual(get_cmd_time(), (None, None, 0, 0))
 
     def test_get_cmd_cnt_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH ABORT' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH ABORT' does not exist"):
             get_cmd_cnt("BLAH", "ABORT")
 
     def test_get_cmd_cnt_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             get_cmd_cnt("INST BLAH")
 
     def test_get_cmd_cnt_returns_the_transmit_count(self):

--- a/openc3/python/test/api/test_limits_api.py
+++ b/openc3/python/test/api/test_limits_api.py
@@ -74,15 +74,15 @@ class TestLimitsApi(unittest.TestCase):
         time.sleep(0.001)
 
     def test_get_limits_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             get_limits("BLAH", "HEALTH_STATUS", "TEMP1")
 
     def test_get_limits_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             get_limits("INST", "BLAH", "TEMP1")
 
     def test_get_limits_complains_about_non_existant_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'INST HEALTH_STATUS BLAH' does not exist \(TargetModel\)"):
             get_limits("INST", "HEALTH_STATUS", "BLAH")
 
     def test_gets_limits_for_an_item(self):
@@ -115,11 +115,11 @@ class TestLimitsApi(unittest.TestCase):
         )
 
     def test_set_limits_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             set_limits("BLAH", "HEALTH_STATUS", "TEMP1", 0.0, 10.0, 20.0, 30.0)
 
     def test_set_limits_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             set_limits("INST", "BLAH", "TEMP1", 0.0, 10.0, 20.0, 30.0)
 
     def test_set_limits_complains_about_non_existant_items(self):
@@ -202,11 +202,11 @@ class TestLimitsApi(unittest.TestCase):
         )
 
     def test_set_state_color_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             set_state_color("BLAH", "HEALTH_STATUS", "GROUND1STATUS", "CONNECTED", "RED")
 
     def test_set_state_color_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             set_state_color("INST", "BLAH", "GROUND1STATUS", "CONNECTED", "RED")
 
     def test_set_state_color_complains_about_non_existant_items(self):
@@ -510,30 +510,30 @@ class TestLimitsApi(unittest.TestCase):
             get_overall_limits_state([["INST", "HEALTH_STATUS"]])
 
     def test_limits_enabled_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             limits_enabled("BLAH", "HEALTH_STATUS", "TEMP1")
 
     def test_limits_enabled_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             limits_enabled("INST", "BLAH", "TEMP1")
 
     def test_limits_enabled_complains_about_non_existant_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'INST HEALTH_STATUS BLAH' does not exist \(TargetModel\)"):
             limits_enabled("INST", "HEALTH_STATUS", "BLAH")
 
     def test_limits_enabled_returns_whether_limits_are_enable_for_an_item(self):
         self.assertTrue(limits_enabled("INST", "HEALTH_STATUS", "TEMP1"))
 
     def test_enable_limits_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             enable_limits("BLAH", "HEALTH_STATUS", "TEMP1")
 
     def test_enable_limits_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             enable_limits("INST", "BLAH", "TEMP1")
 
     def test_enable_limits_complains_about_non_existant_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'INST HEALTH_STATUS BLAH' does not exist \(TargetModel\)"):
             enable_limits("INST", "HEALTH_STATUS", "BLAH")
 
     def test_enable_limits_enables_limits_for_an_item(self):
@@ -544,15 +544,15 @@ class TestLimitsApi(unittest.TestCase):
         self.assertTrue(limits_enabled("INST", "HEALTH_STATUS", "TEMP1"))
 
     def test_disable_limits_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             disable_limits("BLAH", "HEALTH_STATUS", "TEMP1")
 
     def test_disable_limits_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             disable_limits("INST", "BLAH", "TEMP1")
 
     def test_disable_limits_complains_about_non_existant_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'INST HEALTH_STATUS BLAH' does not exist \(TargetModel\)"):
             disable_limits("INST", "HEALTH_STATUS", "BLAH")
 
     def test_disable_limits_disables_limits_for_an_item(self):

--- a/openc3/python/test/api/test_tlm_api.py
+++ b/openc3/python/test/api/test_tlm_api.py
@@ -224,11 +224,11 @@ class TestTlmApi(unittest.TestCase):
             time.sleep(0.001)
 
     def test_inject_tlm_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             inject_tlm("BLAH", "HEALTH_STATUS")
 
     def test_inject_tlm_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             inject_tlm("INST", "BLAH")
 
     def test_inject_tlm_complains_about_non_existant_items(self):
@@ -528,7 +528,7 @@ class TestTlmApi(unittest.TestCase):
 
     # get_all_tlm
     def test_get_all_tlm_raises_if_the_target_does_not_exist(self):
-        with self.assertRaisesRegex(RuntimeError, "Target 'BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Target 'BLAH' does not exist.*\(TargetModel\)"):
             get_all_tlm("BLAH", scope="DEFAULT")
 
     def test_get_all_tlm_returns_an_array_of_all_packet_hashes(self):
@@ -588,9 +588,9 @@ class TestTlmApi(unittest.TestCase):
 
     # get_tlm
     def test_get_tlm_raises_if_the_target_or_packet_do_not_exist(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             get_tlm("BLAH", "HEALTH_STATUS", scope="DEFAULT")
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             get_tlm("INST BLAH", scope="DEFAULT")
 
     def test_get_tlm_returns_a_packet_hash(self):
@@ -603,11 +603,11 @@ class TestTlmApi(unittest.TestCase):
 
     # get_item
     def test_get_item_raises_if_the_target_or_packet_or_item_do_not_exist(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             get_item("BLAH", "HEALTH_STATUS", "CCSDSVER", scope="DEFAULT")
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             get_item("INST BLAH CCSDSVER", scope="DEFAULT")
-        with self.assertRaisesRegex(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'INST HEALTH_STATUS BLAH' does not exist \(TargetModel\)"):
             get_item("INST", "HEALTH_STATUS", "BLAH", scope="DEFAULT")
         with self.assertRaisesRegex(RuntimeError, "ERROR: Target name, packet name and item name required."):
             get_item("INST HEALTH_STATUS", scope="DEFAULT")
@@ -643,15 +643,15 @@ class TestTlmApi(unittest.TestCase):
 
     # get_tlm_packet
     def test_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             get_tlm_packet("BLAH", "HEALTH_STATUS")
 
     def test_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             get_tlm_packet("INST BLAH")
 
     def test_complains_using_latest(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST LATEST' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST LATEST' does not exist"):
             get_tlm_packet("INST", "LATEST")
 
     def test_complains_about_non_existant_value_types(self):
@@ -782,15 +782,15 @@ class TestTlmApi(unittest.TestCase):
 
     # get_tlm_values
     def test_get_tlm_values_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' has no current values in CVT"):
             get_tlm_values(["BLAH__HEALTH_STATUS__TEMP1__CONVERTED"])
 
     def test_get_tlm_values_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' has no current values in CVT"):
             get_tlm_values(["INST__BLAH__TEMP1__CONVERTED"])
 
     def test_get_tlm_values_complains_about_non_existant_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'INST HEALTH_STATUS BLAH' does not exist \(get_tlm_values\)"):
             get_tlm_values(["INST__HEALTH_STATUS__BLAH__CONVERTED"])
         with self.assertRaisesRegex(RuntimeError, "Item 'INST LATEST BLAH' does not exist for scope: DEFAULT"):
             get_tlm_values(["INST__LATEST__BLAH__CONVERTED"])
@@ -1103,11 +1103,11 @@ class TestTlmApi(unittest.TestCase):
                     raise RuntimeError("Found too many packets")
 
     def test_get_tlm_cnt_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH ABORT' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH ABORT' does not exist"):
             get_tlm_cnt("BLAH", "ABORT")
 
     def test_get_tlm_cnt_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             get_tlm_cnt("INST", "BLAH")
 
     def test_get_tlm_cnt_complains_about_missing_packet(self):
@@ -1138,11 +1138,11 @@ class TestTlmApi(unittest.TestCase):
         self.assertEqual(cnts, ([result]))
 
     def test_get_packet_derived_items_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH ABORT' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH ABORT' does not exist"):
             get_packet_derived_items("BLAH", "ABORT")
 
     def test_get_packet_derived_items_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             get_packet_derived_items("INST", "BLAH")
 
     def test_get_packet_derived_items_returns_the_packet_derived_items(self):

--- a/openc3/python/test/conversions/test_unix_time_formatted_conversion.py
+++ b/openc3/python/test/conversions/test_unix_time_formatted_conversion.py
@@ -47,14 +47,14 @@ class TestUnixTimeFormattedConversion(unittest.TestCase):
     def test_complains_if_the_seconds_item_doesnt_exist(self):
         utfc = UnixTimeFormattedConversion("TIME")
         packet = Packet("TGT", "PKT")
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT PKT TIME' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT PKT TIME' does not exist \(Packet\)"):
             utfc.call(None, packet, packet.buffer)
 
     def test_complains_if_the_microseconds_item_doesnt_exist(self):
         utfc = UnixTimeFormattedConversion("TIME", "TIME_US")
         packet = Packet("TGT", "PKT")
         packet.append_item("TIME", 32, "UINT")
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT PKT TIME_US' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT PKT TIME_US' does not exist \(Packet\)"):
             utfc.call(None, packet, packet.buffer)
 
     def test_returns_the_seconds_conversion(self):

--- a/openc3/python/test/conversions/test_unix_time_seconds_conversion.py
+++ b/openc3/python/test/conversions/test_unix_time_seconds_conversion.py
@@ -45,14 +45,14 @@ class TestUnixTimeSecondsConversion(unittest.TestCase):
     def test_complains_if_the_seconds_item_doesnt_exist(self):
         utsc = UnixTimeSecondsConversion("TIME")
         packet = Packet("TGT", "PKT")
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT PKT TIME' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT PKT TIME' does not exist \(Packet\)"):
             utsc.call(None, packet, packet.buffer)
 
     def test_complains_if_the_microseconds_item_doesnt_exist(self):
         utsc = UnixTimeSecondsConversion("TIME", "TIME_US")
         packet = Packet("TGT", "PKT")
         packet.append_item("TIME", 32, "UINT")
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT PKT TIME_US' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT PKT TIME_US' does not exist \(Packet\)"):
             utsc.call(None, packet, packet.buffer)
 
     def test_returns_the_seconds_conversion(self):

--- a/openc3/python/test/interfaces/protocols/test_crc_protocol.py
+++ b/openc3/python/test/interfaces/protocols/test_crc_protocol.py
@@ -846,7 +846,7 @@ class TestCrcProtocol(unittest.TestCase):
         packet.append_item("CRC", 32, "UINT")
         packet.append_item("TRAILER", 32, "UINT")
         packet.buffer = b"\x00\x01\x02\x03\x00\x00\x00\x00\x04\x05\x06\x07"
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT PKT MYCRC' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT PKT MYCRC' does not exist \(Packet\)"):
             self.interface.write(packet)
 
     def test_calculates_and_writes_the_8_bit_crc_item(self):

--- a/openc3/python/test/models/test_cvt_model.py
+++ b/openc3/python/test/models/test_cvt_model.py
@@ -267,12 +267,12 @@ class TestCvtModel(unittest.TestCase):
         self.assertEqual(CvtModel.get_tlm_values([]), ([]))
 
     def test_gettlm_raises_on_invalid_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'NOPE BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet 'NOPE BLAH' has no current values in CVT"):
             CvtModel.get_tlm_values([["NOPE", "BLAH", "TEMP1", "RAW"]])
 
     def test_gettlm_raises_on_invalid_items(self):
         self.update_temp1()
-        with self.assertRaisesRegex(RuntimeError, "Item 'INST HEALTH_STATUS NOPE' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'INST HEALTH_STATUS NOPE' does not exist \(get_tlm_values\)"):
             CvtModel.get_tlm_values([["INST", "HEALTH_STATUS", "NOPE", "RAW"]])
 
     def test_gettlm_raises_on_invalid_types(self):

--- a/openc3/python/test/models/test_target_model.py
+++ b/openc3/python/test/models/test_target_model.py
@@ -161,7 +161,7 @@ class TestTargetModelPackets(unittest.TestCase):
             TargetModel.packets("INST", type="OTHER", scope="DEFAULT")
 
     def test_raises_for_a_non_existent_target(self):
-        with self.assertRaisesRegex(RuntimeError, "Target 'NOPE' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Target 'NOPE' does not exist.*\(TargetModel\)"):
             TargetModel.packets("NOPE", type="TLM", scope="DEFAULT")
 
     def test_returns_all_telemetry_packets(self):
@@ -216,11 +216,11 @@ class TestTargetModelPacket(unittest.TestCase):
             TargetModel.packet("INST", "HEALTH_STATUS", type="OTHER", scope="DEFAULT")
 
     def test_raises_for_a_non_existent_target(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             TargetModel.packet("BLAH", "HEALTH_STATUS", type="TLM", scope="DEFAULT")
 
     def test_raises_for_a_non_existent_packet(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             TargetModel.packet("INST", "BLAH", type="TLM", scope="DEFAULT")
 
     def test_returns_packet_hash_if_the_telemetry_exists(self):
@@ -310,15 +310,15 @@ class TestTargetModelPacketItem(unittest.TestCase):
             TargetModel.packet_item("INST", "HEALTH_STATUS", "CCSDSVER", type="OTHER", scope="DEFAULT")
 
     def test_raises_for_a_non_existent_target(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             TargetModel.packet_item("BLAH", "HEALTH_STATUS", "CCSDSVER", scope="DEFAULT")
 
     def test_raises_for_a_non_existent_packet(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             TargetModel.packet_item("INST", "BLAH", "CCSDSVER", scope="DEFAULT")
 
     def test_raises_for_a_non_existent_item(self):
-        with self.assertRaisesRegex(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'INST HEALTH_STATUS BLAH' does not exist \(TargetModel\)"):
             TargetModel.packet_item("INST", "HEALTH_STATUS", "BLAH", scope="DEFAULT")
 
     def test_returns_item_hash_if_the_telemetry_item_exists(self):
@@ -344,11 +344,11 @@ class TestTargetModelPacketItems(unittest.TestCase):
             TargetModel.packet_items("INST", "HEALTH_STATUS", ["CCSDSVER"], type="OTHER", scope="DEFAULT")
 
     def test_raises_for_a_non_existent_target(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist"):
             TargetModel.packet_items("BLAH", "HEALTH_STATUS", ["CCSDSVER"], scope="DEFAULT")
 
     def test_raises_for_a_non_existent_packet(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet 'INST BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Packet definition 'INST BLAH' does not exist"):
             TargetModel.packet_items("INST", "BLAH", ["CCSDSVER"], scope="DEFAULT")
 
     def test_raises_for_a_non_existent_item(self):

--- a/openc3/python/test/packets/test_commands.py
+++ b/openc3/python/test/packets/test_commands.py
@@ -136,7 +136,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(self.cmd.target_names(), ["TGT1", "TGT2"])
 
     def test_packets_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Command target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Command target 'TGTX' does not exist \(packets lookup\)"):
             self.cmd.packets("tgtX")
 
     def test_packets_returns_all_packets_target_tgt1(self):
@@ -158,11 +158,11 @@ class TestCommands(unittest.TestCase):
         self.assertIn("HYBRIDCMD", pkts.keys())
 
     def test_params_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Command target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Command target 'TGTX' does not exist \(packets lookup\)"):
             self.cmd.params("TGTX", "PKT1")
 
     def test_params_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Command packet 'TGT1 PKTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Command packet 'TGT1 PKTX' does not exist \(packet lookup\)"):
             self.cmd.params("TGT1", "PKTX")
 
     def test_params_returns_all_items_from_packet_tgt1_pkt1(self):
@@ -186,11 +186,11 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(items[8].name, "ITEM4")
 
     def test_packet_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Command target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Command target 'TGTX' does not exist \(packets lookup\)"):
             self.cmd.packet("tgtX", "pkt1")
 
     def test_packet_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Command packet 'TGT1 PKTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Command packet 'TGT1 PKTX' does not exist \(packet lookup\)"):
             self.cmd.packet("TGT1", "PKTX")
 
     def test_packet_returns_the_specified_packet(self):
@@ -288,19 +288,19 @@ class TestCommands(unittest.TestCase):
     def test_build_cmd_complains_about_non_existant_targets(self):
         for range_checking in [True, False]:
             for raw in [True, False]:
-                with self.assertRaisesRegex(RuntimeError, "Command target 'TGTX' does not exist"):
+                with self.assertRaisesRegex(RuntimeError, r"Command target 'TGTX' does not exist \(build_cmd\)"):
                     self.cmd.build_cmd("tgtX", "pkt1", {}, range_checking, raw)
 
     def test_build_cmd_complains_about_non_existant_packets(self):
         for range_checking in [True, False]:
             for raw in [True, False]:
-                with self.assertRaisesRegex(RuntimeError, "Command packet 'TGT1 PKTX' does not exist"):
+                with self.assertRaisesRegex(RuntimeError, r"Command packet 'TGT1 PKTX' does not exist \(build_cmd\)"):
                     self.cmd.build_cmd("tgt1", "pktX", {}, range_checking, raw)
 
     def test_build_cmd_complains_about_non_existant_items(self):
         for range_checking in [True, False]:
             for raw in [True, False]:
-                with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+                with self.assertRaisesRegex(RuntimeError, r"Item 'TGT1 PKT1 ITEMX' does not exist \(Packet\)"):
                     self.cmd.build_cmd("tgt1", "pkt1", {"itemX": 1}, range_checking, raw)
 
     def test_build_cmd_complains_about_missing_required_parameters(self):
@@ -501,15 +501,15 @@ class TestCommands(unittest.TestCase):
         )
 
     def test_cmd_hazardous_complains_about_non_existant_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Command target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Command target 'TGTX' does not exist \(build_cmd\)"):
             self.cmd.cmd_hazardous("tgtX", "pkt1")
 
     def test_cmd_hazardous_complains_about_non_existant_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Command packet 'TGT1 PKTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Command packet 'TGT1 PKTX' does not exist \(build_cmd\)"):
             self.cmd.cmd_hazardous("tgt1", "pktX")
 
     def test_cmd_hazardous_complains_about_non_existant_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist"):
             self.cmd.cmd_hazardous("tgt1", "pkt1", {"itemX": 1})
 
     def test_cmd_hazardous_returns_true_if_the_command_overall_is_hazardous(self):

--- a/openc3/python/test/packets/test_limits.py
+++ b/openc3/python/test/packets/test_limits.py
@@ -91,15 +91,15 @@ class TestLimits(unittest.TestCase):
         tf.close()
 
     def test_enabled_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(limits lookup\)"):
             self.limits.enabled("TGTX", "PKT1", "ITEM1")
 
     def test_enabled_complains_about_non_existent_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry packet 'TGT1 PKTX' does not exist \(limits lookup\)"):
             self.limits.enabled("TGT1", "PKTX", "ITEM1")
 
     def test_enabled_complains_about_non_existent_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT1 PKT1 ITEMX' does not exist \(Packet\)"):
             self.limits.enabled("TGT1", "PKT1", "ITEMX")
 
     def test_returns_whether_limits_are_enable_for_an_item(self):
@@ -109,15 +109,15 @@ class TestLimits(unittest.TestCase):
         self.assertTrue(self.limits.enabled("TGT1", "PKT1", "ITEM5"))
 
     def test_enable_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(limits lookup\)"):
             self.limits.enable("TGTX", "PKT1", "ITEM1")
 
     def test_enable_complains_about_non_existent_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry packet 'TGT1 PKTX' does not exist \(limits lookup\)"):
             self.limits.enable("TGT1", "PKTX", "ITEM1")
 
     def test_enable_complains_about_non_existent_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT1 PKT1 ITEMX' does not exist \(Packet\)"):
             self.limits.enable("TGT1", "PKT1", "ITEMX")
 
     def test_enables_limits_for_an_item(self):
@@ -127,15 +127,15 @@ class TestLimits(unittest.TestCase):
         self.assertTrue(self.limits.enabled("TGT1", "PKT1", "ITEM5"))
 
     def test_disable_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(limits lookup\)"):
             self.limits.disable("TGTX", "PKT1", "ITEM1")
 
     def test_disable_complains_about_non_existent_packets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry packet 'TGT1 PKTX' does not exist \(limits lookup\)"):
             self.limits.disable("TGT1", "PKTX", "ITEM1")
 
     def test_disable_complains_about_non_existent_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT1 PKT1 ITEMX' does not exist \(Packet\)"):
             self.limits.disable("TGT1", "PKT1", "ITEMX")
 
     def test_disables_limits_for_an_item(self):
@@ -219,7 +219,7 @@ class TestLimits(unittest.TestCase):
             self.limits.set_state_color("TGT1", "PKT1", "ITEM5", "CONNECTED", "RED")
 
     def test_set_state_color_complains_about_non_existent_states(self):
-        with self.assertRaisesRegex(RuntimeError, "State BLAH does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "State 'BLAH' does not exist for item 'TGT1 PKT1 STATE1'"):
             self.limits.set_state_color("TGT1", "PKT1", "STATE1", "BLAH", "RED")
 
     def test_set_state_color_complains_about_invalid_colors(self):

--- a/openc3/python/test/packets/test_packet.py
+++ b/openc3/python/test/packets/test_packet.py
@@ -312,7 +312,7 @@ class Buffer(unittest.TestCase):
 
     def test_complains_if_an_item_doesnt_exist(self):
         p = Packet("tgt", "pkt")
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT PKT TEST' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT PKT TEST' does not exist \(Packet\)"):
             p.get_item("test")
 
 

--- a/openc3/python/test/packets/test_structure.py
+++ b/openc3/python/test/packets/test_structure.py
@@ -340,7 +340,7 @@ class TestStructureGetItem(unittest.TestCase):
         self.assertIsNotNone(self.s.get_item("test1"))
 
     def test_complains_if_an_item_doesnt_exist(self):
-        self.assertRaisesRegex(ValueError, "Unknown item: test2", self.s.get_item, "test2")
+        self.assertRaisesRegex(ValueError, r"Unknown item: test2 \(get_item\)", self.s.get_item, "test2")
 
 
 class TestStructureSetItem(unittest.TestCase):
@@ -375,7 +375,7 @@ class TestStructureDeleteItem(unittest.TestCase):
         self.s.append_item("test2", 16, "UINT")
         self.assertEqual(self.s.defined_length, 3)
         self.s.delete_item("test1")
-        self.assertRaisesRegex(ValueError, "Unknown item: test1", self.s.get_item, "test1")
+        self.assertRaisesRegex(ValueError, r"Unknown item: test1 \(get_item\)", self.s.get_item, "test1")
         self.assertEqual(self.s.defined_length, 3)
         self.assertIsNone(self.s.items.get("TEST1"))
         self.assertIsNotNone(self.s.items["TEST2"])
@@ -458,7 +458,7 @@ class TestStructureWriteItem(unittest.TestCase):
 
 class TestStructureRead(unittest.TestCase):
     def test_complains_if_item_doesnt_exist(self):
-        self.assertRaisesRegex(ValueError, "Unknown item: BLAH", Structure().read, "BLAH")
+        self.assertRaisesRegex(ValueError, r"Unknown item: BLAH \(get_item\)", Structure().read, "BLAH")
 
     def test_reads_data_from_the_buffer(self):
         s = Structure()
@@ -487,7 +487,7 @@ class TestStructureRead(unittest.TestCase):
 
 class TestStructureWrite(unittest.TestCase):
     def test_complains_if_item_doesnt_exist(self):
-        with self.assertRaisesRegex(ValueError, "Unknown item: BLAH"):
+        with self.assertRaisesRegex(ValueError, r"Unknown item: BLAH \(get_item\)"):
             Structure().write("BLAH", 0)
 
     def test_writes_data_to_the_buffer(self):

--- a/openc3/python/test/packets/test_telemetry.py
+++ b/openc3/python/test/packets/test_telemetry.py
@@ -66,7 +66,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertEqual(self.tlm.target_names(), ["TGT1", "TGT2"])
 
     def test_packets_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(packets lookup\)"):
             self.tlm.packets("tgtX")
 
     def test_packets_returns_all_packets_target_tgt1(self):
@@ -81,7 +81,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertIn("PKT1", pkts.keys())
 
     def test_packet_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(packets lookup\)"):
             self.tlm.packet("tgtX", "pkt1")
 
     def test_packet_complains_about_non_existent_packets(self):
@@ -98,7 +98,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertEqual(pkt.packet_name, "PKT1")
 
     def test_items_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(packets lookup\)"):
             self.tlm.items("tgtX", "pkt1")
 
     def test_items_complains_about_non_existent_packets(self):
@@ -141,7 +141,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertIn("ITEM4", items)
 
     def test_packet_and_item_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(packets lookup\)"):
             self.tlm.packet_and_item("tgtX", "pkt1", "item1")
 
     def test_packet_and_item_complains_about_non_existent_packets(self):
@@ -149,7 +149,7 @@ class TestTelemetry(unittest.TestCase):
             self.tlm.packet_and_item("TGT1", "PKTX", "ITEM1")
 
     def test_packet_and_item_complains_about_non_existent_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT1 PKT1 ITEMX' does not exist \(Packet\)"):
             self.tlm.packet_and_item("TGT1", "PKT1", "ITEMX")
 
     def test_packet_and_item_returns_the_packet_and_item(self):
@@ -162,7 +162,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertEqual(item.name, "ITEM1")
 
     def test_latest_packets_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(latest_packets lookup\)"):
             self.tlm.latest_packets("tgtX", "item1")
 
     def test_latest_packets_complains_about_non_existent_items(self):
@@ -176,7 +176,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertEqual(pkts[1].packet_name, "PKT2")
 
     def test_newest_packet_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(latest_packets lookup\)"):
             self.tlm.newest_packet("tgtX", "item1")
 
     def test_newest_packet_complains_about_non_existent_items(self):
@@ -339,7 +339,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertIsNone(pkt)
 
     def test_update_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(packets lookup\)"):
             self.tlm.update("TGTX", "PKT1", b"\x00")
 
     def test_update_complains_about_non_existent_packets(self):
@@ -388,7 +388,7 @@ class TestTelemetry(unittest.TestCase):
         callback.assert_called()
 
     def test_value_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(packets lookup\)"):
             self.tlm.value("TGTX", "PKT1", "ITEM1")
 
     def test_value_complains_about_non_existent_packets(self):
@@ -396,7 +396,7 @@ class TestTelemetry(unittest.TestCase):
             self.tlm.value("TGT1", "PKTX", "ITEM1")
 
     def test_value_complains_about_non_existent_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT1 PKT1 ITEMX' does not exist \(Packet\)"):
             self.tlm.value("TGT1", "PKT1", "ITEMX")
 
     def test_value_returns_the_value(self):
@@ -406,7 +406,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertEqual(self.tlm.value("TGT1", "LATEST", "ITEM1"), 0)
 
     def test_set_value_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(packets lookup\)"):
             self.tlm.set_value("TGTX", "PKT1", "ITEM1", 1)
 
     def test_set_value_complains_about_non_existent_packets(self):
@@ -414,7 +414,7 @@ class TestTelemetry(unittest.TestCase):
             self.tlm.set_value("TGT1", "PKTX", "ITEM1", 1)
 
     def test_set_value_complains_about_non_existent_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT1 PKT1 ITEMX' does not exist \(Packet\)"):
             self.tlm.set_value("TGT1", "PKT1", "ITEMX", 1)
 
     def test_set_value_sets_the_value(self):
@@ -427,7 +427,7 @@ class TestTelemetry(unittest.TestCase):
         self.assertEqual(self.tlm.value("TGT1", "PKT2", "ITEM1"), 1)
 
     def test_values_and_limits_states_complains_about_non_existent_targets(self):
-        with self.assertRaisesRegex(RuntimeError, "Telemetry target 'TGTX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Telemetry target 'TGTX' does not exist \(packets lookup\)"):
             self.tlm.values_and_limits_states([["TGTX", "PKT1", "ITEM1"]])
 
     def test_values_and_limits_states_complains_about_non_existent_packets(self):
@@ -435,7 +435,7 @@ class TestTelemetry(unittest.TestCase):
             self.tlm.values_and_limits_states([["TGT1", "PKTX", "ITEM1"]])
 
     def test_values_and_limits_states_complains_about_non_existent_items(self):
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, r"Item 'TGT1 PKT1 ITEMX' does not exist \(Packet\)"):
             self.tlm.values_and_limits_states([["TGT1", "PKT1", "ITEMX"]])
 
     def test_values_and_limits_states_complains_about_non_existent_value_types(self):

--- a/openc3/python/test/script/test_commands.py
+++ b/openc3/python/test/script/test_commands.py
@@ -200,7 +200,7 @@ class TestCommands(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid number of arguments"):
             cmd("INST", "COLLECT", "TYPE", "SPECIAL")
 
-        with self.assertRaisesRegex(RuntimeError, "Packet item 'INST COLLECT NOPE' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Item 'INST COLLECT NOPE' does not exist"):
             cmd("INST", "COLLECT", {"NOPE": "NOPE"})
 
     def test_sends_a_hazardous_cmd(self):

--- a/openc3/python/test/topics/test_limits_event_topic.py
+++ b/openc3/python/test/topics/test_limits_event_topic.py
@@ -216,7 +216,7 @@ class TestLimitsEventTopic(unittest.TestCase):
         self.assertEqual(sets["DEFAULT"], "false")
 
     def test_raise_limits_set_when_set_does_not_exist(self):
-        with self.assertRaisesRegex(RuntimeError, "Set 'BLAH' does not exist"):
+        with self.assertRaisesRegex(RuntimeError, "Limits set 'BLAH' does not exist"):
             event = {"type": "LIMITS_SET", "set": "BLAH", "message": "Limits Set"}
             LimitsEventTopic.write(event, scope="DEFAULT")
 

--- a/openc3/spec/api/cmd_api_spec.rb
+++ b/openc3/spec/api/cmd_api_spec.rb
@@ -374,7 +374,7 @@ module OpenC3
 
     describe "send_raw" do
       it "raises on unknown interfaces" do
-        expect { @api.send_raw("BLAH_INT", "\x00\x01\x02\x03") }.to raise_error("Interface 'BLAH_INT' does not exist")
+        expect { @api.send_raw("BLAH_INT", "\x00\x01\x02\x03") }.to raise_error("Interface 'BLAH_INT' does not exist (get_interface)")
       end
 
       it "sends raw data to an interface" do
@@ -582,12 +582,12 @@ module OpenC3
 
     describe "get_cmd_cnt" do
       it "complains about non-existent targets" do
-        expect { @api.get_cmd_cnt("BLAH", "ABORT") }.to raise_error("Packet 'BLAH ABORT' does not exist")
-        expect { @api.get_cmd_cnt("BLAH ABORT") }.to raise_error("Packet 'BLAH ABORT' does not exist")
+        expect { @api.get_cmd_cnt("BLAH", "ABORT") }.to raise_error("Packet definition 'BLAH ABORT' does not exist")
+        expect { @api.get_cmd_cnt("BLAH ABORT") }.to raise_error("Packet definition 'BLAH ABORT' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.get_cmd_cnt("INST", "BLAH") }.to raise_error("Packet 'INST BLAH' does not exist")
+        expect { @api.get_cmd_cnt("INST", "BLAH") }.to raise_error("Packet definition 'INST BLAH' does not exist")
       end
 
       it "returns the transmit count" do

--- a/openc3/spec/api/limits_api_spec.rb
+++ b/openc3/spec/api/limits_api_spec.rb
@@ -63,15 +63,15 @@ module OpenC3
 
     describe "get_limits" do
       it "complains about non-existent targets" do
-        expect { @api.get_limits("BLAH", "HEALTH_STATUS", "TEMP1") }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.get_limits("BLAH", "HEALTH_STATUS", "TEMP1") }.to raise_error(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.get_limits("INST", "BLAH", "TEMP1") }.to raise_error(RuntimeError, "Packet 'INST BLAH' does not exist")
+        expect { @api.get_limits("INST", "BLAH", "TEMP1") }.to raise_error(RuntimeError, "Packet definition 'INST BLAH' does not exist")
       end
 
       it "complains about non-existent items" do
-        expect { @api.get_limits("INST", "HEALTH_STATUS", "BLAH") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist")
+        expect { @api.get_limits("INST", "HEALTH_STATUS", "BLAH") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist (TargetModel)")
       end
 
       it "gets limits for an item" do
@@ -94,15 +94,15 @@ module OpenC3
 
     describe "set_limits" do
       it "complains about non-existent targets" do
-        expect { @api.set_limits("BLAH", "HEALTH_STATUS", "TEMP1", 0.0, 10.0, 20.0, 30.0) }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.set_limits("BLAH", "HEALTH_STATUS", "TEMP1", 0.0, 10.0, 20.0, 30.0) }.to raise_error(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.set_limits("INST", "BLAH", "TEMP1", 0.0, 10.0, 20.0, 30.0) }.to raise_error(RuntimeError, "Packet 'INST BLAH' does not exist")
+        expect { @api.set_limits("INST", "BLAH", "TEMP1", 0.0, 10.0, 20.0, 30.0) }.to raise_error(RuntimeError, "Packet definition 'INST BLAH' does not exist")
       end
 
       it "complains about non-existent items" do
-        expect { @api.set_limits("INST", "HEALTH_STATUS", "BLAH", 0.0, 10.0, 20.0, 30.0) }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist")
+        expect { @api.set_limits("INST", "HEALTH_STATUS", "BLAH", 0.0, 10.0, 20.0, 30.0) }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist while setting limits")
       end
 
       it "creates a CUSTOM limits set" do
@@ -137,15 +137,15 @@ module OpenC3
 
     describe "set_state_color" do
       it "complains about non-existent targets" do
-        expect { @api.set_state_color("BLAH", "HEALTH_STATUS", "GROUND1STATUS", "CONNECTED", "RED") }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.set_state_color("BLAH", "HEALTH_STATUS", "GROUND1STATUS", "CONNECTED", "RED") }.to raise_error(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.set_state_color("INST", "BLAH", "GROUND1STATUS", "CONNECTED", "RED") }.to raise_error(RuntimeError, "Packet 'INST BLAH' does not exist")
+        expect { @api.set_state_color("INST", "BLAH", "GROUND1STATUS", "CONNECTED", "RED") }.to raise_error(RuntimeError, "Packet definition 'INST BLAH' does not exist")
       end
 
       it "complains about non-existent items" do
-        expect { @api.set_state_color("INST", "HEALTH_STATUS", "BLAH", "CONNECTED", "RED") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist")
+        expect { @api.set_state_color("INST", "HEALTH_STATUS", "BLAH", "CONNECTED", "RED") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist while setting state color")
       end
 
       it "complains about non-existent states" do
@@ -434,15 +434,15 @@ module OpenC3
 
     describe "limits_enabled?" do
       it "complains about non-existent targets" do
-        expect { @api.limits_enabled?("BLAH", "HEALTH_STATUS", "TEMP1") }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.limits_enabled?("BLAH", "HEALTH_STATUS", "TEMP1") }.to raise_error(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.limits_enabled?("INST", "BLAH", "TEMP1") }.to raise_error(RuntimeError, "Packet 'INST BLAH' does not exist")
+        expect { @api.limits_enabled?("INST", "BLAH", "TEMP1") }.to raise_error(RuntimeError, "Packet definition 'INST BLAH' does not exist")
       end
 
       it "complains about non-existent items" do
-        expect { @api.limits_enabled?("INST", "HEALTH_STATUS", "BLAH") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist")
+        expect { @api.limits_enabled?("INST", "HEALTH_STATUS", "BLAH") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist (TargetModel)")
       end
 
       it "returns whether limits are enable for an item" do
@@ -452,15 +452,15 @@ module OpenC3
 
     describe "enable_limits" do
       it "complains about non-existent targets" do
-        expect { @api.enable_limits("BLAH", "HEALTH_STATUS", "TEMP1") }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.enable_limits("BLAH", "HEALTH_STATUS", "TEMP1") }.to raise_error(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.enable_limits("INST", "BLAH", "TEMP1") }.to raise_error(RuntimeError, "Packet 'INST BLAH' does not exist")
+        expect { @api.enable_limits("INST", "BLAH", "TEMP1") }.to raise_error(RuntimeError, "Packet definition 'INST BLAH' does not exist")
       end
 
       it "complains about non-existent items" do
-        expect { @api.enable_limits("INST", "HEALTH_STATUS", "BLAH") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist")
+        expect { @api.enable_limits("INST", "HEALTH_STATUS", "BLAH") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist (TargetModel)")
       end
 
       it "enables limits for an item" do
@@ -474,15 +474,15 @@ module OpenC3
 
     describe "disable_limits" do
       it "complains about non-existent targets" do
-        expect { @api.disable_limits("BLAH", "HEALTH_STATUS", "TEMP1") }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.disable_limits("BLAH", "HEALTH_STATUS", "TEMP1") }.to raise_error(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.disable_limits("INST", "BLAH", "TEMP1") }.to raise_error(RuntimeError, "Packet 'INST BLAH' does not exist")
+        expect { @api.disable_limits("INST", "BLAH", "TEMP1") }.to raise_error(RuntimeError, "Packet definition 'INST BLAH' does not exist")
       end
 
       it "complains about non-existent items" do
-        expect { @api.disable_limits("INST", "HEALTH_STATUS", "BLAH") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist")
+        expect { @api.disable_limits("INST", "HEALTH_STATUS", "BLAH") }.to raise_error(RuntimeError, "Item 'INST HEALTH_STATUS BLAH' does not exist (TargetModel)")
       end
 
       it "disables limits for an item" do

--- a/openc3/spec/api/tlm_api_spec.rb
+++ b/openc3/spec/api/tlm_api_spec.rb
@@ -249,11 +249,11 @@ module OpenC3
       end
 
       it "complains about non-existent targets" do
-        expect { @api.inject_tlm("BLAH", "HEALTH_STATUS") }.to raise_error("Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.inject_tlm("BLAH", "HEALTH_STATUS") }.to raise_error("Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.inject_tlm("INST", "BLAH") }.to raise_error("Packet 'INST BLAH' does not exist")
+        expect { @api.inject_tlm("INST", "BLAH") }.to raise_error("Packet definition 'INST BLAH' does not exist")
       end
 
       it "complains about non-existent items" do
@@ -455,7 +455,7 @@ module OpenC3
 
     describe "get_all_tlm" do
       it "raises if the target does not exist" do
-        expect { @api.get_all_tlm("BLAH", scope: "DEFAULT") }.to raise_error("Target 'BLAH' does not exist for scope: DEFAULT")
+        expect { @api.get_all_tlm("BLAH", scope: "DEFAULT") }.to raise_error("Target 'BLAH' does not exist for scope: DEFAULT (TargetModel)")
       end
 
       it "returns an array of all packet hashes" do
@@ -501,8 +501,8 @@ module OpenC3
 
     describe "get_tlm" do
       it "raises if the target or packet do not exist" do
-        expect { @api.get_tlm("BLAH", "HEALTH_STATUS", scope: "DEFAULT") }.to raise_error("Packet 'BLAH HEALTH_STATUS' does not exist")
-        expect { @api.get_tlm("INST BLAH", scope: "DEFAULT") }.to raise_error("Packet 'INST BLAH' does not exist")
+        expect { @api.get_tlm("BLAH", "HEALTH_STATUS", scope: "DEFAULT") }.to raise_error("Packet definition 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.get_tlm("INST BLAH", scope: "DEFAULT") }.to raise_error("Packet definition 'INST BLAH' does not exist")
       end
 
       it "returns a packet hash" do
@@ -517,9 +517,9 @@ module OpenC3
 
     describe "get_item" do
       it "raises if the target or packet or item do not exist" do
-        expect { @api.get_item("BLAH", "HEALTH_STATUS", "CCSDSVER", scope: "DEFAULT") }.to raise_error("Packet 'BLAH HEALTH_STATUS' does not exist")
-        expect { @api.get_item("INST BLAH CCSDSVER", scope: "DEFAULT") }.to raise_error("Packet 'INST BLAH' does not exist")
-        expect { @api.get_item("INST", "HEALTH_STATUS", "BLAH", scope: "DEFAULT") }.to raise_error("Item 'INST HEALTH_STATUS BLAH' does not exist")
+        expect { @api.get_item("BLAH", "HEALTH_STATUS", "CCSDSVER", scope: "DEFAULT") }.to raise_error("Packet definition 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.get_item("INST BLAH CCSDSVER", scope: "DEFAULT") }.to raise_error("Packet definition 'INST BLAH' does not exist")
+        expect { @api.get_item("INST", "HEALTH_STATUS", "BLAH", scope: "DEFAULT") }.to raise_error("Item 'INST HEALTH_STATUS BLAH' does not exist (TargetModel)")
         expect { @api.get_item("INST HEALTH_STATUS", scope: "DEFAULT") }.to raise_error(/Target name, packet name and item name are required./)
       end
 
@@ -547,15 +547,15 @@ module OpenC3
 
     describe "get_tlm_packet" do
       it "complains about non-existent targets" do
-        expect { @api.get_tlm_packet("BLAH", "HEALTH_STATUS") }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.get_tlm_packet("BLAH", "HEALTH_STATUS") }.to raise_error(RuntimeError, "Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.get_tlm_packet("INST BLAH") }.to raise_error(RuntimeError, "Packet 'INST BLAH' does not exist")
+        expect { @api.get_tlm_packet("INST BLAH") }.to raise_error(RuntimeError, "Packet definition 'INST BLAH' does not exist")
       end
 
       it "complains using LATEST" do
-        expect { @api.get_tlm_packet("INST", "LATEST") }.to raise_error(RuntimeError, "Packet 'INST LATEST' does not exist")
+        expect { @api.get_tlm_packet("INST", "LATEST") }.to raise_error(RuntimeError, "Packet definition 'INST LATEST' does not exist")
       end
 
       it "complains about non-existent value_types" do
@@ -746,11 +746,11 @@ module OpenC3
 
     describe "get_tlm_values" do
       it "complains about non-existent targets" do
-        expect { @api.get_tlm_values(["BLAH__HEALTH_STATUS__TEMP1__CONVERTED"]) }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { @api.get_tlm_values(["BLAH__HEALTH_STATUS__TEMP1__CONVERTED"]) }.to raise_error(RuntimeError, "Packet 'BLAH HEALTH_STATUS' has no current values in CVT")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.get_tlm_values(["INST__BLAH__TEMP1__CONVERTED"]) }.to raise_error(RuntimeError, "Packet 'INST BLAH' does not exist")
+        expect { @api.get_tlm_values(["INST__BLAH__TEMP1__CONVERTED"]) }.to raise_error(RuntimeError, "Packet 'INST BLAH' has no current values in CVT")
       end
 
       it "complains about non-existent value_types" do
@@ -930,11 +930,11 @@ module OpenC3
 
     describe "get_tlm_cnt" do
       it "complains about non-existent targets" do
-        expect { @api.get_tlm_cnt("BLAH", "ABORT") }.to raise_error("Packet 'BLAH ABORT' does not exist")
+        expect { @api.get_tlm_cnt("BLAH", "ABORT") }.to raise_error("Packet definition 'BLAH ABORT' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.get_tlm_cnt("INST BLAH") }.to raise_error("Packet 'INST BLAH' does not exist")
+        expect { @api.get_tlm_cnt("INST BLAH") }.to raise_error("Packet definition 'INST BLAH' does not exist")
       end
 
       it "returns the receive count" do
@@ -959,11 +959,11 @@ module OpenC3
 
     describe "get_packet_derived_items" do
       it "complains about non-existent targets" do
-        expect { @api.get_packet_derived_items("BLAH", "ABORT") }.to raise_error("Packet 'BLAH ABORT' does not exist")
+        expect { @api.get_packet_derived_items("BLAH", "ABORT") }.to raise_error("Packet definition 'BLAH ABORT' does not exist")
       end
 
       it "complains about non-existent packets" do
-        expect { @api.get_packet_derived_items("INST BLAH") }.to raise_error("Packet 'INST BLAH' does not exist")
+        expect { @api.get_packet_derived_items("INST BLAH") }.to raise_error("Packet definition 'INST BLAH' does not exist")
       end
 
       it "returns the packet derived items" do

--- a/openc3/spec/conversions/unix_time_formatted_conversion_spec.rb
+++ b/openc3/spec/conversions/unix_time_formatted_conversion_spec.rb
@@ -51,14 +51,14 @@ module OpenC3
       it "complains if the seconds item doesn't exist" do
         utfc = UnixTimeFormattedConversion.new('TIME')
         packet = Packet.new("TGT", "PKT")
-        expect { utfc.call(nil, packet, packet.buffer) }.to raise_error("Packet item 'TGT PKT TIME' does not exist")
+        expect { utfc.call(nil, packet, packet.buffer) }.to raise_error("Item 'TGT PKT TIME' does not exist (Packet)")
       end
 
       it "complains if the microseconds item doesn't exist" do
         utfc = UnixTimeFormattedConversion.new('TIME', 'TIME_US')
         packet = Packet.new("TGT", "PKT")
         packet.append_item("TIME", 32, :UINT)
-        expect { utfc.call(nil, packet, packet.buffer) }.to raise_error("Packet item 'TGT PKT TIME_US' does not exist")
+        expect { utfc.call(nil, packet, packet.buffer) }.to raise_error("Item 'TGT PKT TIME_US' does not exist (Packet)")
       end
     end
 

--- a/openc3/spec/conversions/unix_time_seconds_conversion_spec.rb
+++ b/openc3/spec/conversions/unix_time_seconds_conversion_spec.rb
@@ -53,14 +53,14 @@ module OpenC3
       it "complains if the seconds item doesn't exist" do
         utsc = UnixTimeSecondsConversion.new('TIME')
         packet = Packet.new("TGT", "PKT")
-        expect { utsc.call(nil, packet, packet.buffer) }.to raise_error("Packet item 'TGT PKT TIME' does not exist")
+        expect { utsc.call(nil, packet, packet.buffer) }.to raise_error("Item 'TGT PKT TIME' does not exist (Packet)")
       end
 
       it "complains if the microseconds item doesn't exist" do
         utsc = UnixTimeSecondsConversion.new('TIME', 'TIME_US')
         packet = Packet.new("TGT", "PKT")
         packet.append_item("TIME", 32, :UINT)
-        expect { utsc.call(nil, packet, packet.buffer) }.to raise_error("Packet item 'TGT PKT TIME_US' does not exist")
+        expect { utsc.call(nil, packet, packet.buffer) }.to raise_error("Item 'TGT PKT TIME_US' does not exist (Packet)")
       end
     end
 

--- a/openc3/spec/interfaces/protocols/crc_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/crc_protocol_spec.rb
@@ -813,7 +813,7 @@ module OpenC3
         packet.append_item("CRC", 32, :UINT)
         packet.append_item("TRAILER", 32, :UINT)
         packet.buffer = "\x00\x01\x02\x03\x00\x00\x00\x00\x04\x05\x06\x07"
-        expect { @interface.write(packet) }.to raise_error(/Packet item 'TGT PKT MYCRC' does not exist/)
+        expect { @interface.write(packet) }.to raise_error(/Item 'TGT PKT MYCRC' does not exist/)
       end
 
       it "calculates and writes the 8 bit CRC item" do

--- a/openc3/spec/models/cvt_model_spec.rb
+++ b/openc3/spec/models/cvt_model_spec.rb
@@ -185,7 +185,7 @@ module OpenC3
       end
 
       it "raises on invalid packets" do
-        expect { CvtModel.get_tlm_values([["NOPE","BLAH","TEMP1","RAW"]]) }.to raise_error("Packet 'NOPE BLAH' does not exist")
+        expect { CvtModel.get_tlm_values([["NOPE","BLAH","TEMP1","RAW"]]) }.to raise_error("Packet 'NOPE BLAH' has no current values in CVT")
       end
 
       it "raises on invalid types" do

--- a/openc3/spec/models/gem_model_spec.rb
+++ b/openc3/spec/models/gem_model_spec.rb
@@ -80,7 +80,7 @@ module OpenC3
         expect { GemModel.install("openc3-test1.gem", scope: 'DEFAULT') }.to \
           raise_error(Gem::Package::FormatError, /package metadata is missing/)
         expect { GemModel.install("openc3-test3.gem", scope: 'DEFAULT') }.to \
-          raise_error(RuntimeError, /Gem openc3-test3.gem not found/)
+          raise_error(RuntimeError, /Gem 'openc3-test3.gem' not found/)
       end
     end
 

--- a/openc3/spec/models/interface_model_spec.rb
+++ b/openc3/spec/models/interface_model_spec.rb
@@ -347,7 +347,7 @@ module OpenC3
 
       it "should complain about unknown targets" do
         model1 = InterfaceModel.get_model(name: "TEST1_INT", scope: "DEFAULT")
-        expect { model1.map_target("TARGET5") }.to raise_error(RuntimeError, "Target TARGET5 does not exist")
+        expect { model1.map_target("TARGET5") }.to raise_error(RuntimeError, "Target 'TARGET5' does not exist (InterfaceModel)")
 
         umodel = double(MicroserviceModel)
         expect(umodel).to receive(:target_names).and_return([]).at_least(:once)

--- a/openc3/spec/models/target_model_spec.rb
+++ b/openc3/spec/models/target_model_spec.rb
@@ -424,7 +424,7 @@ module OpenC3
       end
 
       it "raises for a non-existent target" do
-        expect { TargetModel.packets("BLAH", scope: "DEFAULT") }.to raise_error("Target 'BLAH' does not exist for scope: DEFAULT")
+        expect { TargetModel.packets("BLAH", scope: "DEFAULT") }.to raise_error("Target 'BLAH' does not exist for scope: DEFAULT (TargetModel)")
       end
 
       it "returns all telemetry packets" do
@@ -503,11 +503,11 @@ module OpenC3
       end
 
       it "raises for a non-existent target" do
-        expect { TargetModel.packet("BLAH", "HEALTH_STATUS", type: :TLM, scope: "DEFAULT") }.to raise_error("Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { TargetModel.packet("BLAH", "HEALTH_STATUS", type: :TLM, scope: "DEFAULT") }.to raise_error("Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "raises for a non-existent packet" do
-        expect { TargetModel.packet("INST", "BLAH", type: :TLM, scope: "DEFAULT") }.to raise_error("Packet 'INST BLAH' does not exist")
+        expect { TargetModel.packet("INST", "BLAH", type: :TLM, scope: "DEFAULT") }.to raise_error("Packet definition 'INST BLAH' does not exist")
       end
 
       it "returns packet hash if the telemetry exists" do
@@ -618,15 +618,15 @@ module OpenC3
       end
 
       it "raises for a non-existent target" do
-        expect { TargetModel.packet_item("BLAH", "HEALTH_STATUS", "CCSDSVER", scope: "DEFAULT") }.to raise_error("Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { TargetModel.packet_item("BLAH", "HEALTH_STATUS", "CCSDSVER", scope: "DEFAULT") }.to raise_error("Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "raises for a non-existent packet" do
-        expect { TargetModel.packet_item("INST", "BLAH", "CCSDSVER", scope: "DEFAULT") }.to raise_error("Packet 'INST BLAH' does not exist")
+        expect { TargetModel.packet_item("INST", "BLAH", "CCSDSVER", scope: "DEFAULT") }.to raise_error("Packet definition 'INST BLAH' does not exist")
       end
 
       it "raises for a non-existent item" do
-        expect { TargetModel.packet_item("INST", "HEALTH_STATUS", "BLAH", scope: "DEFAULT") }.to raise_error("Item 'INST HEALTH_STATUS BLAH' does not exist")
+        expect { TargetModel.packet_item("INST", "HEALTH_STATUS", "BLAH", scope: "DEFAULT") }.to raise_error("Item 'INST HEALTH_STATUS BLAH' does not exist (TargetModel)")
       end
 
       it "returns item hash if the telemetry item exists" do
@@ -655,11 +655,11 @@ module OpenC3
       end
 
       it "raises for a non-existent target" do
-        expect { TargetModel.packet_items("BLAH", "HEALTH_STATUS", ["CCSDSVER"], scope: "DEFAULT") }.to raise_error("Packet 'BLAH HEALTH_STATUS' does not exist")
+        expect { TargetModel.packet_items("BLAH", "HEALTH_STATUS", ["CCSDSVER"], scope: "DEFAULT") }.to raise_error("Packet definition 'BLAH HEALTH_STATUS' does not exist")
       end
 
       it "raises for a non-existent packet" do
-        expect { TargetModel.packet_items("INST", "BLAH", ["CCSDSVER"], scope: "DEFAULT") }.to raise_error("Packet 'INST BLAH' does not exist")
+        expect { TargetModel.packet_items("INST", "BLAH", ["CCSDSVER"], scope: "DEFAULT") }.to raise_error("Packet definition 'INST BLAH' does not exist")
       end
 
       it "raises for non-existent items" do

--- a/openc3/spec/packets/commands_spec.rb
+++ b/openc3/spec/packets/commands_spec.rb
@@ -145,7 +145,7 @@ module OpenC3
 
     describe "packets" do
       it "complains about non-existent targets" do
-        expect { @cmd.packets("tgtX") }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist")
+        expect { @cmd.packets("tgtX") }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist (packets lookup)")
       end
 
       it "returns all packets target TGT1" do
@@ -171,11 +171,11 @@ module OpenC3
 
     describe "params" do
       it "complains about non-existent targets" do
-        expect { @cmd.params("TGTX", "PKT1") }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist")
+        expect { @cmd.params("TGTX", "PKT1") }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
-        expect { @cmd.params("TGT1", "PKTX") }.to raise_error(RuntimeError, "Command packet 'TGT1 PKTX' does not exist")
+        expect { @cmd.params("TGT1", "PKTX") }.to raise_error(RuntimeError, "Command packet 'TGT1 PKTX' does not exist (packet lookup)")
       end
 
       it "returns all items from packet TGT1/PKT1" do
@@ -197,11 +197,11 @@ module OpenC3
 
     describe "packet" do
       it "complains about non-existent targets" do
-        expect { @cmd.packet("tgtX", "pkt1") }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist")
+        expect { @cmd.packet("tgtX", "pkt1") }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
-        expect { @cmd.packet("TGT1", "PKTX") }.to raise_error(RuntimeError, "Command packet 'TGT1 PKTX' does not exist")
+        expect { @cmd.packet("TGT1", "PKTX") }.to raise_error(RuntimeError, "Command packet 'TGT1 PKTX' does not exist (packet lookup)")
       end
 
       it "returns the specified packet" do
@@ -320,15 +320,15 @@ module OpenC3
       [true, false].each do |range_checking|
         [true, false].each do |raw|
           it "complains about non-existent targets" do
-            expect { @cmd.build_cmd("tgtX", "pkt1", range_checking, raw) }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist")
+            expect { @cmd.build_cmd("tgtX", "pkt1", range_checking, raw) }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist (build_cmd)")
           end
 
           it "complains about non-existent packets" do
-            expect { @cmd.build_cmd("tgt1", "pktX", range_checking, raw) }.to raise_error(RuntimeError, "Command packet 'TGT1 PKTX' does not exist")
+            expect { @cmd.build_cmd("tgt1", "pktX", range_checking, raw) }.to raise_error(RuntimeError, "Command packet 'TGT1 PKTX' does not exist (build_cmd)")
           end
 
           it "complains about non-existent items" do
-            expect { @cmd.build_cmd("tgt1", "pkt1", { "itemX" => 1 }, range_checking, raw) }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+            expect { @cmd.build_cmd("tgt1", "pkt1", { "itemX" => 1 }, range_checking, raw) }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
           end
 
           it "complains about missing required parameters" do
@@ -498,15 +498,15 @@ module OpenC3
 
     describe "cmd_hazardous?" do
       it "complains about non-existent targets" do
-        expect { @cmd.cmd_hazardous?("tgtX", "pkt1") }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist")
+        expect { @cmd.cmd_hazardous?("tgtX", "pkt1") }.to raise_error(RuntimeError, "Command target 'TGTX' does not exist (build_cmd)")
       end
 
       it "complains about non-existent packets" do
-        expect { @cmd.cmd_hazardous?("tgt1", "pktX") }.to raise_error(RuntimeError, "Command packet 'TGT1 PKTX' does not exist")
+        expect { @cmd.cmd_hazardous?("tgt1", "pktX") }.to raise_error(RuntimeError, "Command packet 'TGT1 PKTX' does not exist (build_cmd)")
       end
 
       it "complains about non-existent items" do
-        expect { @cmd.cmd_hazardous?("tgt1", "pkt1", { "itemX" => 1 }) }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+        expect { @cmd.cmd_hazardous?("tgt1", "pkt1", { "itemX" => 1 }) }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
       end
 
       it "returns true if the command overall is hazardous" do

--- a/openc3/spec/packets/limits_spec.rb
+++ b/openc3/spec/packets/limits_spec.rb
@@ -106,15 +106,15 @@ module OpenC3
 
     describe "enabled?" do
       it "complains about non-existent targets" do
-        expect { @limits.enabled?("TGTX", "PKT1", "ITEM1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @limits.enabled?("TGTX", "PKT1", "ITEM1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (limits lookup)")
       end
 
       it "complains about non-existent packets" do
-        expect { @limits.enabled?("TGT1", "PKTX", "ITEM1") }.to raise_error(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist")
+        expect { @limits.enabled?("TGT1", "PKTX", "ITEM1") }.to raise_error(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist (limits lookup)")
       end
 
       it "complains about non-existent items" do
-        expect { @limits.enabled?("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+        expect { @limits.enabled?("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
       end
 
       it "returns whether limits are enable for an item" do
@@ -127,15 +127,15 @@ module OpenC3
 
     describe "enable" do
       it "complains about non-existent targets" do
-        expect { @limits.enable("TGTX", "PKT1", "ITEM1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @limits.enable("TGTX", "PKT1", "ITEM1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (limits lookup)")
       end
 
       it "complains about non-existent packets" do
-        expect { @limits.enable("TGT1", "PKTX", "ITEM1") }.to raise_error(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist")
+        expect { @limits.enable("TGT1", "PKTX", "ITEM1") }.to raise_error(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist (limits lookup)")
       end
 
       it "complains about non-existent items" do
-        expect { @limits.enable("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+        expect { @limits.enable("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
       end
 
       it "enables limits for an item" do
@@ -148,15 +148,15 @@ module OpenC3
 
     describe "disable" do
       it "complains about non-existent targets" do
-        expect { @limits.disable("TGTX", "PKT1", "ITEM1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @limits.disable("TGTX", "PKT1", "ITEM1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (limits lookup)")
       end
 
       it "complains about non-existent packets" do
-        expect { @limits.disable("TGT1", "PKTX", "ITEM1") }.to raise_error(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist")
+        expect { @limits.disable("TGT1", "PKTX", "ITEM1") }.to raise_error(RuntimeError, "Telemetry packet 'TGT1 PKTX' does not exist (limits lookup)")
       end
 
       it "complains about non-existent items" do
-        expect { @limits.disable("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+        expect { @limits.disable("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
       end
 
       it "disables limits for an item" do

--- a/openc3/spec/packets/packet_spec.rb
+++ b/openc3/spec/packets/packet_spec.rb
@@ -434,7 +434,7 @@ module OpenC3
     describe "get_item" do
       it "complains if an item doesn't exist" do
         p = Packet.new("tgt", "pkt")
-        expect { p.get_item("test") }.to raise_error(RuntimeError, "Packet item 'TGT PKT TEST' does not exist")
+        expect { p.get_item("test") }.to raise_error(RuntimeError, "Item 'TGT PKT TEST' does not exist (Packet)")
       end
     end
 

--- a/openc3/spec/packets/structure_spec.rb
+++ b/openc3/spec/packets/structure_spec.rb
@@ -426,7 +426,7 @@ module OpenC3
       end
 
       it "complains if an item doesn't exist" do
-        expect { @s.get_item("test2") }.to raise_error(ArgumentError, "Unknown item: test2")
+        expect { @s.get_item("test2") }.to raise_error(ArgumentError, "Unknown item: test2 (get_item)")
       end
     end
 
@@ -461,7 +461,7 @@ module OpenC3
         @s.append_item("test2", 16, :UINT)
         expect(@s.defined_length).to eql 3
         @s.delete_item("test1")
-        expect { @s.get_item("test1") }.to raise_error(ArgumentError, "Unknown item: test1")
+        expect { @s.get_item("test1") }.to raise_error(ArgumentError, "Unknown item: test1 (get_item)")
         expect(@s.defined_length).to eql 3
         expect(@s.items["TEST1"]).to be_nil
         expect(@s.items["TEST2"]).not_to be_nil
@@ -552,7 +552,7 @@ module OpenC3
 
     describe "read" do
       it "complains if item doesn't exist" do
-        expect { Structure.new.read("BLAH") }.to raise_error(ArgumentError, "Unknown item: BLAH")
+        expect { Structure.new.read("BLAH") }.to raise_error(ArgumentError, "Unknown item: BLAH (get_item)")
       end
 
       it "reads data from the buffer" do
@@ -586,7 +586,7 @@ module OpenC3
 
     describe "write" do
       it "complains if item doesn't exist" do
-        expect { Structure.new.write("BLAH", 0) }.to raise_error(ArgumentError, "Unknown item: BLAH")
+        expect { Structure.new.write("BLAH", 0) }.to raise_error(ArgumentError, "Unknown item: BLAH (get_item)")
       end
 
       it "writes data to the buffer" do
@@ -873,7 +873,7 @@ module OpenC3
       it "complains if it can't find an item" do
         s = Structure.new(:BIG_ENDIAN)
         s.enable_method_missing
-        expect { s.test1 }.to raise_error(ArgumentError, "Unknown item: test1")
+        expect { s.test1 }.to raise_error(ArgumentError, "Unknown item: test1 (get_item)")
       end
     end
 

--- a/openc3/spec/packets/telemetry_spec.rb
+++ b/openc3/spec/packets/telemetry_spec.rb
@@ -73,7 +73,7 @@ module OpenC3
 
     describe "packets" do
       it "complains about non-existent targets" do
-        expect { @tlm.packets("tgtX") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.packets("tgtX") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (packets lookup)")
       end
 
       it "returns all packets target TGT1" do
@@ -92,7 +92,7 @@ module OpenC3
 
     describe "packet" do
       it "complains about non-existent targets" do
-        expect { @tlm.packet("tgtX", "pkt1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.packet("tgtX", "pkt1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
@@ -112,7 +112,7 @@ module OpenC3
 
     describe "items" do
       it "complains about non-existent targets" do
-        expect { @tlm.items("tgtX", "pkt1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.items("tgtX", "pkt1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
@@ -150,7 +150,7 @@ module OpenC3
 
     describe "packet_and_item" do
       it "complains about non-existent targets" do
-        expect { @tlm.packet_and_item("tgtX", "pkt1", "item1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.packet_and_item("tgtX", "pkt1", "item1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
@@ -158,7 +158,7 @@ module OpenC3
       end
 
       it "complains about non-existent items" do
-        expect { @tlm.packet_and_item("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+        expect { @tlm.packet_and_item("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
       end
 
       it "returns the packet and item" do
@@ -175,7 +175,7 @@ module OpenC3
 
     describe "latest_packets" do
       it "complains about non-existent targets" do
-        expect { @tlm.latest_packets("tgtX", "item1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.latest_packets("tgtX", "item1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (latest_packets lookup)")
       end
 
       it "complains about non-existent items" do
@@ -192,7 +192,7 @@ module OpenC3
 
     describe "newest_packet" do
       it "complains about non-existent targets" do
-        expect { @tlm.newest_packet("tgtX", "item1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.newest_packet("tgtX", "item1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (latest_packets lookup)")
       end
 
       it "complains about non-existent items" do
@@ -385,7 +385,7 @@ module OpenC3
 
     describe "update!" do
       it "complains about non-existent targets" do
-        expect { @tlm.update!("TGTX", "PKT1", "\x00") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.update!("TGTX", "PKT1", "\x00") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
@@ -441,7 +441,7 @@ module OpenC3
 
     describe "value" do
       it "complains about non-existent targets" do
-        expect { @tlm.value("TGTX", "PKT1", "ITEM1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.value("TGTX", "PKT1", "ITEM1") }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
@@ -449,7 +449,7 @@ module OpenC3
       end
 
       it "complains about non-existent items" do
-        expect { @tlm.value("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+        expect { @tlm.value("TGT1", "PKT1", "ITEMX") }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
       end
 
       it "returns the value" do
@@ -463,7 +463,7 @@ module OpenC3
 
     describe "set_value" do
       it "complains about non-existent targets" do
-        expect { @tlm.set_value("TGTX", "PKT1", "ITEM1", 1) }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.set_value("TGTX", "PKT1", "ITEM1", 1) }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
@@ -471,7 +471,7 @@ module OpenC3
       end
 
       it "complains about non-existent items" do
-        expect { @tlm.set_value("TGT1", "PKT1", "ITEMX", 1) }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+        expect { @tlm.set_value("TGT1", "PKT1", "ITEMX", 1) }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
       end
 
       it "sets the value" do
@@ -493,7 +493,7 @@ module OpenC3
       end
 
       it "complains about non-existent targets" do
-        expect { @tlm.values_and_limits_states([["TGTX", "PKT1", "ITEM1"]]) }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist")
+        expect { @tlm.values_and_limits_states([["TGTX", "PKT1", "ITEM1"]]) }.to raise_error(RuntimeError, "Telemetry target 'TGTX' does not exist (packets lookup)")
       end
 
       it "complains about non-existent packets" do
@@ -501,7 +501,7 @@ module OpenC3
       end
 
       it "complains about non-existent items" do
-        expect { @tlm.values_and_limits_states([["TGT1", "PKT1", "ITEMX"]]) }.to raise_error(RuntimeError, "Packet item 'TGT1 PKT1 ITEMX' does not exist")
+        expect { @tlm.values_and_limits_states([["TGT1", "PKT1", "ITEMX"]]) }.to raise_error(RuntimeError, "Item 'TGT1 PKT1 ITEMX' does not exist (Packet)")
       end
 
       it "complains about non-existent value_types" do

--- a/openc3/spec/script/api_shared_spec.rb
+++ b/openc3/spec/script/api_shared_spec.rb
@@ -253,7 +253,7 @@ module OpenC3
           check_exception("check", "INST HEALTH_STATUS TEMP1 == 9", type: :RAW, scope: "DEFAULT")
           expect(stdout.string).to match(/CHECK: INST HEALTH_STATUS TEMP1 == 9 failed/)
           check_exception("check", "INST HEALTH_STATUS TEMP1 == 9", type: :RAW, scope: "OTHER")
-          expect(stdout.string).to match(/Packet 'INST HEALTH_STATUS' does not exist/)
+          expect(stdout.string).to match(/Packet definition 'INST HEALTH_STATUS' does not exist/)
         end
       end
 

--- a/openc3/spec/script/commands_spec.rb
+++ b/openc3/spec/script/commands_spec.rb
@@ -144,7 +144,7 @@ module OpenC3
           end
 
           it "raises if a command item does not exist" do
-            expect { cmd('INST COLLECT with TYPE NORMAL, DURATION 5, NOPE 10') }.to raise_error(/Packet item 'INST COLLECT NOPE' does not exist/)
+            expect { cmd('INST COLLECT with TYPE NORMAL, DURATION 5, NOPE 10') }.to raise_error(/Item 'INST COLLECT NOPE' does not exist/)
           end
 
           if connect == 'connected'

--- a/openc3/spec/topics/limits_event_topic_spec.rb
+++ b/openc3/spec/topics/limits_event_topic_spec.rb
@@ -161,7 +161,7 @@ module OpenC3
         expect {
           LimitsEventTopic.write({ type: :LIMITS_SET, set: "TVAC",
               time_nsec: Time.now.to_nsec_from_epoch, message: "Limits Set" }, scope: "DEFAULT")
-        }.to raise_error(RuntimeError, "Set 'TVAC' does not exist!")
+        }.to raise_error(RuntimeError, "Limits set 'TVAC' does not exist")
       end
 
       it "raise on unknown types" do

--- a/openc3/spec/utilities/aws_bucket_spec.rb
+++ b/openc3/spec/utilities/aws_bucket_spec.rb
@@ -169,7 +169,7 @@ module OpenC3
 
     describe 'list_files' do
       it "returns BucketNotFound if the bucket doesn't exist" do
-        expect { client.list_files(bucket: "NOPE", path: "") }.to raise_error(Bucket::NotFound, "Bucket 'NOPE' does not exist.")
+        expect { client.list_files(bucket: "NOPE", path: "") }.to raise_error(Bucket::NotFound, "Bucket 'NOPE' does not exist (list_files)")
       end
 
       it "lists the root" do


### PR DESCRIPTION
This should help make it easier to identify where and why an error occurs when all you have to debug with is log messages. Also homogenized some of the terminology and punctuation.