### PR TITLE
Better handle permission errors in TargetPacketIemChooser

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/src/tools/PacketViewer/PacketViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/src/tools/PacketViewer/PacketViewer.vue
@@ -584,6 +584,11 @@ export default {
       ) {
         return // No change
       }
+      // The chooser clears its selection when the target has no packets or the
+      // request failed (e.g. no permission). Nothing to look up in that case.
+      if (!event.targetName || !event.packetName) {
+        return
+      }
       try {
         this.loadingPacket = true
         const target = await this.api.get_target(event.targetName)

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/openc3Api.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/openc3Api.js
@@ -439,8 +439,8 @@ export default class OpenC3Api {
     return this.exec('get_tlm_buffer', [target_name, packet_name])
   }
 
-  get_tlm_available(items, headerOptions = {}) {
-    return this.exec('get_tlm_available', [items], {}, headerOptions)
+  get_tlm_available(items, kwparams = {}, headerOptions = {}) {
+    return this.exec('get_tlm_available', [items], kwparams, headerOptions)
   }
 
   async get_tlm_values(

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/openc3Api.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/openc3Api.js
@@ -439,8 +439,8 @@ export default class OpenC3Api {
     return this.exec('get_tlm_buffer', [target_name, packet_name])
   }
 
-  get_tlm_available(items) {
-    return this.exec('get_tlm_available', [items])
+  get_tlm_available(items, headerOptions = {}) {
+    return this.exec('get_tlm_available', [items], {}, headerOptions)
   }
 
   async get_tlm_values(
@@ -449,6 +449,7 @@ export default class OpenC3Api {
     cache_timeout = null,
     start_time = null,
     end_time = null,
+    headerOptions = {},
   ) {
     let kw_args = {
       stale_time: stale_time,
@@ -466,7 +467,7 @@ export default class OpenC3Api {
       'get_tlm_values',
       [items],
       kw_args,
-      {},
+      headerOptions,
       10000, // 10s timeout ... should never be this long
     )
     if (data && data.length > 0) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -1079,7 +1079,7 @@ export default {
       }
       this.tlmAvailableTimeout = setTimeout(() => {
         this.api
-          .get_tlm_available(this.screenItems, { 'Ignore-Errors': '403' })
+          .get_tlm_available(this.screenItems, {}, { 'Ignore-Errors': '403' })
           .then((data) => {
             this.actualScreenItems = data
             // This must be the same or we're going to have problems

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -1014,6 +1014,11 @@ export default {
             this.staleTime,
             this.cacheTimeout,
             dateTime,
+            null,
+            // A user without 'tlm' permission on these items gets a 403 on every
+            // update. Don't raise the global notification, we display the error
+            // on the screen itself (click the error icon in the screen toolbar).
+            { 'Ignore-Errors': '403' },
           )
           .then((data) => {
             if (data && data.length > 0) {
@@ -1023,7 +1028,10 @@ export default {
             }
           })
           .catch((error) => {
-            let message = JSON.stringify(error, null, 2)
+            let message =
+              error.response?.data?.error?.message ||
+              error.response?.data?.message ||
+              JSON.stringify(error, null, 2)
             if (
               !this.errors.find((existing) => {
                 return existing.message === message
@@ -1071,7 +1079,7 @@ export default {
       }
       this.tlmAvailableTimeout = setTimeout(() => {
         this.api
-          .get_tlm_available(this.screenItems)
+          .get_tlm_available(this.screenItems, { 'Ignore-Errors': '403' })
           .then((data) => {
             this.actualScreenItems = data
             // This must be the same or we're going to have problems

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -1028,10 +1028,10 @@ export default {
             }
           })
           .catch((error) => {
-            let message =
-              error.response?.data?.error?.message ||
-              error.response?.data?.message ||
-              JSON.stringify(error, null, 2)
+            // Note: OpenC3Api rejects with an Error built from the server
+            // response so the message is the useful part. JSON.stringify on an
+            // Error returns '{}' because its fields aren't enumerable.
+            let message = error.message || JSON.stringify(error, null, 2)
             if (
               !this.errors.find((existing) => {
                 return existing.message === message

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
@@ -482,42 +482,48 @@ export default {
         })
     }
 
-    this.api.get_target_names().then((result) => {
-      this.targetNames = result.flatMap((target) => {
-        // Ignore the UNKNOWN target as it doesn't make sense to select this
-        if (target == 'UNKNOWN') {
-          return []
+    this.api
+      .get_target_names()
+      .then((result) => {
+        this.targetNames = result.flatMap((target) => {
+          // Ignore the UNKNOWN target as it doesn't make sense to select this
+          if (target == 'UNKNOWN') {
+            return []
+          }
+          return { label: target, value: target }
+        })
+        // TODO: This is a nice enhancement but results in logs of API calls for many targets
+        // See if we can reduce this to a single API call
+        // Filter out any targets without packets
+        // for (let i = this.targetNames.length - 1; i >= 0; i--) {
+        //   const cmd =
+        //     this.mode === 'tlm' ? 'get_all_tlm_names' : 'get_all_cmd_names'
+        //   await this.api[cmd](this.targetNames[i].value).then((names) => {
+        //     if (names.length === 0) {
+        //       this.targetNames.splice(i, 1)
+        //     }
+        //   })
+        // }
+        if (this.allowAllTargets) {
+          this.targetNames.unshift(this.ALL)
         }
-        return { label: target, value: target }
+        // If the initial target name is not set, default to the first target
+        // which also updates packets and items as needed
+        if (this.selectedTargetName) {
+          // Selected target name was set but we still have to update packets
+          this.updatePackets()
+        } else {
+          this.selectedTargetName = this.targetNames[0].value
+          this.targetNameChanged(this.selectedTargetName)
+        }
+        if (this.unknown) {
+          this.targetNames.push(this.UNKNOWN)
+        }
       })
-      // TODO: This is a nice enhancement but results in logs of API calls for many targets
-      // See if we can reduce this to a single API call
-      // Filter out any targets without packets
-      // for (let i = this.targetNames.length - 1; i >= 0; i--) {
-      //   const cmd =
-      //     this.mode === 'tlm' ? 'get_all_tlm_names' : 'get_all_cmd_names'
-      //   await this.api[cmd](this.targetNames[i].value).then((names) => {
-      //     if (names.length === 0) {
-      //       this.targetNames.splice(i, 1)
-      //     }
-      //   })
-      // }
-      if (this.allowAllTargets) {
-        this.targetNames.unshift(this.ALL)
-      }
-      // If the initial target name is not set, default to the first target
-      // which also updates packets and items as needed
-      if (this.selectedTargetName) {
-        // Selected target name was set but we still have to update packets
-        this.updatePackets()
-      } else {
-        this.selectedTargetName = this.targetNames[0].value
-        this.targetNameChanged(this.selectedTargetName)
-      }
-      if (this.unknown) {
-        this.targetNames.push(this.UNKNOWN)
-      }
-    })
+      .catch(() => {
+        // Re-enable the dropdowns so we're not stuck disabled forever
+        this.internalDisabled = false
+      })
   },
   methods: {
     selectOnFocus: function (refName) {
@@ -549,41 +555,56 @@ export default {
       this.internalDisabled = true
       const cmd =
         this.mode === 'tlm' ? 'get_all_tlm_names' : 'get_all_cmd_names'
-      this.api[cmd](this.selectedTargetName, this.hidden).then((names) => {
-        this.packetNames = names.map((name) => {
-          return {
-            label: name,
-            value: name,
+      this.api[cmd](this.selectedTargetName, this.hidden)
+        .then((names) => {
+          this.packetNames = names.map((name) => {
+            return {
+              label: name,
+              value: name,
+            }
+          })
+          if (this.includeLatestPacketInDropdown) {
+            this.packetNames.unshift(this.LATEST)
           }
-        })
-        if (this.includeLatestPacketInDropdown) {
-          this.packetNames.unshift(this.LATEST)
-        }
-        if (this.allowAll) {
-          this.packetNames.unshift(this.ALL)
-        }
-        if (!this.selectedPacketName) {
-          if (this.packetNames.length === 0) {
-            this.selectedPacketName = null
-          } else {
-            this.selectedPacketName = this.packetNames[0].value
-            if (
-              this.selectedPacketName === 'LATEST' &&
-              this.packetNames.length > 1
-            ) {
-              this.selectedPacketName = this.packetNames[1].value
+          if (this.allowAll) {
+            this.packetNames.unshift(this.ALL)
+          }
+          if (!this.selectedPacketName) {
+            if (this.packetNames.length === 0) {
+              this.selectedPacketName = null
+            } else {
+              this.selectedPacketName = this.packetNames[0].value
+              if (
+                this.selectedPacketName === 'LATEST' &&
+                this.packetNames.length > 1
+              ) {
+                this.selectedPacketName = this.packetNames[1].value
+              }
             }
           }
-        }
-        this.updatePacketDetails(this.selectedPacketName)
-        const item = this.packetNames.find((packet) => {
-          return packet.value === this.selectedPacketName
+          this.updatePacketDetails(this.selectedPacketName)
+          const item = this.packetNames.find((packet) => {
+            return packet.value === this.selectedPacketName
+          })
+          if (item && this.chooseItem) {
+            this.updateItems()
+          }
+          this.internalDisabled = false
         })
-        if (item && this.chooseItem) {
-          this.updateItems()
-        }
-        this.internalDisabled = false
-      })
+        .catch(() => {
+          // The request failed, e.g. the user doesn't have permission on this
+          // target. Clear the packets but re-enable the dropdowns so they can
+          // select a different target. The error itself is displayed by the
+          // global error notification.
+          this.packetNames = []
+          this.selectedPacketName = null
+          this.itemNames = []
+          this.selectedItemName = null
+          this.description = ''
+          this.hazardous = false
+          this.hazardousDescription = ''
+          this.internalDisabled = false
+        })
     },
 
     updateItems: function () {
@@ -616,10 +637,15 @@ export default {
             })
             this.finishUpdateItems()
           })
+          .catch(() => {
+            this.itemNames = []
+            this.selectedItemName = null
+            this.internalDisabled = false
+          })
       } else {
         const cmd = this.mode === 'tlm' ? 'get_tlm' : 'get_cmd'
-        this.api[cmd](this.selectedTargetName, this.selectedPacketName).then(
-          (packet) => {
+        this.api[cmd](this.selectedTargetName, this.selectedPacketName)
+          .then((packet) => {
             let items = []
             packet.items.forEach((item) => {
               if (!item['hidden']) {
@@ -640,13 +666,23 @@ export default {
             })
             this.itemNames.sort((a, b) => (a.label > b.label ? 1 : -1))
             this.finishUpdateItems()
-          },
-        )
+          })
+          .catch(() => {
+            this.itemNames = []
+            this.selectedItemName = null
+            this.internalDisabled = false
+          })
       }
     },
     finishUpdateItems: function () {
       if (this.allowAll) {
         this.itemNames.unshift(this.ALL)
+      }
+      if (this.itemNames.length === 0) {
+        this.selectedItemName = null
+        this.description = ''
+        this.internalDisabled = false
+        return
       }
       if (!this.selectedItemName) {
         this.selectedItemName = this.itemNames[0].value
@@ -734,13 +770,18 @@ export default {
         if (packet) {
           this.selectedPacketName = packet.value
           const cmd = this.mode === 'tlm' ? 'get_tlm' : 'get_cmd'
-          this.api[cmd](this.selectedTargetName, this.selectedPacketName).then(
-            (packet) => {
+          this.api[cmd](this.selectedTargetName, this.selectedPacketName)
+            .then((packet) => {
               this.description = packet.description
               this.hazardous = packet.hazardous
               this.hazardousDescription = packet.hazardous_description || ''
-            },
-          )
+            })
+            .catch(() => {
+              this.description = ''
+              this.hazardous = false
+              this.hazardousDescription = ''
+              this.internalDisabled = false
+            })
         }
       }
       if (this.chooseItem) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
@@ -512,6 +512,9 @@ export default {
         if (this.selectedTargetName) {
           // Selected target name was set but we still have to update packets
           this.updatePackets()
+        } else if (this.targetNames.length === 0) {
+          // No targets to select so re-enable and let the user see empty lists
+          this.internalDisabled = false
         } else {
           this.selectedTargetName = this.targetNames[0].value
           this.targetNameChanged(this.selectedTargetName)
@@ -569,26 +572,29 @@ export default {
           if (this.allowAll) {
             this.packetNames.unshift(this.ALL)
           }
+          // Nothing to select, e.g. a target with no commands. Don't call
+          // updatePacketDetails which would request a null packet.
+          if (this.packetNames.length === 0) {
+            this.selectedPacketName = null
+            this.itemNames = []
+            this.selectedItemName = null
+            this.description = ''
+            this.hazardous = false
+            this.hazardousDescription = ''
+            this.internalDisabled = false
+            return
+          }
           if (!this.selectedPacketName) {
-            if (this.packetNames.length === 0) {
-              this.selectedPacketName = null
-            } else {
-              this.selectedPacketName = this.packetNames[0].value
-              if (
-                this.selectedPacketName === 'LATEST' &&
-                this.packetNames.length > 1
-              ) {
-                this.selectedPacketName = this.packetNames[1].value
-              }
+            this.selectedPacketName = this.packetNames[0].value
+            if (
+              this.selectedPacketName === 'LATEST' &&
+              this.packetNames.length > 1
+            ) {
+              this.selectedPacketName = this.packetNames[1].value
             }
           }
+          // Note: updatePacketDetails calls updateItems if chooseItem is set
           this.updatePacketDetails(this.selectedPacketName)
-          const item = this.packetNames.find((packet) => {
-            return packet.value === this.selectedPacketName
-          })
-          if (item && this.chooseItem) {
-            this.updateItems()
-          }
           this.internalDisabled = false
         })
         .catch(() => {
@@ -609,6 +615,13 @@ export default {
 
     updateItems: function () {
       if (this.selectedPacketName === 'ALL') {
+        return
+      }
+      // No packet selected, e.g. a target with no packets, so nothing to request
+      if (!this.selectedPacketName) {
+        this.itemNames = []
+        this.selectedItemName = null
+        this.internalDisabled = false
         return
       }
       // In glob mode, skip API calls if the packet name is free text (not a known packet)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
@@ -529,6 +529,17 @@ export default {
       })
   },
   methods: {
+    emitOnSet: function () {
+      this.$emit('on-set', {
+        targetName: this.selectedTargetName,
+        packetName: this.selectedPacketName,
+        itemName: this.selectedItemNameWIndex,
+        valueType: this.selectedValueType,
+        reduced: this.selectedReduced,
+        reducedType: this.selectedReducedType,
+        queueName: this.selectedQueueName,
+      })
+    },
     selectOnFocus: function (refName) {
       this.$nextTick(() => {
         const component = this.$refs[refName]
@@ -582,6 +593,9 @@ export default {
             this.hazardous = false
             this.hazardousDescription = ''
             this.internalDisabled = false
+            // Tell the parent the selection is gone so it doesn't keep acting
+            // on the previous packet / item
+            this.emitOnSet()
             return
           }
           if (!this.selectedPacketName) {
@@ -610,6 +624,7 @@ export default {
           this.hazardous = false
           this.hazardousDescription = ''
           this.internalDisabled = false
+          this.emitOnSet()
         })
     },
 
@@ -654,6 +669,7 @@ export default {
             this.itemNames = []
             this.selectedItemName = null
             this.internalDisabled = false
+            this.emitOnSet()
           })
       } else {
         const cmd = this.mode === 'tlm' ? 'get_tlm' : 'get_cmd'
@@ -684,6 +700,7 @@ export default {
             this.itemNames = []
             this.selectedItemName = null
             this.internalDisabled = false
+            this.emitOnSet()
           })
       }
     },
@@ -695,21 +712,14 @@ export default {
         this.selectedItemName = null
         this.description = ''
         this.internalDisabled = false
+        this.emitOnSet()
         return
       }
       if (!this.selectedItemName) {
         this.selectedItemName = this.itemNames[0].value
       }
       this.description = this.itemNames[0].description
-      this.$emit('on-set', {
-        targetName: this.selectedTargetName,
-        packetName: this.selectedPacketName,
-        itemName: this.selectedItemNameWIndex,
-        valueType: this.selectedValueType,
-        reduced: this.selectedReduced,
-        reducedType: this.selectedReducedType,
-        queueName: this.selectedQueueName,
-      })
+      this.emitOnSet()
       this.internalDisabled = false
     },
 
@@ -754,15 +764,7 @@ export default {
 
     queueNameChanged: function (value) {
       this.selectedQueueName = value
-      this.$emit('on-set', {
-        targetName: this.selectedTargetName,
-        packetName: this.selectedPacketName,
-        itemName: this.selectedItemNameWIndex,
-        valueType: this.selectedValueType,
-        reduced: this.selectedReduced,
-        reducedType: this.selectedReducedType,
-        queueName: this.selectedQueueName,
-      })
+      this.emitOnSet()
     },
 
     updatePacketDetails: function (value) {
@@ -800,15 +802,7 @@ export default {
       if (this.chooseItem) {
         this.updateItems()
       } else {
-        this.$emit('on-set', {
-          targetName: this.selectedTargetName,
-          packetName: this.selectedPacketName,
-          itemName: this.selectedItemNameWIndex,
-          valueType: this.selectedValueType,
-          reduced: this.selectedReduced,
-          reducedType: this.selectedReducedType,
-          queueName: this.selectedQueueName,
-        })
+        this.emitOnSet()
       }
     },
 
@@ -824,15 +818,7 @@ export default {
       if (item) {
         this.selectedItemName = item.value
         this.description = item.description
-        this.$emit('on-set', {
-          targetName: this.selectedTargetName,
-          packetName: this.selectedPacketName,
-          itemName: this.selectedItemNameWIndex,
-          valueType: this.selectedValueType,
-          reduced: this.selectedReduced,
-          reducedType: this.selectedReducedType,
-          queueName: this.selectedQueueName,
-        })
+        this.emitOnSet()
       } else if (
         this.globEnabled &&
         typeof value === 'string' &&
@@ -844,15 +830,7 @@ export default {
     },
 
     indexChanged: function (value) {
-      this.$emit('on-set', {
-        targetName: this.selectedTargetName,
-        packetName: this.selectedPacketName,
-        itemName: this.selectedItemNameWIndex,
-        valueType: this.selectedValueType,
-        reduced: this.selectedReduced,
-        reducedType: this.selectedReducedType,
-        queueName: this.selectedQueueName,
-      })
+      this.emitOnSet()
     },
 
     buttonPressed: function () {


### PR DESCRIPTION
I ran through the entire sequence in 7.2.1 and could not reproduce any error message when visiting Command Sender. @ryanmelt please update the issue with reproduction steps.

closes #3452 

Created new role `inst-only`. Created new user `insty` with new realm role `ALLSCOPES__inst-only`. Logged in and observed user could not send INST2 command:

<img width="1251" height="538" alt="Screenshot 2026-07-21 at 12 00 35 PM" src="https://github.com/user-attachments/assets/e0ee6fc3-5725-48c8-bde8-244ce3283c9d" />

Refreshing page shows no errors. Can send INST ABORT command:

<img width="1254" height="404" alt="image" src="https://github.com/user-attachments/assets/9fc5541b-b03e-4215-9ef1-0e7b1908d806" />
