### PR TITLE
Fix script stuck in SPAWNING state when auth error

### DIFF
--- a/openc3-cosmos-script-runner-api/app/controllers/running_script_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/running_script_controller.rb
@@ -66,43 +66,47 @@ class RunningScriptController < ApplicationController
     running_script = OpenC3::ScriptStatusModel.get_model(name: params[:id], scope: params[:scope])
     if running_script
       target_name = running_script.filename.split('/')[0]
-      pid = running_script.pid.to_i
+      pid = running_script.pid&.to_i
       return unless authorization('script_run', target_name: target_name)
       running_script_publish("cmd-running-script-channel:#{params[:id]}", "stop")
 
-      # Give the process 1 second to stop from stop message
-      stopped = false
-      start_time = Time.now
-      while Time.now - start_time < 1.0
-        begin
-          Process.getpgid(pid.to_i)
-          sleep 0.1
-        rescue Errno::ESRCH
-          stopped = true
-          break
-        end
-      end
-
-      # If the process is still running
-      # Send a SIGINT and give it one more second
-      if not stopped
-        Process.kill("SIGINT", pid)
+      if pid
+        # Give the process 1 second to stop from stop message
+        stopped = false
         start_time = Time.now
         while Time.now - start_time < 1.0
           begin
-            Process.getpgid(pid.to_i)
+            Process.getpgid(pid)
             sleep 0.1
           rescue Errno::ESRCH
             stopped = true
             break
           end
         end
+
+        # If the process is still running
+        # Send a SIGINT and give it one more second
+        if not stopped
+          Process.kill("SIGINT", pid)
+          start_time = Time.now
+          while Time.now - start_time < 1.0
+            begin
+              Process.getpgid(pid)
+              sleep 0.1
+            rescue Errno::ESRCH
+              stopped = true
+              break
+            end
+          end
+        end
+
+        # If the process is still running send a hard kill signal
+        if not stopped
+          Process.kill("SIGKILL", pid)
+        end
       end
 
-      # If the process is still running send a hard kill signal
-      if not stopped
-        Process.kill("SIGKILL", pid)
-
+      if pid.nil? or not stopped
         # Also need to cleanup the status model in this case because the process will not die and cleanup
         running_script.end_time = Time.now.utc.iso8601
         running_script.state = "killed"

--- a/openc3-cosmos-script-runner-api/app/controllers/running_script_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/running_script_controller.rb
@@ -70,9 +70,9 @@ class RunningScriptController < ApplicationController
       return unless authorization('script_run', target_name: target_name)
       running_script_publish("cmd-running-script-channel:#{params[:id]}", "stop")
 
+      stopped = false
       if pid and pid > 0
         # Give the process 1 second to stop from stop message
-        stopped = false
         start_time = Time.now
         while Time.now - start_time < 1.0
           begin
@@ -87,7 +87,11 @@ class RunningScriptController < ApplicationController
         # If the process is still running
         # Send a SIGINT and give it one more second
         if not stopped
-          Process.kill("SIGINT", pid)
+          begin
+            Process.kill("SIGINT", pid)
+          rescue Errno::ESRCH
+            stopped = true
+          end
           start_time = Time.now
           while Time.now - start_time < 1.0
             begin
@@ -102,7 +106,11 @@ class RunningScriptController < ApplicationController
 
         # If the process is still running send a hard kill signal
         if not stopped
-          Process.kill("SIGKILL", pid)
+          begin
+            Process.kill("SIGKILL", pid)
+          rescue Errno::ESRCH
+            stopped = true
+          end
         end
       end
 

--- a/openc3-cosmos-script-runner-api/app/controllers/running_script_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/running_script_controller.rb
@@ -70,7 +70,7 @@ class RunningScriptController < ApplicationController
       return unless authorization('script_run', target_name: target_name)
       running_script_publish("cmd-running-script-channel:#{params[:id]}", "stop")
 
-      if pid
+      if pid and pid > 0
         # Give the process 1 second to stop from stop message
         stopped = false
         start_time = Time.now

--- a/openc3-cosmos-script-runner-api/app/controllers/scripts_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/scripts_controller.rb
@@ -227,6 +227,9 @@ class ScriptsController < ApplicationController
     else
       render plain: "Script not found: #{name}", status: :not_found
     end
+  rescue => e
+    log_error(e)
+    render json: { status: 'error', message: e.message }, status: :internal_server_error
   end
 
   def lock

--- a/openc3-cosmos-script-runner-api/spec/controllers/running_script_controller_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/controllers/running_script_controller_spec.rb
@@ -276,6 +276,29 @@ RSpec.describe RunningScriptController, type: :controller do
       end
     end
 
+    context "when script has no pid (spawn failed)" do
+      it "skips process signaling and cleans up the status model" do
+        script_model = double("ScriptModel")
+        allow(script_model).to receive(:filename).and_return("INST/procedures/test.rb")
+        allow(script_model).to receive(:pid).and_return(nil)
+        allow(script_model).to receive(:end_time=)
+        allow(script_model).to receive(:state=)
+        allow(script_model).to receive(:update)
+        allow(OpenC3::ScriptStatusModel).to receive(:get_model).and_return(script_model)
+        expect_any_instance_of(RunningScriptController).to receive(:running_script_publish).at_least(:once).with("cmd-running-script-channel:1", "stop")
+
+        expect(Process).not_to receive(:kill)
+        expect(Process).not_to receive(:getpgid)
+
+        expect(script_model).to receive(:state=).with("killed")
+        expect(script_model).to receive(:update)
+
+        delete :delete, params: {id: "1", scope: "DEFAULT"}
+
+        expect(response.status).to eq(200)
+      end
+    end
+
     context "when script does not exist" do
       it "returns not found" do
         delete :delete, params: {id: "999", scope: "DEFAULT"}

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe RunningScript, type: :model do
       expect(process_env_double["OPENC3_API_TOKEN"]).to eq("valid_token")
     end
 
-    it "raises an error if offline token is invalid" do
+    it "raises an error and cleans up script status if offline token is invalid" do
       # Mock just the authentication parts
       model_double = double("model", offline_access_token: "invalid_token", update: nil)
       allow(model_double).to receive(:offline_access_token=)
@@ -137,6 +137,39 @@ RSpec.describe RunningScript, type: :model do
       expect {
         RunningScript.spawn("DEFAULT", "script.rb", nil, false, nil, "Test User", "testuser")
       }.to raise_error("offline_access token invalid for script")
+
+      # Verify the orphaned script status was cleaned up
+      expect(OpenC3::ScriptStatusModel.count(scope: "DEFAULT", type: "running")).to eq(0)
+    end
+
+    it "raises an error and cleans up script status if no authentication is available" do
+      # Ensure OPENC3_SERVICE_PASSWORD is not set so the fallback auth fails
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('OPENC3_SERVICE_PASSWORD').and_return(nil)
+
+      expect {
+        RunningScript.spawn("DEFAULT", "script.rb")
+      }.to raise_error("No authentication available for script")
+
+      # Verify the orphaned script status was cleaned up
+      expect(OpenC3::ScriptStatusModel.count(scope: "DEFAULT", type: "running")).to eq(0)
+    end
+
+    it "cleans up script status if process.start raises an error" do
+      failing_process = double("process")
+      allow(failing_process).to receive(:io).and_return(double("io", inherit!: nil))
+      allow(failing_process).to receive(:cwd=)
+      allow(failing_process).to receive(:environment).and_return({})
+      allow(failing_process).to receive(:detach=)
+      allow(failing_process).to receive(:start).and_raise(RuntimeError.new("Failed to start process"))
+      allow(ChildProcess).to receive(:build).and_return(failing_process)
+
+      expect {
+        RunningScript.spawn("DEFAULT", "script.rb")
+      }.to raise_error("Failed to start process")
+
+      # Verify the orphaned script status was cleaned up
+      expect(OpenC3::ScriptStatusModel.count(scope: "DEFAULT", type: "running")).to eq(0)
     end
 
     context "per-plugin Python venv detection" do

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_spec.rb
@@ -155,6 +155,18 @@ RSpec.describe RunningScript, type: :model do
       expect(OpenC3::ScriptStatusModel.count(scope: "DEFAULT", type: "running")).to eq(0)
     end
 
+    it "propagates the error cleanly if failure occurs before script status is created" do
+      # Simulate mkdir_p failing before the ScriptStatusModel is created
+      allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES.new("Permission denied"))
+
+      expect {
+        RunningScript.spawn("DEFAULT", "script.rb")
+      }.to raise_error(Errno::EACCES)
+
+      # No script status should exist since it was never created
+      expect(OpenC3::ScriptStatusModel.count(scope: "DEFAULT", type: "running")).to eq(0)
+    end
+
     it "cleans up script status if process.start raises an error" do
       failing_process = double("process")
       allow(failing_process).to receive(:io).and_return(double("io", inherit!: nil))

--- a/openc3/lib/openc3/utilities/running_script.rb
+++ b/openc3/lib/openc3/utilities/running_script.rb
@@ -609,11 +609,15 @@ class RunningScript
       process.start
       running_script_id
     rescue => e
-      # Clean up the orphaned script status record so the script
-      # does not remain stuck in 'spawning' state forever.
-      # Guard against nil in case the error occurred before these were assigned.
-      script_status.destroy() if script_status
-      FileUtils.rm_rf(script_cwd) if script_cwd
+      begin
+        # Clean up the orphaned script status record so the script
+        # does not remain stuck in 'spawning' state forever.
+        # Guard against nil in case the error occurred before these were assigned.
+        script_status.destroy() if script_status
+        FileUtils.rm_rf(script_cwd) if script_cwd
+      rescue => cleanup_error
+        OpenC3::Logger.error("Failed to cleanup after spawn failure: #{cleanup_error.message}")
+      end
       raise e
     end
   end

--- a/openc3/lib/openc3/utilities/running_script.rb
+++ b/openc3/lib/openc3/utilities/running_script.rb
@@ -468,57 +468,57 @@ class RunningScript
     user_full_name ||= 'Anonymous'
     start_time = Time.now.utc.iso8601
 
-    process = ChildProcess.build(process_name, runner_path.to_s, running_script_id.to_s, scope)
-    process.io.inherit! # Helps with debugging
-    script_cwd = File.join(RAILS_ROOT, 'tmp', "script_#{running_script_id}")
-    FileUtils.mkdir_p(script_cwd)
-    process.cwd = script_cwd
+    begin
+      process = ChildProcess.build(process_name, runner_path.to_s, running_script_id.to_s, scope)
+      process.io.inherit! # Helps with debugging
+      script_cwd = File.join(RAILS_ROOT, 'tmp', "script_#{running_script_id}")
+      FileUtils.mkdir_p(script_cwd)
+      process.cwd = script_cwd
 
-    # Check for offline access token
-    model = nil
-    model = OpenC3::OfflineAccessModel.get_model(name: username, scope: scope) if username != 'Anonymous'
+      # Check for offline access token
+      model = nil
+      model = OpenC3::OfflineAccessModel.get_model(name: username, scope: scope) if username != 'Anonymous'
 
-    # Load the global environment variables
-    status_environment = {}
-    values = OpenC3::EnvironmentModel.all(scope: scope).values
-    values.each do |env|
-      process.environment[env['key']] = env['value']
-      status_environment[env['key']] = env['value']
-    end
-    # Load the script specific ENV vars set by the GUI
-    # These can override the previously defined global env vars
-    if environment
-      environment.each do |env|
+      # Load the global environment variables
+      status_environment = {}
+      values = OpenC3::EnvironmentModel.all(scope: scope).values
+      values.each do |env|
         process.environment[env['key']] = env['value']
         status_environment[env['key']] = env['value']
       end
-    end
+      # Load the script specific ENV vars set by the GUI
+      # These can override the previously defined global env vars
+      if environment
+        environment.each do |env|
+          process.environment[env['key']] = env['value']
+          status_environment[env['key']] = env['value']
+        end
+      end
 
-    script_status = OpenC3::ScriptStatusModel.new(
-      name: running_script_id.to_s, # Unique id for this script
-      state: 'spawning', # State will be spawning until the script is running
-      shard: 0, # Future enhancement of script runner shards
-      filename: name, # Initial filename never changes
-      current_filename: name, # Current filename updates while we are running
-      line_no: 0, # 0 means not running yet
-      start_line_no: line_no || 1, # Line number to start running the script
-      end_line_no: end_line_no || nil, # Line number to stop running the script
-      username: username, # username of the person who started the script
-      user_full_name: user_full_name, # full name of the person who started the script
-      start_time: start_time, # Time the script started ISO format
-      end_time: nil, # Time the script ended ISO format
-      disconnect: disconnect, # Disconnect is set to true if the script is running in a disconnected mode
-      environment: status_environment, # hash of environment variables set for the script
-      suite_runner: suite_runner ? suite_runner : nil, # current suite information if any
-      errors: nil, # array of errors that occurred during the script run
-      pid: nil, # pid of the script process - set by the script itself when it starts
-      script_engine: script_engine, # script engine filename
-      updated_at: nil, # Set by create/update
-      scope: scope # Scope of the script
-    )
-    script_status.create()
+      script_status = OpenC3::ScriptStatusModel.new(
+        name: running_script_id.to_s, # Unique id for this script
+        state: 'spawning', # State will be spawning until the script is running
+        shard: 0, # Future enhancement of script runner shards
+        filename: name, # Initial filename never changes
+        current_filename: name, # Current filename updates while we are running
+        line_no: 0, # 0 means not running yet
+        start_line_no: line_no || 1, # Line number to start running the script
+        end_line_no: end_line_no || nil, # Line number to stop running the script
+        username: username, # username of the person who started the script
+        user_full_name: user_full_name, # full name of the person who started the script
+        start_time: start_time, # Time the script started ISO format
+        end_time: nil, # Time the script ended ISO format
+        disconnect: disconnect, # Disconnect is set to true if the script is running in a disconnected mode
+        environment: status_environment, # hash of environment variables set for the script
+        suite_runner: suite_runner ? suite_runner : nil, # current suite information if any
+        errors: nil, # array of errors that occurred during the script run
+        pid: nil, # pid of the script process - set by the script itself when it starts
+        script_engine: script_engine, # script engine filename
+        updated_at: nil, # Set by create/update
+        scope: scope # Scope of the script
+      )
+      script_status.create()
 
-    begin
       # Set proper secrets for running script
       process.environment['SECRET_KEY_BASE'] = nil
       process.environment['OPENC3_REDIS_USERNAME'] = ENV['OPENC3_SR_REDIS_USERNAME']
@@ -609,8 +609,11 @@ class RunningScript
       process.start
       running_script_id
     rescue => e
-      script_status.destroy()
-      FileUtils.rm_rf(script_cwd)
+      # Clean up the orphaned script status record so the script
+      # does not remain stuck in 'spawning' state forever.
+      # Guard against nil in case the error occurred before these were assigned.
+      script_status.destroy() if script_status
+      FileUtils.rm_rf(script_cwd) if script_cwd
       raise e
     end
   end

--- a/openc3/lib/openc3/utilities/running_script.rb
+++ b/openc3/lib/openc3/utilities/running_script.rb
@@ -518,95 +518,101 @@ class RunningScript
     )
     script_status.create()
 
-    # Set proper secrets for running script
-    process.environment['SECRET_KEY_BASE'] = nil
-    process.environment['OPENC3_REDIS_USERNAME'] = ENV['OPENC3_SR_REDIS_USERNAME']
-    process.environment['OPENC3_REDIS_PASSWORD'] = ENV['OPENC3_SR_REDIS_PASSWORD']
-    process.environment['OPENC3_BUCKET_USERNAME'] = ENV['OPENC3_SR_BUCKET_USERNAME']
-    process.environment['OPENC3_BUCKET_PASSWORD'] = ENV['OPENC3_SR_BUCKET_PASSWORD']
-    process.environment['OPENC3_SR_REDIS_USERNAME'] = nil
-    process.environment['OPENC3_SR_REDIS_PASSWORD'] = nil
-    process.environment['OPENC3_SR_BUCKET_USERNAME'] = nil
-    process.environment['OPENC3_SR_BUCKET_PASSWORD'] = nil
-    process.environment['OPENC3_API_CLIENT'] = ENV['OPENC3_API_CLIENT']
-    if model and model.offline_access_token
-      auth = OpenC3::OpenC3KeycloakAuthentication.new(ENV['OPENC3_KEYCLOAK_URL'])
-      valid_token = auth.get_token_from_refresh_token(model.offline_access_token)
-      if valid_token
-        process.environment['OPENC3_API_TOKEN'] = model.offline_access_token
-      else
-        model.offline_access_token = nil
-        model.update
-        raise "offline_access token invalid for script"
-      end
-    else
-      process.environment['OPENC3_API_USER'] = ENV['OPENC3_API_USER']
-      if ENV['OPENC3_SERVICE_PASSWORD']
-        process.environment['OPENC3_API_PASSWORD'] = ENV['OPENC3_SERVICE_PASSWORD']
-      else
-        raise "No authentication available for script"
-      end
-    end
-    process.environment['GEM_HOME'] = ENV['GEM_HOME']
-
-    # Resolve the per-plugin Python venv for this script. For saved scripts
-    # we look up which plugin owns the target and check whether that plugin
-    # has an isolated UV venv. For temp scripts the frontend can pass a
-    # python_venv name directly, skipping the target lookup entirely.
-    python_venv_dir = nil
     begin
-      target_name = name.split('/')[0].to_s.upcase
-      if target_name == '__TEMP__' && python_venv
-        # File.basename prevents path traversal (strips directory components)
-        safe_name = File.basename(python_venv.to_s)
-        candidate = "/gems/plugin_venvs/#{safe_name}/.venv"
-        python_venv_dir = candidate if File.directory?(candidate)
+      # Set proper secrets for running script
+      process.environment['SECRET_KEY_BASE'] = nil
+      process.environment['OPENC3_REDIS_USERNAME'] = ENV['OPENC3_SR_REDIS_USERNAME']
+      process.environment['OPENC3_REDIS_PASSWORD'] = ENV['OPENC3_SR_REDIS_PASSWORD']
+      process.environment['OPENC3_BUCKET_USERNAME'] = ENV['OPENC3_SR_BUCKET_USERNAME']
+      process.environment['OPENC3_BUCKET_PASSWORD'] = ENV['OPENC3_SR_BUCKET_PASSWORD']
+      process.environment['OPENC3_SR_REDIS_USERNAME'] = nil
+      process.environment['OPENC3_SR_REDIS_PASSWORD'] = nil
+      process.environment['OPENC3_SR_BUCKET_USERNAME'] = nil
+      process.environment['OPENC3_SR_BUCKET_PASSWORD'] = nil
+      process.environment['OPENC3_API_CLIENT'] = ENV['OPENC3_API_CLIENT']
+      if model and model.offline_access_token
+        auth = OpenC3::OpenC3KeycloakAuthentication.new(ENV['OPENC3_KEYCLOAK_URL'])
+        valid_token = auth.get_token_from_refresh_token(model.offline_access_token)
+        if valid_token
+          process.environment['OPENC3_API_TOKEN'] = model.offline_access_token
+        else
+          model.offline_access_token = nil
+          model.update
+          raise "offline_access token invalid for script"
+        end
       else
-        target_info = OpenC3::TargetModel.get(name: target_name, scope: scope)
-        if target_info && target_info['plugin']
-          sanitized_name = "#{scope}__#{target_info['plugin']}".tr('^a-zA-Z0-9_-', '_')
-          candidate = "/gems/plugin_venvs/#{sanitized_name}/.venv"
-          python_venv_dir = candidate if File.directory?(candidate)
+        process.environment['OPENC3_API_USER'] = ENV['OPENC3_API_USER']
+        if ENV['OPENC3_SERVICE_PASSWORD']
+          process.environment['OPENC3_API_PASSWORD'] = ENV['OPENC3_SERVICE_PASSWORD']
+        else
+          raise "No authentication available for script"
         end
       end
-    rescue => e
-      OpenC3::Logger.debug("Could not resolve plugin venv for script '#{name}': #{e.message}")
-    end
+      process.environment['GEM_HOME'] = ENV['GEM_HOME']
 
-    if python_venv_dir
-      process.environment['VIRTUAL_ENV'] = python_venv_dir
-      process.environment['PATH'] = "#{python_venv_dir}/bin:#{ENV.fetch('PATH', '')}"
-      process.environment['PYTHONUSERBASE'] = python_venv_dir
-      # Add plugin venv site-packages to PYTHONPATH so the base venv's Python
-      # binary can find plugin-specific packages. PYTHONPATH is always respected
-      # by CPython regardless of venv activation state.
-      site_packages = Dir.glob("#{python_venv_dir}/lib/python*/site-packages").first
-      existing_pythonpath = ENV.fetch('PYTHONPATH', '')
-      if site_packages
-        process.environment['PYTHONPATH'] = existing_pythonpath.empty? ? site_packages : "#{site_packages}:#{existing_pythonpath}"
+      # Resolve the per-plugin Python venv for this script. For saved scripts
+      # we look up which plugin owns the target and check whether that plugin
+      # has an isolated UV venv. For temp scripts the frontend can pass a
+      # python_venv name directly, skipping the target lookup entirely.
+      python_venv_dir = nil
+      begin
+        target_name = name.split('/')[0].to_s.upcase
+        if target_name == '__TEMP__' && python_venv
+          # File.basename prevents path traversal (strips directory components)
+          safe_name = File.basename(python_venv.to_s)
+          candidate = "/gems/plugin_venvs/#{safe_name}/.venv"
+          python_venv_dir = candidate if File.directory?(candidate)
+        else
+          target_info = OpenC3::TargetModel.get(name: target_name, scope: scope)
+          if target_info && target_info['plugin']
+            sanitized_name = "#{scope}__#{target_info['plugin']}".tr('^a-zA-Z0-9_-', '_')
+            candidate = "/gems/plugin_venvs/#{sanitized_name}/.venv"
+            python_venv_dir = candidate if File.directory?(candidate)
+          end
+        end
+      rescue => e
+        OpenC3::Logger.debug("Could not resolve plugin venv for script '#{name}': #{e.message}")
+      end
+
+      if python_venv_dir
+        process.environment['VIRTUAL_ENV'] = python_venv_dir
+        process.environment['PATH'] = "#{python_venv_dir}/bin:#{ENV.fetch('PATH', '')}"
+        process.environment['PYTHONUSERBASE'] = python_venv_dir
+        # Add plugin venv site-packages to PYTHONPATH so the base venv's Python
+        # binary can find plugin-specific packages. PYTHONPATH is always respected
+        # by CPython regardless of venv activation state.
+        site_packages = Dir.glob("#{python_venv_dir}/lib/python*/site-packages").first
+        existing_pythonpath = ENV.fetch('PYTHONPATH', '')
+        if site_packages
+          process.environment['PYTHONPATH'] = existing_pythonpath.empty? ? site_packages : "#{site_packages}:#{existing_pythonpath}"
+        else
+          process.environment['PYTHONPATH'] = existing_pythonpath.empty? ? nil : existing_pythonpath
+        end
       else
-        process.environment['PYTHONPATH'] = existing_pythonpath.empty? ? nil : existing_pythonpath
+        system_venv = File.dirname(ENV['OPENC3_PYTHON_BIN'] || '/openc3/python/.venv/bin/python').chomp('/bin')
+        process.environment['VIRTUAL_ENV'] = system_venv
+        process.environment['PYTHONUSERBASE'] = ENV['PYTHONUSERBASE']
+        process.environment['PYTHONPATH'] = ENV['PYTHONPATH']
       end
-    else
-      system_venv = File.dirname(ENV['OPENC3_PYTHON_BIN'] || '/openc3/python/.venv/bin/python').chomp('/bin')
-      process.environment['VIRTUAL_ENV'] = system_venv
-      process.environment['PYTHONUSERBASE'] = ENV['PYTHONUSERBASE']
-      process.environment['PYTHONPATH'] = ENV['PYTHONPATH']
-    end
 
-    # Spawned process should not be controlled by same Bundler constraints as spawning process
-    ENV.each do |key, _value|
-      if key =~ /^BUNDLE/
-        process.environment[key] = nil
+      # Spawned process should not be controlled by same Bundler constraints as spawning process
+      ENV.each do |key, _value|
+        if key =~ /^BUNDLE/
+          process.environment[key] = nil
+        end
       end
-    end
-    process.environment['RUBYOPT'] = nil # Removes loading bundler setup
-    process.environment['OPENC3_SCOPE'] = scope
-    process.environment['RAILS_ROOT'] = RAILS_ROOT
+      process.environment['RUBYOPT'] = nil # Removes loading bundler setup
+      process.environment['OPENC3_SCOPE'] = scope
+      process.environment['RAILS_ROOT'] = RAILS_ROOT
 
-    process.detach = true
-    process.start
-    running_script_id
+      process.detach = true
+      process.start
+      running_script_id
+    rescue => e
+      script_status.destroy()
+      FileUtils.rm_rf(script_cwd)
+      raise e
+    end
   end
 
   def initialize(script_status)


### PR DESCRIPTION
Before, in Enterprise, if you didn't have an offline access token set, the script status would never be cleaned up, so the script would show "spawning" forever