### PR TITLE
[Bug] Persist screen width on float mode

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
@@ -221,6 +221,7 @@
           :initial-top="def.top"
           :initial-left="def.left"
           :initial-z="def.zIndex"
+          :initial-width="def.width"
           :time-zone="timeZone"
           :playback-mode="playbackMode"
           :playback-date-time="playbackDateTime"
@@ -371,6 +372,7 @@ export default {
           top: def.top,
           left: def.left,
           zIndex: def.zIndex,
+          width: def.width,
         }
       })
     },
@@ -593,6 +595,7 @@ export default {
             top: 0,
             left: 0,
             zIndex: 0,
+            width: null,
           })
         })
       }
@@ -660,31 +663,34 @@ export default {
         }
       }
     },
-    floatScreen(definition, floated, top, left, zIndex) {
+    floatScreen(definition, floated, top, left, zIndex, width) {
       definition.floated = floated
       definition.top = top
       definition.left = left
       definition.zIndex = zIndex
+      definition.width = width
       let items = this.grid.getItems([
         document.getElementById(this.screenId(definition.id)),
       ])
       this.grid.remove(items)
       this.grid.refreshItems().layout()
     },
-    unfloatScreen(definition, floated, top, left, zIndex) {
+    unfloatScreen(definition, floated, top, left, zIndex, width) {
       definition.floated = floated
       definition.top = top
       definition.left = left
       definition.zIndex = zIndex
+      definition.width = width
       let items = [document.getElementById(this.screenId(definition.id))]
       this.grid.add(items)
       this.grid.refreshItems().layout()
     },
-    dragScreen(definition, floated, top, left, zIndex) {
+    dragScreen(definition, floated, top, left, zIndex, width) {
       definition.floated = floated
       definition.top = top
       definition.left = left
       definition.zIndex = zIndex
+      definition.width = width
     },
     refreshLayout() {
       setTimeout(() => {
@@ -709,6 +715,7 @@ export default {
               let top = definition.top || 0
               let left = definition.left || 0
               let zIndex = definition.zIndex || 0
+              let width = definition.width || null
               this.pushScreen({
                 id: this.counter++,
                 target: definition.target,
@@ -718,6 +725,7 @@ export default {
                 top: top,
                 left: left,
                 zIndex: zIndex,
+                width: width,
               })
             }, 0) // I don't even know... but Muuri complains if this isn't in a setTimeout
           })

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -278,6 +278,10 @@ export default {
       type: Number,
       default: 0,
     },
+    initialWidth: {
+      type: Number,
+      default: null,
+    },
     minZ: {
       type: Number,
       default: 0,
@@ -358,6 +362,7 @@ export default {
       top: this.initialTop,
       left: this.initialLeft,
       zIndex: this.initialZ,
+      floatedWidth: this.initialWidth,
       changeCounter: 0,
       screenItems: [],
       actualScreenItems: [],
@@ -387,8 +392,8 @@ export default {
     },
     computedStyle() {
       let style = {}
-      // note down what the width was in case it was set to AUTO, because absolute positioning will lose that
-      const origWidth = this.width || this.$refs.bar?.clientWidth
+      const origWidth =
+        this.width || this.floatedWidth || this.$refs.bar?.clientWidth
       if (this.floated) {
         style['position'] = 'absolute'
         style['top'] = this.top + 'px'
@@ -746,6 +751,7 @@ export default {
         this.top,
         this.left,
         this.zIndex,
+        this.floatedWidth,
       ])
     },
     downScreen: function () {
@@ -771,6 +777,7 @@ export default {
           this.top,
           this.left,
           this.zIndex,
+          this.floatedWidth,
         ])
       } else {
         let bodyRect =
@@ -778,6 +785,7 @@ export default {
         let elemRect = this.$refs.bar.getBoundingClientRect()
         this.top = elemRect.top - bodyRect.top - 5
         this.left = elemRect.left - bodyRect.left - 5
+        this.floatedWidth = this.$refs.bar.clientWidth
         this.$refs.bar.onmousedown = this.dragMouseDown
         this.$refs.bar.parentElement.parentElement.style =
           'z-index: ' + this.zIndex
@@ -787,6 +795,7 @@ export default {
           this.top,
           this.left,
           this.zIndex,
+          this.floatedWidth,
         ])
       }
     },
@@ -843,6 +852,7 @@ export default {
         this.top,
         this.left,
         this.zIndex,
+        this.floatedWidth,
       ])
     },
     closeDragElement: function () {


### PR DESCRIPTION
closes #3590

Minimum reproducible code for the screen (must be in _float_ mode to reproduce bug):

```
SCREEN AUTO AUTO 1.0

TITLE "Combobox Float Bug"

VERTICALBOX "Pulldown"
  NAMED_WIDGET PULLDOWN COMBOBOX "Select a very long option here" "Another long option value" "Short"
END
```