### PR TITLE
Lower the log level of "Log writer out of order..."

### DIFF
--- a/openc3/lib/openc3/logs/log_writer.rb
+++ b/openc3/lib/openc3/logs/log_writer.rb
@@ -328,9 +328,9 @@ module OpenC3
             start_new_file()
           elsif !stored
             # Warning: Creating new files here can cause lots of files to be created if packets make it through out of order
-            # Changed to just a error to prevent file thrashing
+            # Changed to just a warning to prevent file thrashing
             unless @out_of_order
-              Logger.error("Log writer out of order time detected (increase buffer depth?): #{Time.from_nsec_from_epoch(@previous_time_nsec_since_epoch)} #{Time.from_nsec_from_epoch(time_nsec_since_epoch)}")
+              Logger.warn("Log writer out of order time detected (increase buffer depth?): #{Time.from_nsec_from_epoch(@previous_time_nsec_since_epoch)} #{Time.from_nsec_from_epoch(time_nsec_since_epoch)}")
               @out_of_order = true
             end
           end

--- a/openc3/python/openc3/logs/log_writer.py
+++ b/openc3/python/openc3/logs/log_writer.py
@@ -283,9 +283,9 @@ class LogWriter:
                 and (self.previous_time_nsec_since_epoch > time_nsec_since_epoch)
             ):
                 # Warning= Creating new files here can cause lots of files to be created if packets make it through out of order:
-                # Changed to just a error to prevent file thrashing
+                # Changed to just a warning to prevent file thrashing
                 if not self.out_of_order:
-                    Logger.error(
+                    Logger.warn(
                         f"Log writer out of order time detected (increase buffer depth?): {from_nsec_from_epoch(self.previous_time_nsec_since_epoch)} {from_nsec_from_epoch(time_nsec_since_epoch)}"
                     )
                     self.out_of_order = True


### PR DESCRIPTION
because it's really just a notification that packets are arriving out of order, but there's no real issue to error on