### PR TITLE
fix(uvinstall): make per-plugin venv install offline-first and network-bounded

### DIFF
--- a/openc3-cosmos-init/plugins/docker-package-build.sh
+++ b/openc3-cosmos-init/plugins/docker-package-build.sh
@@ -27,3 +27,17 @@ ls *.gem
 echo "--- packageInstall $1 mv gem file"
 mv ${1}-*.gem ${GEMS}
 echo "=== packageInstall $1 mv gem complete"
+
+# Pre-warm the shared UV wheel cache with this plugin's locked Python
+# dependencies (cwd is still FOLDER_NAME from the cd above). Without this the
+# runtime per-plugin venv install (uvinstall) must fetch the plugin's exact
+# locked wheels from PyPI, because the image only seeds core's own dependency
+# versions - a guaranteed cache miss for any plugin pinning a different version
+# (e.g. demo numpy 2.4.6 vs core 2.2.6). Seeding here makes the runtime install
+# an offline cache hit: fast, deterministic, and works in air-gapped clusters.
+if command -v uv > /dev/null 2>&1 && [ -f uv.lock ] && [ -f pyproject.toml ]; then
+  echo "--- packageBuild $1 warm UV cache (uv sync --frozen)"
+  UV_CACHE_DIR=/openc3/uv_cache uv sync --frozen --no-dev --no-install-project \
+    || echo "Warning: UV cache warm failed for $1 - runtime install will fall back to network"
+  echo "=== packageBuild $1 warm UV cache complete"
+fi

--- a/openc3/Dockerfile
+++ b/openc3/Dockerfile
@@ -58,5 +58,9 @@ RUN mkdir /gems && chown openc3:openc3 /gems \
 
 ENV HOME=/openc3
 ENV XDG_CACHE_HOME=/tmp/.cache
+# Runtime cache = the /gems volume. The init container copies the baked
+# /openc3/uv_cache seed (see the uv sync steps above) into here at startup.
+# Build-time steps override this per-RUN with UV_CACHE_DIR=/openc3/uv_cache so
+# wheels land in the baked seed, not this volume (which is empty until runtime).
 ENV UV_CACHE_DIR=/gems/uv/
 USER ${USER_ID}:${GROUP_ID}

--- a/openc3/bin/uvinstall
+++ b/openc3/bin/uvinstall
@@ -9,12 +9,15 @@
 #   1. If gem_path contains uv.lock: uses `uv sync --frozen` (reproducible)
 #   2. Otherwise: falls back to `uv pip install` for requirements.txt / pyproject.toml
 #
-# Network safety: every uv invocation is bounded by a wall-clock timeout and a
-# per-request HTTP timeout so a slow/unreachable index fails fast instead of
+# Network safety: uv's own HTTP controls (connect timeout, read timeout,
+# bounded retries) make a slow or unreachable index fail fast instead of
 # hanging the plugin install (which stalls the whole deploy - the init hook
-# never completes and helm's --wait times out). Path 1 also tries an OFFLINE
-# sync first so a plugin whose wheels are already in the seeded UV cache
-# installs deterministically without ever touching the network.
+# never completes and helm's --wait times out). These are idle/connect
+# timeouts, NOT a total-transfer cap, so a large but healthy download (e.g.
+# torch over a slow link) is never killed mid-stream as long as bytes keep
+# arriving. Path 1 also tries an OFFLINE sync first so a plugin whose wheels
+# are already in the seeded UV cache installs deterministically without ever
+# touching the network.
 
 PLUGIN_VENV_NAME="$1"
 GEM_PATH="$2"
@@ -26,19 +29,15 @@ if [ -z "$PLUGIN_VENV_NAME" ] || [ -z "$GEM_PATH" ]; then
     exit 1
 fi
 
-# Bound each uv network request so a stalled connection fails fast.
+# Bound uv's network behavior with uv's own HTTP knobs. Unlike a blunt
+# wall-clock cap, these fail fast on a dead/unreachable index or a stalled
+# connection WITHOUT killing a large but progressing download. All overridable.
+#   UV_HTTP_CONNECT_TIMEOUT - give up connecting to an unreachable index (s)
+#   UV_HTTP_TIMEOUT         - give up when a connection stalls mid-read (s)
+#   UV_HTTP_RETRIES         - bounded retries for transient failures
+export UV_HTTP_CONNECT_TIMEOUT="${UV_HTTP_CONNECT_TIMEOUT:-10}"
 export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-30}"
-
-# Hard wall-clock cap for a single uv invocation. Even with UV_HTTP_TIMEOUT,
-# retries or DNS stalls could accumulate; this guarantees uv gives up so the
-# caller can fall back (or the init pod can restart) rather than block forever.
-# Wrap uv only when a `timeout` binary is available (busybox/coreutils).
-UV_CMD_TIMEOUT="${UV_CMD_TIMEOUT:-600}"
-if command -v timeout > /dev/null 2>&1; then
-    RUN_UV="timeout ${UV_CMD_TIMEOUT}"
-else
-    RUN_UV=""
-fi
+export UV_HTTP_RETRIES="${UV_HTTP_RETRIES:-3}"
 
 VENV_BASE="/gems/plugin_venvs/${PLUGIN_VENV_NAME}"
 VENV_DIR="${VENV_BASE}/.venv"
@@ -61,12 +60,12 @@ if [ -f "${GEM_PATH}/uv.lock" ] && [ -f "${GEM_PATH}/pyproject.toml" ]; then
     # Prefer an offline sync: if every locked wheel is already in the seeded
     # UV cache this succeeds instantly and never touches the network, so it
     # cannot hang and works in air-gapped clusters. Only on a cache miss do we
-    # fall back to an online sync (bounded by UV_HTTP_TIMEOUT / timeout).
-    $RUN_UV uv sync --frozen --no-dev --no-install-project --offline ${UV_ARGS}
+    # fall back to an online sync (bounded by the UV_HTTP_* knobs above).
+    uv sync --frozen --no-dev --no-install-project --offline ${UV_ARGS}
     RESULT=$?
     if [ $RESULT -ne 0 ]; then
         echo "Offline uv sync failed (exit code ${RESULT}); retrying online"
-        $RUN_UV uv sync --frozen --no-dev --no-install-project ${UV_ARGS}
+        uv sync --frozen --no-dev --no-install-project ${UV_ARGS}
         RESULT=$?
     fi
 
@@ -84,11 +83,11 @@ uv venv "${VENV_DIR}" --allow-existing
 
 if [ -f "${GEM_PATH}/requirements.txt" ]; then
     echo "Installing from requirements.txt via uv pip install"
-    $RUN_UV uv pip install --python "${VENV_DIR}" ${UV_ARGS} -r "${GEM_PATH}/requirements.txt"
+    uv pip install --python "${VENV_DIR}" ${UV_ARGS} -r "${GEM_PATH}/requirements.txt"
     RESULT=$?
 elif [ -f "${GEM_PATH}/pyproject.toml" ]; then
     echo "Installing from pyproject.toml via uv pip install"
-    $RUN_UV uv pip install --python "${VENV_DIR}" ${UV_ARGS} "${GEM_PATH}"
+    uv pip install --python "${VENV_DIR}" ${UV_ARGS} "${GEM_PATH}"
     RESULT=$?
 
     # If the build failed (e.g. Poetry package-mode = false), try installing
@@ -96,9 +95,9 @@ elif [ -f "${GEM_PATH}/pyproject.toml" ]; then
     if [ $RESULT -ne 0 ]; then
         echo "Warning: Failed to build Python package, attempting to install declared dependencies from pyproject.toml"
         TMPFILE=$(mktemp)
-        $RUN_UV uv pip compile ${UV_ARGS} "${GEM_PATH}/pyproject.toml" > "$TMPFILE"
+        uv pip compile ${UV_ARGS} "${GEM_PATH}/pyproject.toml" > "$TMPFILE"
         if [ $? -eq 0 ] && [ -s "$TMPFILE" ]; then
-            $RUN_UV uv pip install --python "${VENV_DIR}" ${UV_ARGS} -r "$TMPFILE"
+            uv pip install --python "${VENV_DIR}" ${UV_ARGS} -r "$TMPFILE"
             RESULT=$?
         fi
         rm -f "$TMPFILE"

--- a/openc3/bin/uvinstall
+++ b/openc3/bin/uvinstall
@@ -8,6 +8,13 @@
 # Two installation paths:
 #   1. If gem_path contains uv.lock: uses `uv sync --frozen` (reproducible)
 #   2. Otherwise: falls back to `uv pip install` for requirements.txt / pyproject.toml
+#
+# Network safety: every uv invocation is bounded by a wall-clock timeout and a
+# per-request HTTP timeout so a slow/unreachable index fails fast instead of
+# hanging the plugin install (which stalls the whole deploy - the init hook
+# never completes and helm's --wait times out). Path 1 also tries an OFFLINE
+# sync first so a plugin whose wheels are already in the seeded UV cache
+# installs deterministically without ever touching the network.
 
 PLUGIN_VENV_NAME="$1"
 GEM_PATH="$2"
@@ -17,6 +24,20 @@ UV_ARGS="$@"
 if [ -z "$PLUGIN_VENV_NAME" ] || [ -z "$GEM_PATH" ]; then
     echo "Usage: uvinstall <plugin_venv_name> <gem_path> [extra uv args...]"
     exit 1
+fi
+
+# Bound each uv network request so a stalled connection fails fast.
+export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-30}"
+
+# Hard wall-clock cap for a single uv invocation. Even with UV_HTTP_TIMEOUT,
+# retries or DNS stalls could accumulate; this guarantees uv gives up so the
+# caller can fall back (or the init pod can restart) rather than block forever.
+# Wrap uv only when a `timeout` binary is available (busybox/coreutils).
+UV_CMD_TIMEOUT="${UV_CMD_TIMEOUT:-600}"
+if command -v timeout > /dev/null 2>&1; then
+    RUN_UV="timeout ${UV_CMD_TIMEOUT}"
+else
+    RUN_UV=""
 fi
 
 VENV_BASE="/gems/plugin_venvs/${PLUGIN_VENV_NAME}"
@@ -36,8 +57,18 @@ if [ -f "${GEM_PATH}/uv.lock" ] && [ -f "${GEM_PATH}/pyproject.toml" ]; then
     # Create venv and sync dependencies
     cd "${VENV_BASE}"
     uv venv "${VENV_DIR}" --allow-existing
-    uv sync --frozen --no-dev --no-install-project ${UV_ARGS}
+
+    # Prefer an offline sync: if every locked wheel is already in the seeded
+    # UV cache this succeeds instantly and never touches the network, so it
+    # cannot hang and works in air-gapped clusters. Only on a cache miss do we
+    # fall back to an online sync (bounded by UV_HTTP_TIMEOUT / timeout).
+    $RUN_UV uv sync --frozen --no-dev --no-install-project --offline ${UV_ARGS}
     RESULT=$?
+    if [ $RESULT -ne 0 ]; then
+        echo "Offline uv sync failed (exit code ${RESULT}); retrying online"
+        $RUN_UV uv sync --frozen --no-dev --no-install-project ${UV_ARGS}
+        RESULT=$?
+    fi
 
     if [ $RESULT -eq 0 ]; then
         echo "uv sync --frozen succeeded"
@@ -53,11 +84,11 @@ uv venv "${VENV_DIR}" --allow-existing
 
 if [ -f "${GEM_PATH}/requirements.txt" ]; then
     echo "Installing from requirements.txt via uv pip install"
-    uv pip install --python "${VENV_DIR}" ${UV_ARGS} -r "${GEM_PATH}/requirements.txt"
+    $RUN_UV uv pip install --python "${VENV_DIR}" ${UV_ARGS} -r "${GEM_PATH}/requirements.txt"
     RESULT=$?
 elif [ -f "${GEM_PATH}/pyproject.toml" ]; then
     echo "Installing from pyproject.toml via uv pip install"
-    uv pip install --python "${VENV_DIR}" ${UV_ARGS} "${GEM_PATH}"
+    $RUN_UV uv pip install --python "${VENV_DIR}" ${UV_ARGS} "${GEM_PATH}"
     RESULT=$?
 
     # If the build failed (e.g. Poetry package-mode = false), try installing
@@ -65,9 +96,9 @@ elif [ -f "${GEM_PATH}/pyproject.toml" ]; then
     if [ $RESULT -ne 0 ]; then
         echo "Warning: Failed to build Python package, attempting to install declared dependencies from pyproject.toml"
         TMPFILE=$(mktemp)
-        uv pip compile ${UV_ARGS} "${GEM_PATH}/pyproject.toml" > "$TMPFILE"
+        $RUN_UV uv pip compile ${UV_ARGS} "${GEM_PATH}/pyproject.toml" > "$TMPFILE"
         if [ $? -eq 0 ] && [ -s "$TMPFILE" ]; then
-            uv pip install --python "${VENV_DIR}" ${UV_ARGS} -r "$TMPFILE"
+            $RUN_UV uv pip install --python "${VENV_DIR}" ${UV_ARGS} -r "$TMPFILE"
             RESULT=$?
         fi
         rm -f "$TMPFILE"
@@ -83,7 +114,7 @@ if [ $RESULT -eq 0 ]; then
     exit 0
 fi
 
-# Last resort: try --no-index
+# Last resort: try --no-index (cache only, no network)
 echo "Warning: Install failed - retrying with --no-index"
 if [ -f "${GEM_PATH}/requirements.txt" ]; then
     uv pip install --python "${VENV_DIR}" --no-index ${UV_ARGS} -r "${GEM_PATH}/requirements.txt"


### PR DESCRIPTION
- Pre-warm the shared UV wheel cache at plugin build time (`docker-package-build.sh`) with each plugin's locked Python dependencies, so the runtime per-plugin venv install is an offline cache hit — even when a plugin pins versions that differ from core (e.g. demo numpy 2.4.6 vs core 2.2.6)
- Try an offline `uv sync --frozen` first in `uvinstall`, falling back to an online sync only on cache miss; makes installs deterministic and air-gap safe
- Bound every `uv` invocation with uv's own HTTP controls (`UV_HTTP_CONNECT_TIMEOUT`, `UV_HTTP_TIMEOUT`, `UV_HTTP_RETRIES`) so a slow/unreachable index fails fast without killing a large but healthy download — these are connect/idle timeouts, not a total-transfer cap, so a big wheel (e.g. torch over a slow link) still completes; a blunt wall-clock `timeout` would SIGTERM it mid-stream
- Document build-time vs runtime UV cache layout in the `Dockerfile`: build steps seed `/openc3/uv_cache`; the init container copies that seed into the `/gems` runtime volume at startup