### PR TITLE
Eslint improvements

### DIFF
--- a/openc3-cosmos-init/plugins/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/eslint.config.mjs
@@ -30,6 +30,8 @@ export default defineConfig([
         },
       ],
 
+      'require-await': 'error',
+
       'vue/multi-word-component-names': 'off',
 
       'vue/valid-v-slot': [

--- a/openc3-cosmos-init/plugins/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/eslint.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig([
     },
 
     rules: {
-      'no-console': 'error',
+      'no-console': ['error', { allow: ['error'] }],
       'no-debugger': 'error',
 
       'prettier/prettier': [

--- a/openc3-cosmos-init/plugins/lint-all.mjs
+++ b/openc3-cosmos-init/plugins/lint-all.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/*
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+*/
+/* eslint-disable no-console */
+// Run ESLint across every package that has its own eslint config file, so each
+// package's source is checked against its *closest* config.
+//
+// ESLint's flat config (v9+) does not cascade like the old .eslintrc: a single
+// run uses only the nearest config to the working directory. We therefore run
+// ESLint once per config directory (with that directory as cwd) so each picks
+// up its own config. Following the per-package `lint` scripts, we lint `src`
+// only -- this skips build output (tools/) and vendored bundles (public/).
+//
+// Usage:
+//   node lint-all.mjs            # lint every package's src
+//   node lint-all.mjs --fix      # extra args are forwarded to eslint
+import { spawnSync } from 'node:child_process'
+import { existsSync, readdirSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = dirname(fileURLToPath(import.meta.url))
+const CONFIG_RE = /^eslint\.config\.[mc]?[jt]s$/
+
+// Run eslint via the current Node binary and eslint's own JS entry point rather
+// than resolving a `pnpm`/`eslint` command name through $PATH (which is
+// hijackable). eslint's bin isn't exposed through its package `exports`, so we
+// resolve the package root and append the known bin path.
+const require = createRequire(import.meta.url)
+const ESLINT_BIN = join(
+  dirname(require.resolve('eslint/package.json')),
+  'bin',
+  'eslint.js',
+)
+
+// Recursively collect every directory that contains an eslint config file.
+function findConfigDirs(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue
+    if (entry.isDirectory()) {
+      findConfigDirs(join(dir, entry.name), acc)
+    } else if (CONFIG_RE.test(entry.name)) {
+      acc.push(dir)
+    }
+  }
+  return acc
+}
+
+const configDirs = findConfigDirs(ROOT).sort((a, b) => a.localeCompare(b))
+const extraArgs = process.argv.slice(2)
+
+if (configDirs.length === 0) {
+  console.error('No eslint config files found under', ROOT)
+  process.exit(1)
+}
+
+// A folder under packages/ that has source but no eslint.config.mjs would be
+// linted by no one -- flag it as an error so it can't slip through unchecked.
+const PACKAGES = join(ROOT, 'packages')
+const configDirSet = new Set(configDirs)
+const missingConfig = []
+if (existsSync(PACKAGES)) {
+  for (const entry of readdirSync(PACKAGES, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const pkgDir = join(PACKAGES, entry.name)
+    if (existsSync(join(pkgDir, 'src')) && !configDirSet.has(pkgDir)) {
+      missingConfig.push(relative(ROOT, pkgDir))
+    }
+  }
+}
+
+let overall = 0
+const failed = []
+const skipped = []
+
+for (const dir of configDirs) {
+  const relDir = relative(ROOT, dir) || '.'
+
+  // The per-package convention is `eslint src`; a config dir without a src/
+  // (e.g. the workspace root) has nothing of its own to lint.
+  if (!existsSync(join(dir, 'src'))) {
+    skipped.push(relDir)
+    console.log(`\n==> Skipping ${relDir} (no src/)`)
+    continue
+  }
+
+  console.log(
+    `\n==> Linting ${relDir}/src (closest config: ${relDir}/eslint.config.*)`,
+  )
+
+  const result = spawnSync(
+    process.execPath,
+    [ESLINT_BIN, 'src', ...extraArgs],
+    {
+      cwd: dir,
+      stdio: 'inherit',
+    },
+  )
+
+  const status = result.status ?? 1
+  if (status !== 0) {
+    overall = status
+    failed.push(relDir)
+    console.log(`    ✗ ${relDir} reported problems`)
+  } else {
+    console.log(`    ✓ ${relDir} clean`)
+  }
+}
+
+const linted = configDirs.length - skipped.length
+console.log(`\n${'='.repeat(60)}`)
+if (failed.length === 0) {
+  console.log(
+    `All ${linted} linted package(s) clean. (${skipped.length} skipped)`,
+  )
+} else {
+  console.log(`${failed.length}/${linted} package(s) reported problems:`)
+  for (const f of failed) console.log(`  - ${f}`)
+}
+
+if (missingConfig.length > 0) {
+  overall = overall || 1
+  console.log(
+    `\n${missingConfig.length} package(s) have a src/ but no eslint.config.mjs (source would go unlinted):`,
+  )
+  for (const p of missingConfig) console.log(`  - ${p}`)
+}
+
+process.exit(overall)

--- a/openc3-cosmos-init/plugins/package.json
+++ b/openc3-cosmos-init/plugins/package.json
@@ -2,7 +2,8 @@
   "name": "openc3",
   "private": true,
   "scripts": {
-    "build:common": "pnpm -F @openc3/*-common build"
+    "build:common": "pnpm -F @openc3/*-common build",
+    "lint": "./lint-all.mjs"
   },
   "devDependencies": {
     "@vue/eslint-config-prettier": "10.2.0",

--- a/openc3-cosmos-init/plugins/package.json
+++ b/openc3-cosmos-init/plugins/package.json
@@ -10,6 +10,8 @@
     "eslint-plugin-vue": "10.9.2",
     "eslint-plugin-vuetify": "2.7.2",
     "globals": "17.7.0",
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.64.0",
     "vue-eslint-parser": "10.4.1"
   }
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/src/tools/BucketExplorer/BucketExplorer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-bucketexplorer/src/tools/BucketExplorer/BucketExplorer.vue
@@ -454,7 +454,7 @@ export default {
   },
   watch: {
     // This is the upload function that is activated when the file gets set
-    file: async function () {
+    file: function () {
       if (this.file === null) return
       this.uploadFilePath = `${this.path}${this.file.name}`
       this.uploadPathDialog = true

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/eslint.config.mjs
@@ -1,11 +1,1 @@
-import { defineConfig } from 'eslint/config'
-import baseConfig from '../../eslint.config.mjs'
-
-export default defineConfig([
-  baseConfig,
-  {
-    rules: {
-      'no-console': 'warn',
-    },
-  },
-])
+export { default } from '../../eslint.config.mjs'

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/eslint.config.mjs
@@ -5,7 +5,6 @@ export default defineConfig([
   baseConfig,
   {
     rules: {
-      'no-console': 'warn',
       'vue/no-side-effects-in-computed-properties': 'warn',
       'vuetify/no-deprecated-props': 'warn',
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/InterfaceComponents/InterfaceFlowChart.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/InterfaceComponents/InterfaceFlowChart.vue
@@ -53,7 +53,7 @@ const edges = ref([])
 let layoutNeeded = false
 let structureChanged = false
 
-async function layoutGraph(direction, force = false) {
+function layoutGraph(direction, force = false) {
   if (layoutNeeded || force) {
     nodes.value = layout(nodes.value, edges.value, direction)
     layoutNeeded = false
@@ -281,7 +281,7 @@ onConnect((params) => {
               cmd_or_tlm === 'tlm',
               false,
             )
-            .then((response) => {
+            .then(() => {
               addEdges(params)
               edges.value.push(params)
             })
@@ -290,7 +290,7 @@ onConnect((params) => {
   }
 })
 
-onNodesChange(async (changes) => {
+onNodesChange((changes) => {
   const nextChanges = []
 
   for (const change of changes) {
@@ -309,7 +309,7 @@ onNodesChange(async (changes) => {
   applyNodeChanges(nextChanges)
 })
 
-onEdgesChange(async (changes) => {
+onEdgesChange((changes) => {
   const nextChanges = []
   for (const change of changes) {
     if (change.type !== 'remove') {
@@ -389,7 +389,7 @@ onEdgesChange(async (changes) => {
                   cmd_or_tlm === 'cmd',
                   cmd_or_tlm === 'tlm',
                 )
-                .then((response) => {
+                .then(() => {
                   applyEdgeChanges([change])
                   edges.value.forEach((edge, index) => {
                     if (edge.id === change.id) {
@@ -406,7 +406,7 @@ onEdgesChange(async (changes) => {
                   cmd_or_tlm === 'cmd',
                   cmd_or_tlm === 'tlm',
                 )
-                .then((response) => {
+                .then(() => {
                   applyEdgeChanges([change])
                   edges.value.forEach((edge, index) => {
                     if (edge.id === change.id) {
@@ -924,7 +924,7 @@ function updateFlowChart() {
 
 watch(
   () => props.interfaceDetails,
-  async () => {
+  () => {
     if (props.interfaceDetails !== null) {
       updateFlowChart()
     }
@@ -934,7 +934,7 @@ watch(
 
 watch(
   () => props.routerDetails,
-  async () => {
+  () => {
     if (props.routerDetails !== null) {
       updateFlowChart()
     }

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/InterfacesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/InterfacesTab.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -223,7 +223,6 @@ export default {
           this.detailsDialog = true
         })
         .catch((error) => {
-          // eslint-disable-next-line no-console
           console.error('Failed to fetch interface details:', error)
           this.interfaceDetails = null
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/RoutersTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/RoutersTab.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -207,7 +207,6 @@ export default {
           this.detailsDialog = true
         })
         .catch((error) => {
-          // eslint-disable-next-line no-console
           console.error('Failed to fetch router details:', error)
           this.routerDetails = null
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/TargetsTab.vue
@@ -274,7 +274,7 @@ export default {
     update() {
       if (this.tabId != this.curTab) return
       if (this.data.length !== 0) {
-        this.api.get_target_interfaces().then(async (info) => {
+        this.api.get_target_interfaces().then((info) => {
           for (let i = 0; i < info.length; i++) {
             this.data[i].name = info[i][0]
             this.data[i].interface = info[i][1]

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/src/tools/PacketViewer/PacketViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/src/tools/PacketViewer/PacketViewer.vue
@@ -706,10 +706,7 @@ export default {
               .then((values) => {
                 this.latestGetTlmValues(values)
               })
-              .catch((error) => {
-                // eslint-disable-next-line no-console
-                console.log(error)
-              })
+              .catch(console.error)
           } else {
             this.api
               .get_all_tlm_item_names(this.targetName)
@@ -729,10 +726,7 @@ export default {
               .then((values) => {
                 this.latestGetTlmValues(values)
               })
-              .catch((error) => {
-                // eslint-disable-next-line no-console
-                console.log(error)
-              })
+              .catch(console.error)
           }
         } else {
           // Regular packet handling using get_tlm_packet
@@ -786,10 +780,7 @@ export default {
             // Catch errors but just log to the console
             // We don't clear the updater because errors can happen on upgrade
             // and we want to continue updating once the new plugin comes online
-            .catch((error) => {
-              // eslint-disable-next-line no-console
-              console.log(error)
-            })
+            .catch(console.error)
         }
         if (loadingFirstTlm) {
           loadingFirstTlm = false

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/eslint.config.mjs
@@ -1,11 +1,1 @@
-import { defineConfig } from 'eslint/config'
-import baseConfig from '../../eslint.config.mjs'
-
-export default defineConfig([
-  baseConfig,
-  {
-    rules: {
-      'vue/no-deprecated-delete-set': 'warn',
-    },
-  },
-])
+export { default } from '../../eslint.config.mjs'

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
@@ -489,7 +489,6 @@ export default {
         }
       })
       .catch((error) => {
-        // eslint-disable-next-line no-console
         console.error('Error loading screens:', error)
       })
     Api.get('/openc3-api/autocomplete/keywords/screen')
@@ -497,7 +496,6 @@ export default {
         this.keywords = response.data
       })
       .catch((error) => {
-        // eslint-disable-next-line no-console
         console.error('Error loading screen keywords:', error)
       })
 
@@ -608,7 +606,6 @@ export default {
           'Ignore-Errors': '404',
         },
       }).catch((error) => {
-        // eslint-disable-next-line no-console
         console.error(
           `Error loading screen ${screen} for target ${target}:`,
           error,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/eslint.config.mjs
@@ -9,8 +9,7 @@ const packageDir = dirname(fileURLToPath(import.meta.url))
 export default defineConfig([
   baseConfig,
   {
-    // TODO: expand this list to other parts of the src folder and to other packages
-    files: ['src/tools/**/*.{js,vue}'],
+    files: ['src/**/*.{js,vue}'],
 
     plugins: {
       '@typescript-eslint': tseslint.plugin,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/eslint.config.mjs
@@ -1,17 +1,32 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'eslint/config'
+import tseslint from 'typescript-eslint'
 import baseConfig from '../../eslint.config.mjs'
+
+const packageDir = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig([
   baseConfig,
   {
+    // TODO: expand this list to other parts of the src folder and to other packages
+    files: ['src/tools/**/*.{js,vue}'],
+
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+    },
+
+    languageOptions: {
+      parserOptions: {
+        parser: tseslint.parser,
+        projectService: true,
+        tsconfigRootDir: resolve(packageDir, '../..'),
+        extraFileExtensions: ['.vue'],
+      },
+    },
+
     rules: {
-      'no-console': 'warn',
-      'vue/no-mutating-props': 'warn',
-      'vue/no-side-effects-in-computed-properties': 'warn',
-      'vue/valid-v-slot': 'warn',
-      'vuetify/no-deprecated-classes': 'warn',
-      'vuetify/no-deprecated-components': 'warn',
-      'vuetify/no-deprecated-props': 'warn',
+      '@typescript-eslint/no-floating-promises': 'error',
     },
   },
 ])

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
@@ -252,7 +252,6 @@ export default {
               return this.api.get_cmd(this.targetName, this.commandName)
             },
             (error) => {
-              // eslint-disable-next-line no-console
               console.error('Error getting ignored parameters:', error)
             },
           )
@@ -338,7 +337,6 @@ export default {
               }
             },
             (error) => {
-              // eslint-disable-next-line no-console
               console.error('Error getting command parameters:', error)
               this.$emit('command-loaded', null)
             },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CriticalCmdDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CriticalCmdDialog.vue
@@ -134,25 +134,25 @@ export default {
     modelValue: function (newValue, oldValue) {
       if (newValue) {
         // Check if we can approve without username/password
-        Api.get('/openc3-api/criticalcmd/canapprove/' + this.uuid).then(
-          (response) => {
+        Api.get('/openc3-api/criticalcmd/canapprove/' + this.uuid)
+          .then((response) => {
             if (response.data.status === 'ok') {
               this.canApprove = true
             }
-          },
-        )
+          })
+          .catch(console.error)
 
         // Clear if approved/rejected
         this.updater = setInterval(() => {
           if (this.uuid) {
-            Api.get('/openc3-api/criticalcmd/status/' + this.uuid).then(
-              (response) => {
+            Api.get('/openc3-api/criticalcmd/status/' + this.uuid)
+              .then((response) => {
                 if (response.data.status !== 'WAITING') {
                   this.$emit('status', response.data.status, this.uuid)
                   this.show = false
                 }
-              },
-            )
+              })
+              .catch(console.error)
           } else {
             this.show = false
           }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/DetailsDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/DetailsDialog.vue
@@ -387,33 +387,32 @@ export default {
     },
     async requestDetails() {
       if (this.type === 'tlm') {
-        this.api
-          .get_tlm_available([
-            `${this.targetName}__${this.packetName}__${this.itemName}__RAW`,
-            `${this.targetName}__${this.packetName}__${this.itemName}__CONVERTED`,
-            `${this.targetName}__${this.packetName}__${this.itemName}__FORMATTED`,
-          ])
-          .then((available) => {
-            if (available && available.length > 0) {
-              this.available = available
-            }
-            this.api
-              .get_item(this.targetName, this.packetName, this.itemName)
-              .then((details) => {
-                this.details = details
-                // If the item does not have limits explicitly null it
-                // to make the check in the template easier
-                if (!this.hasLimits(details)) {
-                  this.details.limits = null
-                }
-              })
-          })
+        const available = await this.api.get_tlm_available([
+          `${this.targetName}__${this.packetName}__${this.itemName}__RAW`,
+          `${this.targetName}__${this.packetName}__${this.itemName}__CONVERTED`,
+          `${this.targetName}__${this.packetName}__${this.itemName}__FORMATTED`,
+        ])
+        if (available && available.length > 0) {
+          this.available = available
+        }
+        const details = await this.api.get_item(
+          this.targetName,
+          this.packetName,
+          this.itemName,
+        )
+        this.details = details
+        // If the item does not have limits explicitly null it
+        // to make the check in the template easier
+        if (!this.hasLimits(details)) {
+          this.details.limits = null
+        }
       } else {
-        this.api
-          .get_parameter(this.targetName, this.packetName, this.itemName)
-          .then((details) => {
-            this.details = details
-          })
+        const details = await this.api.get_parameter(
+          this.targetName,
+          this.packetName,
+          this.itemName,
+        )
+        this.details = details
       }
     },
     async changeLimitsEnabled() {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/FileOpenSaveDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/FileOpenSaveDialog.vue
@@ -225,25 +225,29 @@ export default {
     },
   },
   created() {
-    Api.get('/openc3-api/targets').then((response) => {
-      this.targets = response.data
-      this.targets.push('__TEMP__') // Also support __TEMP__
-      const loadPromises = this.targets.map((target) => {
-        // Name not found so push the item and add a children array
-        this.items.push({
-          id: target,
-          disabled: true,
-          title: target,
-          children: [],
-          path: target,
+    Api.get('/openc3-api/targets')
+      .then((response) => {
+        this.targets = response.data
+        this.targets.push('__TEMP__') // Also support __TEMP__
+        const loadPromises = this.targets.map((target) => {
+          // Name not found so push the item and add a children array
+          this.items.push({
+            id: target,
+            disabled: true,
+            title: target,
+            children: [],
+            path: target,
+          })
+          // Load the targets 1 by 1 in the background
+          return this.loadFiles(target)
         })
-        // Load the targets 1 by 1 in the background
-        return this.loadFiles(target)
+        Promise.all(loadPromises)
+          .then(() => {
+            this.disableButtons = false
+          })
+          .catch(console.error)
       })
-      Promise.all(loadPromises).then(() => {
-        this.disableButtons = false
-      })
-    })
+      .catch(console.error)
   },
   methods: {
     calcIcon: function (filename) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -674,7 +674,6 @@ export default {
               this.updateGraphData()
             })
             .catch((error) => {
-              // eslint-disable-next-line no-console
               console.error('Error fetching playback telemetry:', error)
             })
             .finally(() => {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -1095,8 +1095,7 @@ export default {
         // This must be the same or we're going to have problems
         // because the data comes back in an ordered array
         if (screenItems.length != data.length) {
-          // eslint-disable-next-line no-console
-          console.log(
+          console.error(
             'Error getting tlm available',
             screenItems,
             this.graphItems,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/GraphEditItemDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/GraphEditItemDialog.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2023, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -135,20 +135,21 @@ export default {
   },
   async created() {
     this.editItem = { ...this.item }
-    new OpenC3Api()
-      .get_item(this.item.targetName, this.item.packetName, this.item.itemName)
-      .then((details) => {
-        for (const [key, value] of Object.entries(details.limits)) {
-          if (Object.keys(value).includes('red_low')) {
-            this.limits[key] = Object.values(value)
-          }
-        }
-        // Locate the key for the value array that we pass in
-        this.limitsName = Object.keys(this.limits).find(
-          // Little hack to compare arrays you convert them to strings
-          (key) => this.limits[key] + '' === this.editItem.limits + '',
-        )
-      })
+    const details = await new OpenC3Api().get_item(
+      this.item.targetName,
+      this.item.packetName,
+      this.item.itemName,
+    )
+    for (const [key, value] of Object.entries(details.limits)) {
+      if (Object.keys(value).includes('red_low')) {
+        this.limits[key] = Object.values(value)
+      }
+    }
+    // Locate the key for the value array that we pass in
+    this.limitsName = Object.keys(this.limits).find(
+      // Little hack to compare arrays you convert them to strings
+      (key) => this.limits[key] + '' === this.editItem.limits + '',
+    )
   },
 }
 </script>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -894,16 +894,16 @@ export default {
             },
           },
           0,
-        )
+        ).catch(console.error)
       })
     },
     deleteScreen: function () {
       this.editDialog = false
-      Api.delete(`/openc3-api/screen/${this.target}/${this.screen}`).then(
-        (response) => {
+      Api.delete(`/openc3-api/screen/${this.target}/${this.screen}`)
+        .then((response) => {
           this.$emit('delete-screen')
-        },
-      )
+        })
+        .catch(console.error)
     },
     minMaxTransition: function () {
       this.expand = !this.expand

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -1057,8 +1057,7 @@ export default {
         values.length != this.screenItems.length ||
         values.length != this.actualScreenItems.length
       ) {
-        // eslint-disable-next-line no-console
-        console.log(
+        console.error(
           `get_tlm_values mismatch: data.length: ${values.length}, screenItems.length: ${this.screenItems.length}, actualScreenItems.length: ${this.actualScreenItems.length}`,
           JSON.stringify(values),
           JSON.stringify(this.screenItems),
@@ -1087,8 +1086,7 @@ export default {
             // This must be the same or we're going to have problems
             // because the data comes back in an ordered array
             if (this.screenItems.length != data.length) {
-              // eslint-disable-next-line no-console
-              console.log(
+              console.error(
                 'Error getting tlm available',
                 this.screenItems,
                 this.actualScreenItems,
@@ -1126,8 +1124,7 @@ export default {
             }
           })
           .catch((error) => {
-            // eslint-disable-next-line no-console
-            console.log('Error getting tlm available', error)
+            console.error('Error getting tlm available', error)
             this.actualScreenItems = this.screenItems
           })
         this.tlmAvailableTimeout = null

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/ScreenEditor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/ScreenEditor.vue
@@ -159,7 +159,6 @@ export default {
         )
         this.loadedKeywords = response.data
       } catch (error) {
-        // eslint-disable-next-line no-console
         console.error('Error loading screen keywords:', error)
       }
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
@@ -476,7 +476,6 @@ export default {
           }
         })
         .catch((error) => {
-          // eslint-disable-next-line no-console
           console.error('Error fetching queues:', error)
           // Keep default "None" option even if fetch fails
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/autocomplete/screenCompleter.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/autocomplete/screenCompleter.js
@@ -40,9 +40,11 @@ export default class ScreenCompleter {
     // See openc3-cosmos-cmd-tlm-api/app/controllers/script_autocomplete_controller.rb
     // for how the autocompleteData is built
 
-    Api.get(`/openc3-api/autocomplete/data/screen`).then((response) => {
-      this.autocompleteData = response.data
-    })
+    Api.get(`/openc3-api/autocomplete/data/screen`)
+      .then((response) => {
+        this.autocompleteData = response.data
+      })
+      .catch(console.error)
     this.api = new OpenC3Api()
   }
 

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/OpenConfigDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/OpenConfigDialog.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -190,7 +190,9 @@ export default {
             this.selectedRows = []
           }
           this.configs.splice(this.configs.indexOf(item), 1)
-          new OpenC3Api().delete_config(this.configKey, item.config)
+          new OpenC3Api()
+            .delete_config(this.configKey, item.config)
+            .catch(console.error)
         })
         .catch((error) => {
           if (error !== true) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/SaveConfigDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/SaveConfigDialog.vue
@@ -206,7 +206,9 @@ export default {
             this.configName = ''
           }
           this.configs.splice(this.configs.indexOf(item), 1)
-          new OpenC3Api().delete_config(this.configKey, item.config)
+          new OpenC3Api()
+            .delete_config(this.configKey, item.config)
+            .catch(console.error)
         })
         .catch((error) => {
           if (error !== true) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/composables/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/composables/index.js
@@ -12,4 +12,5 @@
 */
 
 export { useContainerHeight } from './useContainerHeight'
+export { useDownloadFile, useDownloadZip } from './useDownloadFile'
 export { useTimeFilters } from './useTimeFilters'

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/composables/useDownloadFile.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/composables/useDownloadFile.js
@@ -13,30 +13,30 @@
 
 import { Api } from '@openc3/js-common/services'
 
+// Decode a Base64 string into raw bytes
+function base64ToBytes(base64) {
+  const decodedData = window.atob(base64)
+  // Create UNIT8ARRAY of size same as row data length
+  const uInt8Array = new Uint8Array(decodedData.length)
+  // Insert all character code into uInt8Array
+  for (let i = 0; i < decodedData.length; ++i) {
+    uInt8Array[i] = decodedData.codePointAt(i)
+  }
+  return uInt8Array
+}
+
+// Make a link and then 'click' on it to start the download
+function saveBlob(blob, filename) {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.setAttribute('download', filename)
+  link.click()
+  // Let the browser start the download before releasing the blob
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
 export function useDownloadFile() {
-  // Decode a Base64 string into raw bytes
-  function base64ToBytes(base64) {
-    const decodedData = window.atob(base64)
-    // Create UNIT8ARRAY of size same as row data length
-    const uInt8Array = new Uint8Array(decodedData.length)
-    // Insert all character code into uInt8Array
-    for (let i = 0; i < decodedData.length; ++i) {
-      uInt8Array[i] = decodedData.charCodeAt(i)
-    }
-    return uInt8Array
-  }
-
-  // Make a link and then 'click' on it to start the download
-  function saveBlob(blob, filename) {
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
-    link.setAttribute('download', filename)
-    link.click()
-    // Let the browser start the download before releasing the blob
-    setTimeout(() => URL.revokeObjectURL(url), 0)
-  }
-
   // POST to url and download the response as a file. The response is expected
   // to be JSON with 'contents' and 'filename' attributes.
   //   data:    request body passed to Api.post, a FormData implies multipart

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/composables/useDownloadFile.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/composables/useDownloadFile.js
@@ -1,0 +1,78 @@
+/*
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+*/
+
+import { Api } from '@openc3/js-common/services'
+
+export function useDownloadFile() {
+  // Decode a Base64 string into raw bytes
+  function base64ToBytes(base64) {
+    const decodedData = window.atob(base64)
+    // Create UNIT8ARRAY of size same as row data length
+    const uInt8Array = new Uint8Array(decodedData.length)
+    // Insert all character code into uInt8Array
+    for (let i = 0; i < decodedData.length; ++i) {
+      uInt8Array[i] = decodedData.charCodeAt(i)
+    }
+    return uInt8Array
+  }
+
+  // Make a link and then 'click' on it to start the download
+  function saveBlob(blob, filename) {
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.setAttribute('download', filename)
+    link.click()
+    // Let the browser start the download before releasing the blob
+    setTimeout(() => URL.revokeObjectURL(url), 0)
+  }
+
+  // POST to url and download the response as a file. The response is expected
+  // to be JSON with 'contents' and 'filename' attributes.
+  //   data:    request body passed to Api.post, a FormData implies multipart
+  //   headers: request headers passed to Api.post
+  //   type:    MIME type of the downloaded file
+  //   base64:  response contents are Base64 encoded and must be decoded
+  //   prefix:  text prepended to the contents of the downloaded file
+  async function downloadFile(
+    url,
+    {
+      data = undefined,
+      headers = undefined,
+      type = 'application/octet-stream',
+      base64 = false,
+      prefix = null,
+    } = {},
+  ) {
+    let postHeaders = headers
+    if (!postHeaders && data instanceof FormData) {
+      postHeaders = { 'Content-Type': 'multipart/form-data' }
+    }
+    const response = await Api.post(url, { data, headers: postHeaders })
+    const contents = base64
+      ? base64ToBytes(response.data.contents)
+      : response.data.contents
+    const blob = new Blob(prefix ? [prefix, contents] : [contents], { type })
+    saveBlob(blob, response.data.filename)
+    return response
+  }
+
+  return { downloadFile, saveBlob }
+}
+
+// Convenience wrapper for the common case of downloading a Base64 encoded zip
+export function useDownloadZip() {
+  const { downloadFile } = useDownloadFile()
+
+  return (url) => downloadFile(url, { base64: true, type: 'application/zip' })
+}

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginDetailsDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginDetailsDialog.vue
@@ -321,9 +321,11 @@ export default {
     },
   },
   created: function () {
-    Api.get('/openc3-api/info').then(({ data }) => {
-      this.installedCosmosVersion = data.version
-    })
+    Api.get('/openc3-api/info')
+      .then(({ data }) => {
+        this.installedCosmosVersion = data.version
+      })
+      .catch(console.error)
   },
   mounted: function () {
     this.selectedVersionId = this.current_version_id
@@ -348,7 +350,7 @@ export default {
       })
     },
     copyChecksum: function () {
-      navigator.clipboard.writeText(this.versionChecksum)
+      navigator.clipboard.writeText(this.versionChecksum).catch(console.error)
       this.showCopiedTooltip = true
       setTimeout(() => {
         this.showCopiedTooltip = false

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStore.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStore.vue
@@ -152,14 +152,17 @@ export default {
             this.plugins = data
           }
         })
+        .catch(console.error)
         .finally(() => {
           this.loading = false
         })
     },
     fetchUserContext: function () {
-      Api.get('/openc3-api/info').then(({ data }) => {
-        this.isEnterprise = !!data.enterprise
-      })
+      Api.get('/openc3-api/info')
+        .then(({ data }) => {
+          this.isEnterprise = !!data.enterprise
+        })
+        .catch(console.error)
       const roles = OpenC3Auth.userroles() || []
       this.isAdmin = roles.includes('admin')
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStoreSettingsDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStoreSettingsDialog.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -145,9 +145,11 @@ export default {
     },
   },
   created: function () {
-    Api.get('/openc3-api/info').then(({ data }) => {
-      this.isEnterprise = data.enterprise
-    })
+    Api.get('/openc3-api/info')
+      .then(({ data }) => {
+        this.isEnterprise = data.enterprise
+      })
+      .catch(console.error)
     this.loadSetting(URL_SETTING_NAME, { scope: SETTING_SCOPE })
     this.loadSetting(API_KEY_SETTING_NAME, { scope: SETTING_SCOPE })
     this.$emit('update:storeUrl', this.storeUrl)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/DownloadDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/DownloadDialog.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -146,9 +146,13 @@ export default {
     },
     getResponse: function () {
       this.disableSearch = true
-      axios.get(this.url).then((response) => {
-        this.response = response.data
-      })
+      axios
+        .get(this.url)
+        .then((response) => {
+          this.response = response.data
+        })
+        .catch(console.error)
+      this.response = response.data
       setTimeout(() => {
         this.disableSearch = false
       }, 10000)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/DownloadDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/DownloadDialog.vue
@@ -152,7 +152,6 @@ export default {
           this.response = response.data
         })
         .catch(console.error)
-      this.response = response.data
       setTimeout(() => {
         this.disableSearch = false
       }, 10000)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/ModifiedPluginDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/ModifiedPluginDialog.vue
@@ -153,24 +153,28 @@ export default {
     }
   },
   methods: {
-    loadModifiedFiles() {
-      for (const target of this.targets) {
-        Api.get(`/openc3-api/targets/${target.name}/modified_files`).then(
-          (response) => {
-            if (response.data.length !== 0) {
-              this.modifiedTargets.push({
-                name: target.name,
-                files: response.data.map((file) => ({
-                  file,
-                  fullName: file.startsWith(`${target.name}/`)
-                    ? file
-                    : `${target.name}/${file}`,
-                })),
-              })
-            }
-          },
-        )
-      }
+    async loadModifiedFiles() {
+      // Request all targets concurrently, then assign once so the list renders
+      // in target order rather than response order.
+      const responses = await Promise.all(
+        this.targets.map((target) =>
+          Api.get(`/openc3-api/targets/${target.name}/modified_files`)
+            .then((response) => response.data)
+            .catch((error) => {
+              console.error(error)
+              return []
+            }),
+        ),
+      )
+      this.modifiedTargets = this.targets
+        .map(({ name }, index) => ({
+          name,
+          files: responses[index].map((file) => ({
+            file,
+            fullName: file.startsWith(`${name}/`) ? file : `${name}/${file}`,
+          })),
+        }))
+        .filter(({ files }) => files.length > 0)
     },
     async loadDiff() {
       this.loading = true

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/PluginDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/PluginDialog.vue
@@ -268,9 +268,11 @@ export default {
     },
   },
   created() {
-    Api.get('/openc3-api/info').then(({ data }) => {
-      this.installedCosmosVersion = data.version
-    })
+    Api.get('/openc3-api/info')
+      .then(({ data }) => {
+        this.installedCosmosVersion = data.version
+      })
+      .catch(console.error)
   },
   mounted() {
     const pluginMode = this.buildPluginMode()

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/InterfacesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/InterfacesTab.vue
@@ -63,17 +63,15 @@ export default {
     this.update()
   },
   methods: {
-    update() {
-      Api.get('/openc3-api/interfaces').then((response) => {
-        this.interfaces = response.data
-      })
+    async update() {
+      const response = await Api.get('/openc3-api/interfaces')
+      this.interfaces = response.data
     },
-    showInterface(name) {
-      Api.get(`/openc3-api/interfaces/${name}`).then((response) => {
-        this.jsonContent = JSON.stringify(response.data, null, '\t')
-        this.dialogTitle = name
-        this.showDialog = true
-      })
+    async showInterface(name) {
+      const response = await Api.get(`/openc3-api/interfaces/${name}`)
+      this.jsonContent = JSON.stringify(response.data, null, '\t')
+      this.dialogTitle = name
+      this.showDialog = true
     },
     dialogCallback(content) {
       this.showDialog = false

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/MicroservicesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/MicroservicesTab.vue
@@ -539,7 +539,7 @@ export default {
           url = '/openc3-api/microservices'
         }
 
-        const response = await Api[method](url, {
+        await Api[method](url, {
           data: {
             json: content,
           },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/MicroservicesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/MicroservicesTab.vue
@@ -274,22 +274,26 @@ export default {
       return this.microserviceOperations[name]?.operation === 'stopping'
     },
     update: function () {
-      Api.get('/openc3-api/microservice_status/all').then((response) => {
-        this.microservice_status = response.data
-        this.checkOperationCompletion()
-      })
-      Api.get('/openc3-api/microservices/all').then((response) => {
-        // Convert hash of microservices to array of microservices
-        let microservices = []
-        for (const [_microservice_name, microservice] of Object.entries(
-          response.data,
-        )) {
-          microservices.push(microservice)
-        }
-        microservices.sort((a, b) => a.name.localeCompare(b.name))
-        this.allMicroservices = microservices
-        this.applyServiceFilter()
-      })
+      Api.get('/openc3-api/microservice_status/all')
+        .then((response) => {
+          this.microservice_status = response.data
+          this.checkOperationCompletion()
+        })
+        .catch(console.error)
+      Api.get('/openc3-api/microservices/all')
+        .then((response) => {
+          // Convert hash of microservices to array of microservices
+          let microservices = []
+          for (const [_microservice_name, microservice] of Object.entries(
+            response.data,
+          )) {
+            microservices.push(microservice)
+          }
+          microservices.sort((a, b) => a.name.localeCompare(b.name))
+          this.allMicroservices = microservices
+          this.applyServiceFilter()
+        })
+        .catch(console.error)
     },
     checkOperationCompletion: function () {
       for (const [name, tracking] of Object.entries(
@@ -493,13 +497,12 @@ export default {
           })
         })
     },
-    showMicroservice: function (name) {
-      Api.get(`/openc3-api/microservices/${name}`).then((response) => {
-        this.microservice_id = name
-        this.dialogTitle = name
-        this.jsonContent = JSON.stringify(response.data, null, '\t')
-        this.showDialog = true
-      })
+    showMicroservice: async function (name) {
+      const response = await Api.get(`/openc3-api/microservices/${name}`)
+      this.microservice_id = name
+      this.dialogTitle = name
+      this.jsonContent = JSON.stringify(response.data, null, '\t')
+      this.showDialog = true
     },
     showMicroserviceError: function (name) {
       this.dialogTitle = name
@@ -525,7 +528,7 @@ export default {
       }
       return this.microservice_status[microserviceName].state
     },
-    dialogCallback: function (content) {
+    dialogCallback: async function (content) {
       this.showDialog = false
       if (content !== null) {
         let parsed = JSON.parse(content)
@@ -536,19 +539,18 @@ export default {
           url = '/openc3-api/microservices'
         }
 
-        Api[method](url, {
+        const response = await Api[method](url, {
           data: {
             json: content,
           },
-        }).then((response) => {
-          this.alert = 'Modified Microservice'
-          this.alertType = 'success'
-          this.showAlert = true
-          setTimeout(() => {
-            this.showAlert = false
-          }, 5000)
-          this.update()
         })
+        this.alert = 'Modified Microservice'
+        this.alertType = 'success'
+        this.showAlert = true
+        setTimeout(() => {
+          this.showAlert = false
+        }, 5000)
+        this.update()
       }
     },
   },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/PackagesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/PackagesTab.vue
@@ -245,17 +245,21 @@ export default {
       this.showProcessOutput = true
     },
     update() {
-      Api.get('/openc3-api/packages').then((response) => {
-        this.gems = response.data.ruby
-        this.python = response.data.python
-      })
-      Api.get('/openc3-api/packages/trees').then((response) => {
-        this.pythonTrees = response.data
-      })
+      Api.get('/openc3-api/packages')
+        .then((response) => {
+          this.gems = response.data.ruby
+          this.python = response.data.python
+        })
+        .catch(console.error)
+      Api.get('/openc3-api/packages/trees')
+        .then((response) => {
+          this.pythonTrees = response.data
+        })
+        .catch(console.error)
     },
     updateProcesses: function () {
-      Api.get('/openc3-api/process_status/package_?substr=true').then(
-        (response) => {
+      Api.get('/openc3-api/process_status/package_?substr=true')
+        .then((response) => {
           this.processes = response.data
           if (Object.keys(this.processes).length > 0) {
             // process_manager.rb script operates on a 5 second cycle
@@ -264,8 +268,8 @@ export default {
               this.update()
             }, 2500)
           }
-        },
-      )
+        })
+        .catch(console.error)
     },
     selectFile() {
       this.progress = 0

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/PluginsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/PluginsTab.vue
@@ -334,18 +334,22 @@ export default {
       this.showProcessOutput = true
     },
     update: function () {
-      Api.get('/openc3-api/plugins/all').then((response) => {
-        this.plugins = Object.entries(response.data).map(
-          ([_, plugin]) => plugin,
-        )
-      })
-      Api.get('/openc3-api/targets_modified').then((response) => {
-        this.targets = response.data
-      })
+      Api.get('/openc3-api/plugins/all')
+        .then((response) => {
+          this.plugins = Object.entries(response.data).map(
+            ([_, plugin]) => plugin,
+          )
+        })
+        .catch(console.error)
+      Api.get('/openc3-api/targets_modified')
+        .then((response) => {
+          this.targets = response.data
+        })
+        .catch(console.error)
     },
     updateProcesses: function () {
-      Api.get('openc3-api/process_status/plugin_?substr=true').then(
-        (response) => {
+      Api.get('openc3-api/process_status/plugin_?substr=true')
+        .then((response) => {
           this.processes = response.data
           if (Object.keys(this.processes).length > 0) {
             setTimeout(() => {
@@ -353,8 +357,8 @@ export default {
               this.update()
             }, 5000)
           }
-        },
-      )
+        })
+        .catch(console.error)
     },
     upload: function (existing = null, storeData = null) {
       const method = existing ? 'put' : 'post'
@@ -458,37 +462,42 @@ export default {
         data: {
           plugin_hash: JSON.stringify(pluginHash),
         },
-      }).then((response) => {
-        this.alert = `Started installing plugin ${this.pluginName} ...`
-        this.alertType = 'success'
-        this.showAlert = true
-        this.currentPlugin = null
-        this.file = undefined
-        this.variables = {}
-        this.pluginTxt = ''
-        this.existingPluginTxt = null
-        this.storePluginId = null
-        this.storeVersionId = null
-        setTimeout(() => {
-          this.showAlert = false
-          this.updateProcesses()
-        }, 5000)
-        this.update()
       })
+        .then((response) => {
+          this.alert = `Started installing plugin ${this.pluginName} ...`
+          this.alertType = 'success'
+          this.showAlert = true
+          this.currentPlugin = null
+          this.file = undefined
+          this.variables = {}
+          this.pluginTxt = ''
+          this.existingPluginTxt = null
+          this.storePluginId = null
+          this.storeVersionId = null
+          setTimeout(() => {
+            this.showAlert = false
+            this.updateProcesses()
+          }, 5000)
+          this.update()
+        })
+        .catch(console.error)
     },
     editPlugin: function (plugin) {
       this.resetControlState()
-      Api.get(`/openc3-api/plugins/${plugin}`).then((response) => {
-        let existingPluginTxt = null
-        if (response.data.existing_plugin_txt_lines !== undefined) {
-          existingPluginTxt = response.data.existing_plugin_txt_lines.join('\n')
-        }
-        this.pluginName = response.data.name
-        this.variables = response.data.variables
-        this.pluginTxt = response.data.plugin_txt_lines.join('\n')
-        this.existingPluginTxt = existingPluginTxt
-        this.showPluginDialog = true
-      })
+      Api.get(`/openc3-api/plugins/${plugin}`)
+        .then((response) => {
+          let existingPluginTxt = null
+          if (response.data.existing_plugin_txt_lines !== undefined) {
+            existingPluginTxt =
+              response.data.existing_plugin_txt_lines.join('\n')
+          }
+          this.pluginName = response.data.name
+          this.variables = response.data.variables
+          this.pluginTxt = response.data.plugin_txt_lines.join('\n')
+          this.existingPluginTxt = existingPluginTxt
+          this.showPluginDialog = true
+        })
+        .catch(console.error)
     },
     deletePrompt: function (plugin) {
       this.resetControlState()
@@ -511,12 +520,14 @@ export default {
       this.alert = `Removing plugin ${plugin} ...`
       this.alertType = 'success'
       this.showAlert = true
-      Api.delete(`/openc3-api/plugins/${plugin}`).then((response) => {
-        setTimeout(() => {
-          this.showAlert = false
-          this.updateProcesses()
-        }, 5000)
-      })
+      Api.delete(`/openc3-api/plugins/${plugin}`)
+        .then((response) => {
+          setTimeout(() => {
+            this.showAlert = false
+            this.updateProcesses()
+          }, 5000)
+        })
+        .catch(console.error)
       this.update()
     },
     migrateToUv: function (plugin) {
@@ -529,8 +540,8 @@ export default {
           },
         )
         .then(() => {
-          Api.post(`/openc3-api/plugins/${plugin}/migrate_to_uv`).then(
-            (response) => {
+          Api.post(`/openc3-api/plugins/${plugin}/migrate_to_uv`)
+            .then((response) => {
               this.alert = `Started migrating plugin ${plugin} to UV ...`
               this.alertType = 'success'
               this.showAlert = true
@@ -538,8 +549,8 @@ export default {
                 this.showAlert = false
                 this.updateProcesses()
               }, 5000)
-            },
-          )
+            })
+            .catch(console.error)
         })
     },
     upgradePlugin(plugin) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RedisTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RedisTab.vue
@@ -163,19 +163,21 @@ export default {
           Accept: 'application/json',
           'Content-Type': 'text/plain',
         },
-      }).then((response) => {
-        this.redisResponse = response.data.result
-        let redis =
-          this.redisEndpoint === 'ephemeral' ? 'Ephemeral' : 'Persistent'
-        if (this.db_shard !== 0) {
-          redis += ` (db_shard ${this.db_shard})`
-        }
-        this.commands.unshift({
-          redis: redis,
-          command: this.redisCommandText,
-          response: this.redisResponse,
-        })
       })
+        .then((response) => {
+          this.redisResponse = response.data.result
+          let redis =
+            this.redisEndpoint === 'ephemeral' ? 'Ephemeral' : 'Persistent'
+          if (this.db_shard !== 0) {
+            redis += ` (db_shard ${this.db_shard})`
+          }
+          this.commands.unshift({
+            redis: redis,
+            command: this.redisCommandText,
+            response: this.redisResponse,
+          })
+        })
+        .catch(console.error)
     },
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RoutersTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/RoutersTab.vue
@@ -64,17 +64,18 @@ export default {
   },
   methods: {
     update() {
-      Api.get('/openc3-api/routers').then((response) => {
-        this.routers = response.data
-      })
+      Api.get('/openc3-api/routers')
+        .then((response) => {
+          this.routers = response.data
+        })
+        .catch(console.error)
     },
     add() {},
-    showRouter(name) {
-      Api.get(`/openc3-api/routers/${name}`).then((response) => {
-        this.jsonContent = JSON.stringify(response.data, null, '\t')
-        this.dialogTitle = name
-        this.showDialog = true
-      })
+    async showRouter(name) {
+      const response = await Api.get(`/openc3-api/routers/${name}`)
+      this.jsonContent = JSON.stringify(response.data, null, '\t')
+      this.dialogTitle = name
+      this.showDialog = true
     },
     dialogCallback(content) {
       this.showDialog = false

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/SecretsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/SecretsTab.vue
@@ -107,18 +107,22 @@ export default {
     }
   },
   created() {
-    Api.get('/openc3-api/info').then(({ data }) => {
-      this.isEnterprise = data.enterprise
-    })
+    Api.get('/openc3-api/info')
+      .then(({ data }) => {
+        this.isEnterprise = data.enterprise
+      })
+      .catch(console.error)
   },
   mounted() {
     this.update()
   },
   methods: {
     update() {
-      Api.get('/openc3-api/secrets').then((response) => {
-        this.secrets = response.data
-      })
+      Api.get('/openc3-api/secrets')
+        .then((response) => {
+          this.secrets = response.data
+        })
+        .catch(console.error)
     },
     upload: function () {
       this.loadingSecret = true

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/SettingsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/SettingsTab.vue
@@ -89,9 +89,11 @@ export default {
     }
   },
   created() {
-    Api.get('/openc3-api/info').then(({ data }) => {
-      this.isEnterprise = data.enterprise
-    })
+    Api.get('/openc3-api/info')
+      .then(({ data }) => {
+        this.isEnterprise = data.enterprise
+      })
+      .catch(console.error)
   },
 }
 </script>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/TargetsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/TargetsTab.vue
@@ -76,40 +76,37 @@ export default {
     }
   },
   mounted() {
-    this.update()
+    void this.update()
   },
   methods: {
-    update() {
-      Api.get('/openc3-api/targets_modified').then((response) => {
-        this.targets = response.data
-      })
+    async update() {
+      const response = await Api.get('/openc3-api/targets_modified')
+      this.targets = response.data
     },
-    showTarget(name) {
-      Api.get(`/openc3-api/targets/${name}`).then((response) => {
-        this.jsonContent = JSON.stringify(response.data, null, '\t')
-        this.dialogTitle = name
-        this.showDialog = true
-      })
+    async showTarget(name) {
+      const response = await Api.get(`/openc3-api/targets/${name}`)
+      this.jsonContent = JSON.stringify(response.data, null, '\t')
+      this.dialogTitle = name
+      this.showDialog = true
     },
     dialogCallback(content) {
       this.showDialog = false
     },
-    downloadTarget: function (name) {
-      Api.post(`/openc3-api/targets/${name}/download`).then((response) => {
-        // Decode Base64 string
-        const decodedData = window.atob(response.data.contents)
-        // Create UNIT8ARRAY of size same as row data length
-        const uInt8Array = new Uint8Array(decodedData.length)
-        // Insert all character code into uInt8Array
-        for (let i = 0; i < decodedData.length; ++i) {
-          uInt8Array[i] = decodedData.charCodeAt(i)
-        }
-        const blob = new Blob([uInt8Array], { type: 'application/zip' })
-        const link = document.createElement('a')
-        link.href = URL.createObjectURL(blob)
-        link.setAttribute('download', response.data.filename)
-        link.click()
-      })
+    downloadTarget: async function (name) {
+      const response = await Api.post(`/openc3-api/targets/${name}/download`)
+      // Decode Base64 string
+      const decodedData = window.atob(response.data.contents)
+      // Create UNIT8ARRAY of size same as row data length
+      const uInt8Array = new Uint8Array(decodedData.length)
+      // Insert all character code into uInt8Array
+      for (let i = 0; i < decodedData.length; ++i) {
+        uInt8Array[i] = decodedData.charCodeAt(i)
+      }
+      const blob = new Blob([uInt8Array], { type: 'application/zip' })
+      const link = document.createElement('a')
+      link.href = URL.createObjectURL(blob)
+      link.setAttribute('download', response.data.filename)
+      link.click()
     },
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/TargetsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/TargetsTab.vue
@@ -64,9 +64,15 @@
 <script>
 import { Api } from '@openc3/js-common/services'
 import { OutputDialog } from '@/components'
+import { useDownloadZip } from '@/composables'
 
 export default {
   components: { OutputDialog },
+  setup() {
+    const downloadZip = useDownloadZip()
+
+    return { downloadZip }
+  },
   data() {
     return {
       targets: [],
@@ -93,20 +99,7 @@ export default {
       this.showDialog = false
     },
     downloadTarget: async function (name) {
-      const response = await Api.post(`/openc3-api/targets/${name}/download`)
-      // Decode Base64 string
-      const decodedData = window.atob(response.data.contents)
-      // Create UNIT8ARRAY of size same as row data length
-      const uInt8Array = new Uint8Array(decodedData.length)
-      // Insert all character code into uInt8Array
-      for (let i = 0; i < decodedData.length; ++i) {
-        uInt8Array[i] = decodedData.charCodeAt(i)
-      }
-      const blob = new Blob([uInt8Array], { type: 'application/zip' })
-      const link = document.createElement('a')
-      link.href = URL.createObjectURL(blob)
-      link.setAttribute('download', response.data.filename)
-      link.click()
+      await this.downloadZip(`/openc3-api/targets/${name}/download`)
     },
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/ToolsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/ToolsTab.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2024, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -117,22 +117,24 @@ export default {
         },
         // Tools are global and are always installed into the DEFAULT scope
         params: { scope: 'DEFAULT' },
-      }).then((response) => {
-        this.$notify.normal({
-          title: `Reordered tool ${this.tools[evt.oldIndex]}`,
-        })
-        this.update()
       })
+        .then((response) => {
+          this.$notify.normal({
+            title: `Reordered tool ${this.tools[evt.oldIndex]}`,
+          })
+          this.update()
+        })
+        .catch(console.error)
     },
     update() {
       // Tools are global and are always installed into the DEFAULT scope
-      Api.get('/openc3-api/tools', { params: { scope: 'DEFAULT' } }).then(
-        (response) => {
+      Api.get('/openc3-api/tools', { params: { scope: 'DEFAULT' } })
+        .then((response) => {
           this.tools = response.data
           this.name = ''
           this.url = ''
-        },
-      )
+        })
+        .catch(console.error)
     },
     add() {
       Api.post('/openc3-api/tools', {
@@ -161,18 +163,17 @@ export default {
           })
         })
     },
-    showTool(name) {
-      Api.get(`/openc3-api/tools/${name}`, {
+    async showTool(name) {
+      const response = await Api.get(`/openc3-api/tools/${name}`, {
         // Tools are global and are always installed into the DEFAULT scope
         params: { scope: 'DEFAULT' },
-      }).then((response) => {
-        this.tool_id = name
-        this.jsonContent = JSON.stringify(response.data, null, '\t')
-        this.dialogTitle = name
-        this.showDialog = true
       })
+      this.tool_id = name
+      this.jsonContent = JSON.stringify(response.data, null, '\t')
+      this.dialogTitle = name
+      this.showDialog = true
     },
-    dialogCallback(content) {
+    async dialogCallback(content) {
       this.showDialog = false
       if (content !== null) {
         let parsed = JSON.parse(content)
@@ -183,18 +184,17 @@ export default {
           url = '/openc3-api/tools'
         }
 
-        Api[method](url, {
+        await Api[method](url, {
           data: {
             json: content,
           },
           // Tools are global and are always installed into the DEFAULT scope
           params: { scope: 'DEFAULT' },
-        }).then((response) => {
-          this.$notify.normal({
-            title: `Modified tool ${parsed['name']}`,
-          })
-          this.update()
         })
+        this.$notify.normal({
+          title: `Modified tool ${parsed['name']}`,
+        })
+        this.update()
       }
     },
     deleteTool(name) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/plugins/PluginList.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/plugins/PluginList.vue
@@ -135,7 +135,7 @@ export default {
       this.$emit('delete', plugin)
     },
     fetchMicroservices: async function () {
-      const reseponse = await Api.get('/openc3-api/microservices/all')
+      const response = await Api.get('/openc3-api/microservices/all')
       this.microservices = response.data
     },
   },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/plugins/PluginList.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/plugins/PluginList.vue
@@ -134,10 +134,9 @@ export default {
     deletePrompt: function (plugin) {
       this.$emit('delete', plugin)
     },
-    fetchMicroservices: function () {
-      Api.get('/openc3-api/microservices/all').then((response) => {
-        this.microservices = response.data
-      })
+    fetchMicroservices: async function () {
+      const reseponse = await Api.get('/openc3-api/microservices/all')
+      this.microservices = response.data
     },
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/plugins/PluginListItem.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/plugins/PluginListItem.vue
@@ -197,41 +197,39 @@ export default {
         this.showCard = true
       }
     },
-    downloadPlugin: function () {
-      Api.post(`/openc3-api/packages/${this.name}/download`).then(
-        (response) => {
-          // Decode Base64 string
-          const decodedData = window.atob(response.data.contents)
-          // Create UNIT8ARRAY of size same as row data length
-          const uInt8Array = new Uint8Array(decodedData.length)
-          // Insert all character code into uInt8Array
-          for (let i = 0; i < decodedData.length; ++i) {
-            uInt8Array[i] = decodedData.charCodeAt(i)
-          }
-          const blob = new Blob([uInt8Array], { type: 'application/zip' })
-          const link = document.createElement('a')
-          link.href = URL.createObjectURL(blob)
-          link.setAttribute('download', response.data.filename)
-          link.click()
-        },
+    downloadPlugin: async function () {
+      const response = await Api.post(
+        `/openc3-api/packages/${this.name}/download`,
       )
+      // Decode Base64 string
+      const decodedData = window.atob(response.data.contents)
+      // Create UNIT8ARRAY of size same as row data length
+      const uInt8Array = new Uint8Array(decodedData.length)
+      // Insert all character code into uInt8Array
+      for (let i = 0; i < decodedData.length; ++i) {
+        uInt8Array[i] = decodedData.charCodeAt(i)
+      }
+      const blob = new Blob([uInt8Array], { type: 'application/zip' })
+      const link = document.createElement('a')
+      link.href = URL.createObjectURL(blob)
+      link.setAttribute('download', response.data.filename)
+      link.click()
     },
-    downloadTarget: function (name) {
-      Api.post(`/openc3-api/targets/${name}/download`).then((response) => {
-        // Decode Base64 string
-        const decodedData = window.atob(response.data.contents)
-        // Create UNIT8ARRAY of size same as row data length
-        const uInt8Array = new Uint8Array(decodedData.length)
-        // Insert all character code into uInt8Array
-        for (let i = 0; i < decodedData.length; ++i) {
-          uInt8Array[i] = decodedData.charCodeAt(i)
-        }
-        const blob = new Blob([uInt8Array], { type: 'application/zip' })
-        const link = document.createElement('a')
-        link.href = URL.createObjectURL(blob)
-        link.setAttribute('download', response.data.filename)
-        link.click()
-      })
+    downloadTarget: async function (name) {
+      const response = await Api.post(`/openc3-api/targets/${name}/download`)
+      // Decode Base64 string
+      const decodedData = window.atob(response.data.contents)
+      // Create UNIT8ARRAY of size same as row data length
+      const uInt8Array = new Uint8Array(decodedData.length)
+      // Insert all character code into uInt8Array
+      for (let i = 0; i < decodedData.length; ++i) {
+        uInt8Array[i] = decodedData.charCodeAt(i)
+      }
+      const blob = new Blob([uInt8Array], { type: 'application/zip' })
+      const link = document.createElement('a')
+      link.href = URL.createObjectURL(blob)
+      link.setAttribute('download', response.data.filename)
+      link.click()
     },
     async exportHistory() {
       this.exporting = true

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/plugins/PluginListItem.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/plugins/PluginListItem.vue
@@ -129,6 +129,7 @@
 <script>
 import { Api } from '@openc3/js-common/services'
 import { PluginDetailsDialog, PluginProps } from '@/plugins/plugin-store'
+import { useDownloadZip } from '@/composables'
 
 export default {
   components: {
@@ -153,6 +154,11 @@ export default {
     scriptVersionsEnabled: Boolean,
   },
   emits: ['edit', 'delete', 'upgrade', 'migrate-to-uv'],
+  setup() {
+    const downloadZip = useDownloadZip()
+
+    return { downloadZip }
+  },
   data() {
     return {
       showCard: false,
@@ -198,38 +204,10 @@ export default {
       }
     },
     downloadPlugin: async function () {
-      const response = await Api.post(
-        `/openc3-api/packages/${this.name}/download`,
-      )
-      // Decode Base64 string
-      const decodedData = window.atob(response.data.contents)
-      // Create UNIT8ARRAY of size same as row data length
-      const uInt8Array = new Uint8Array(decodedData.length)
-      // Insert all character code into uInt8Array
-      for (let i = 0; i < decodedData.length; ++i) {
-        uInt8Array[i] = decodedData.charCodeAt(i)
-      }
-      const blob = new Blob([uInt8Array], { type: 'application/zip' })
-      const link = document.createElement('a')
-      link.href = URL.createObjectURL(blob)
-      link.setAttribute('download', response.data.filename)
-      link.click()
+      await this.downloadZip(`/openc3-api/packages/${this.name}/download`)
     },
     downloadTarget: async function (name) {
-      const response = await Api.post(`/openc3-api/targets/${name}/download`)
-      // Decode Base64 string
-      const decodedData = window.atob(response.data.contents)
-      // Create UNIT8ARRAY of size same as row data length
-      const uInt8Array = new Uint8Array(decodedData.length)
-      // Insert all character code into uInt8Array
-      for (let i = 0; i < decodedData.length; ++i) {
-        uInt8Array[i] = decodedData.charCodeAt(i)
-      }
-      const blob = new Blob([uInt8Array], { type: 'application/zip' })
-      const link = document.createElement('a')
-      link.href = URL.createObjectURL(blob)
-      link.setAttribute('download', response.data.filename)
-      link.click()
+      await this.downloadZip(`/openc3-api/targets/${name}/download`)
     },
     async exportHistory() {
       this.exporting = true

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/EditorSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/EditorSettings.vue
@@ -115,10 +115,12 @@ export default {
   created() {
     this.loadSetting(SCRIPT_LOCKING_SETTING)
     this.loadSetting(SCRIPT_LIFECYCLE_SETTING)
-    Api.get('/openc3-api/info').then(({ data }) => {
-      this.isEnterprise = data.enterprise === true
-      this.gitHistoryEnabled = data.script_versions === true
-    })
+    Api.get('/openc3-api/info')
+      .then(({ data }) => {
+        this.isEnterprise = data.enterprise === true
+        this.gitHistoryEnabled = data.script_versions === true
+      })
+      .catch(console.error)
   },
   methods: {
     save: function () {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppFooter.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppFooter.vue
@@ -72,22 +72,27 @@ export default {
     this.chromeless = urlParams.get('chromeless')
 
     this.getSourceUrl()
-    Api.get('/openc3-api/info').then((response) => {
-      if (response.data.enterprise) {
-        this.edition = 'COSMOS Enterprise'
-      } else {
-        this.edition = 'COSMOS Core'
-      }
-      this.enterprise = response.data.enterprise
-      this.license = response.data.license
-      this.version = response.data.version
-    })
+    Api.get('/openc3-api/info')
+      .then((response) => {
+        if (response.data.enterprise) {
+          this.edition = 'COSMOS Enterprise'
+        } else {
+          this.edition = 'COSMOS Core'
+        }
+        this.enterprise = response.data.enterprise
+        this.license = response.data.license
+        this.version = response.data.version
+      })
+      .catch(console.error)
   },
   methods: {
     getSourceUrl: function () {
-      new OpenC3Api().get_settings(['source_url']).then((response) => {
-        this.sourceUrl = response[0]
-      })
+      new OpenC3Api()
+        .get_settings(['source_url'])
+        .then((response) => {
+          this.sourceUrl = response[0]
+        })
+        .catch(console.error)
     },
     upgrade: function () {
       if (!this.enterprise) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
@@ -261,8 +261,8 @@ export default {
         // Do nothing
       })
     // Tools are global and are always installed into the DEFAULT scope
-    Api.get('/openc3-api/tools/all', { params: { scope: 'DEFAULT' } }).then(
-      (response) => {
+    Api.get('/openc3-api/tools/all', { params: { scope: 'DEFAULT' } })
+      .then((response) => {
         this.appNav = response.data
 
         let id = 1
@@ -349,8 +349,8 @@ export default {
             }
           })
         }, 60000)
-      },
-    )
+      })
+      .catch(console.error)
   },
   mounted() {
     globalThis.addEventListener(

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ContextTag.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ContextTag.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -64,10 +64,7 @@ export default {
             }
           }
         })
-        .catch((error) => {
-          // eslint-disable-next-line no-console
-          console.error(error)
-        })
+        .catch(console.error)
     },
     startContextTagAutoRefresh() {
       this.stopContextTagAutoRefresh()

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Login.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Login.vue
@@ -126,12 +126,14 @@ export default {
     },
   },
   created: function () {
-    Api.get('/openc3-api/auth/token-exists', this.options).then((response) => {
-      this.isSet = !!response.data.result
-      if (!this.isSet) {
-        this.reset = true
-      }
-    })
+    Api.get('/openc3-api/auth/token-exists', this.options)
+      .then((response) => {
+        this.isSet = !!response.data.result
+        if (!this.isSet) {
+          this.reset = true
+        }
+      })
+      .catch(console.error)
   },
   mounted: function () {
     if (localStorage.openc3Token) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Notifications.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Notifications.vue
@@ -320,9 +320,11 @@ export default {
     window.addEventListener('openc3-ack-alert', this.onAckAlert)
     this.subscribe()
     // Get the initial number of running scripts
-    Api.get('/script-api/running-script').then((response) => {
-      this.numScripts = response.data.total
-    })
+    Api.get('/script-api/running-script')
+      .then((response) => {
+        this.numScripts = response.data.total
+      })
+      .catch(console.error)
   },
   unmounted: function () {
     window.removeEventListener('openc3-ack-alert', this.onAckAlert)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/UserMenu.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/UserMenu.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2025, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -163,14 +163,16 @@ export default {
         }
 
         if (this.name !== 'Anonymous') {
-          Api.get('/openc3-api/users/active').then((response) => {
-            this.activeUsers = response.data.filter(
-              (item) => !item.includes(this.name),
-            )
-            if (this.activeUsers.length === 0) {
-              this.activeUsers = ['None']
-            }
-          })
+          Api.get('/openc3-api/users/active')
+            .then((response) => {
+              this.activeUsers = response.data.filter(
+                (item) => !item.includes(this.name),
+              )
+              if (this.activeUsers.length === 0) {
+                this.activeUsers = ['None']
+              }
+            })
+            .catch(console.error)
         }
       }
     },
@@ -208,25 +210,27 @@ export default {
       return date.split('T')[0]
     },
     fetchNews: function () {
-      Api.get('/openc3-api/news').then((response) => {
-        // We always get the full list of news we want to display
-        // At some point we may delete old news items so we don't
-        // want to persist news items in the frontend
-        this.news = response.data.sort(
-          (a, b) => Date.parse(b.date) - Date.parse(a.date),
-        )
-        // If we've previously read the news then mark anything older than that as read
-        if (localStorage.lastNewsRead) {
-          this.news.forEach((news) => {
-            news.read =
-              Date.parse(news.date) <= Date.parse(localStorage.lastNewsRead)
-          })
-        }
-      })
+      Api.get('/openc3-api/news')
+        .then((response) => {
+          // We always get the full list of news we want to display
+          // At some point we may delete old news items so we don't
+          // want to persist news items in the frontend
+          this.news = response.data.sort(
+            (a, b) => Date.parse(b.date) - Date.parse(a.date),
+          )
+          // If we've previously read the news then mark anything older than that as read
+          if (localStorage.lastNewsRead) {
+            this.news.forEach((news) => {
+              news.read =
+                Date.parse(news.date) <= Date.parse(localStorage.lastNewsRead)
+            })
+          }
+        })
+        .catch(console.error)
     },
     logout: function () {
       OpenC3Auth.logout()
-      Api.put(`/openc3-api/users/logout/${this.username}`)
+      Api.put(`/openc3-api/users/logout/${this.username}`).catch(console.error)
     },
     login: function () {
       OpenC3Auth.login(location.href)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/MetadataCreateDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/MetadataCreateDialog.vue
@@ -200,25 +200,29 @@ export default {
       if (this.metadata) {
         Api.put(`/openc3-api/metadata/${this.metadata.start}`, {
           data,
-        }).then((response) => {
-          this.$notify.normal({
-            title: 'Updated Metadata',
-            body: `Metadata updated: (${response.data.start})`,
-          })
-          this.$emit('update', response.data)
-          this.show = !this.show
         })
+          .then((response) => {
+            this.$notify.normal({
+              title: 'Updated Metadata',
+              body: `Metadata updated: (${response.data.start})`,
+            })
+            this.$emit('update', response.data)
+            this.show = !this.show
+          })
+          .catch(console.error)
       } else {
         Api.post('/openc3-api/metadata', {
           data,
-        }).then((response) => {
-          this.$notify.normal({
-            title: 'Created new Metadata',
-            body: `Metadata: (${response.data.start})`,
-          })
-          this.$emit('update', response.data)
-          this.show = !this.show
         })
+          .then((response) => {
+            this.$notify.normal({
+              title: 'Created new Metadata',
+              body: `Metadata: (${response.data.start})`,
+            })
+            this.$emit('update', response.data)
+            this.show = !this.show
+          })
+          .catch(console.error)
       }
       // We don't do the $emit or set show here because it has to be in the callback
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/NoteCreateDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/NoteCreateDialog.vue
@@ -240,33 +240,37 @@ export default {
       if (this.note) {
         Api.put(`/openc3-api/notes/${this.note.start}`, {
           data: { start, stop, color, description },
-        }).then((response) => {
-          const desc =
-            response.data.description.length > 16
-              ? `${response.data.description.substring(0, 16)}...`
-              : response.data.description
-          this.$notify.normal({
-            title: 'Updated Note',
-            body: `Note updated: (${response.data.start}): "${desc}"`,
-          })
-          this.$emit('update', response.data)
-          this.show = !this.show
         })
+          .then((response) => {
+            const desc =
+              response.data.description.length > 16
+                ? `${response.data.description.substring(0, 16)}...`
+                : response.data.description
+            this.$notify.normal({
+              title: 'Updated Note',
+              body: `Note updated: (${response.data.start}): "${desc}"`,
+            })
+            this.$emit('update', response.data)
+            this.show = !this.show
+          })
+          .catch(console.error)
       } else {
         Api.post('/openc3-api/notes', {
           data: { start, stop, color, description },
-        }).then((response) => {
-          const desc =
-            response.data.description.length > 16
-              ? `${response.data.description.substring(0, 16)}...`
-              : response.data.description
-          this.$notify.normal({
-            title: 'Created new Note',
-            body: `Note: (${response.data.start}) created: "${desc}"`,
-          })
-          this.$emit('update', response.data)
-          this.show = !this.show
         })
+          .then((response) => {
+            const desc =
+              response.data.description.length > 16
+                ? `${response.data.description.substring(0, 16)}...`
+                : response.data.description
+            this.$notify.normal({
+              title: 'Created new Note',
+              body: `Note: (${response.data.start}) created: "${desc}"`,
+            })
+            this.$emit('update', response.data)
+            this.show = !this.show
+          })
+          .catch(console.error)
       }
       // We don't do the $emit or set show here because it has to be in the callback
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/BucketDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/BucketDialog.vue
@@ -224,10 +224,12 @@ export default {
     },
   },
   created() {
-    Api.get('/openc3-api/storage/buckets').then((response) => {
-      this.buckets = response.data
-      this.applyDefaultPath()
-    })
+    Api.get('/openc3-api/storage/buckets')
+      .then((response) => {
+        this.buckets = response.data
+        this.applyDefaultPath()
+      })
+      .catch(console.error)
   },
   methods: {
     formatSize(bytes) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/OverridesDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/OverridesDialog.vue
@@ -133,7 +133,7 @@ async function deleteOverride(item) {
   overrides.value.splice(index, 1)
 }
 
-onMounted(() => {
-  void getOverrides()
+onMounted(async () => {
+  await getOverrides()
 })
 </script>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/OverridesDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/Dialogs/OverridesDialog.vue
@@ -134,6 +134,6 @@ async function deleteOverride(item) {
 }
 
 onMounted(() => {
-  getOverrides()
+  void getOverrides()
 })
 </script>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/RunningScripts.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/RunningScripts.vue
@@ -282,21 +282,22 @@ function useScriptTable(endpoint, errorTitle) {
       scripts.value = data.items || []
       total.value = data.total || scripts.value.length
     } catch (error) {
+      console.error(error)
       notify.caution({ title: errorTitle, body: error.message })
     } finally {
       loading.value = false
     }
   }
 
-  function setPage(newPage) {
+  async function setPage(newPage) {
     page.value = newPage
-    void fetchScripts()
+    await fetchScripts()
   }
 
-  function setItemsPerPage(newItemsPerPage) {
+  async function setItemsPerPage(newItemsPerPage) {
     itemsPerPage.value = newItemsPerPage
     page.value = 1
-    void fetchScripts()
+    await fetchScripts()
   }
 
   // Debounce search so we refetch from the server after the user stops typing.
@@ -305,7 +306,7 @@ function useScriptTable(endpoint, errorTitle) {
     search,
     debounce(() => {
       page.value = 1
-      void fetchScripts()
+      fetchScripts().catch(console.error)
     }, 300),
   )
 
@@ -380,11 +381,11 @@ const dialogName = ref('')
 const dialogContent = ref('')
 const dialogFilename = ref('')
 
-watch(activeTab, (newTab) => {
+watch(activeTab, async (newTab) => {
   if (newTab === 'running') {
-    void getRunningScripts()
+    await getRunningScripts()
   } else if (newTab === 'completed') {
-    void getCompletedScripts()
+    await getCompletedScripts()
   }
 })
 
@@ -401,9 +402,9 @@ onMounted(async () => {
   await Promise.all([getRunningScripts(), getCompletedScripts()])
 
   // Start a timer to refresh the running scripts list every 5 seconds
-  refreshTimer.value = setInterval(() => {
+  refreshTimer.value = setInterval(async () => {
     if (activeTab.value === 'running') {
-      void getRunningScripts()
+      await getRunningScripts()
     }
   }, 5000)
 })
@@ -494,7 +495,7 @@ async function deleteScript(script) {
     notify.normal({
       body: `Stopped script: ${script.name} ${script.filename}`,
     })
-    getRunningScripts().catch(console.error)
+    await getRunningScripts()
   } catch (error) {
     if (error !== true) {
       notify.caution({

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/RunningScripts.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/RunningScripts.vue
@@ -290,13 +290,13 @@ function useScriptTable(endpoint, errorTitle) {
 
   function setPage(newPage) {
     page.value = newPage
-    fetchScripts()
+    void fetchScripts()
   }
 
   function setItemsPerPage(newItemsPerPage) {
     itemsPerPage.value = newItemsPerPage
     page.value = 1
-    fetchScripts()
+    void fetchScripts()
   }
 
   // Debounce search so we refetch from the server after the user stops typing.
@@ -305,7 +305,7 @@ function useScriptTable(endpoint, errorTitle) {
     search,
     debounce(() => {
       page.value = 1
-      fetchScripts()
+      void fetchScripts()
     }, 300),
   )
 
@@ -382,9 +382,9 @@ const dialogFilename = ref('')
 
 watch(activeTab, (newTab) => {
   if (newTab === 'running') {
-    getRunningScripts()
+    void getRunningScripts()
   } else if (newTab === 'completed') {
-    getCompletedScripts()
+    void getCompletedScripts()
   }
 })
 
@@ -398,13 +398,12 @@ onMounted(async () => {
     // Do nothing
   }
 
-  getRunningScripts()
-  getCompletedScripts()
+  await Promise.all([getRunningScripts(), getCompletedScripts()])
 
   // Start a timer to refresh the running scripts list every 5 seconds
   refreshTimer.value = setInterval(() => {
     if (activeTab.value === 'running') {
-      getRunningScripts()
+      void getRunningScripts()
     }
   }, 5000)
 })
@@ -495,7 +494,7 @@ async function deleteScript(script) {
     notify.normal({
       body: `Stopped script: ${script.name} ${script.filename}`,
     })
-    getRunningScripts()
+    getRunningScripts().catch(console.error)
   } catch (error) {
     if (error !== true) {
       notify.caution({

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -2742,7 +2742,7 @@ export default {
         })
       }
       // We have to wait for all the upload API requests to finish before notifying the prompt
-      const responses = await Promise.all(promises)
+      await Promise.all(promises)
       Api.post(`/script-api/running-script/${this.scriptId}/prompt`, {
         data: {
           method: this.file.multiple ? 'open_files_dialog' : 'open_file_dialog',

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1581,9 +1581,11 @@ export default {
       this.showAlert = true
     }
 
-    Api.get('/openc3-api/autocomplete/keywords/screen').then((response) => {
-      this.screenKeywords = response.data
-    })
+    Api.get('/openc3-api/autocomplete/keywords/screen')
+      .then((response) => {
+        this.screenKeywords = response.data
+      })
+      .catch(console.error)
 
     if (this.inline) {
       this.readOnly = true
@@ -1782,21 +1784,23 @@ export default {
       this.receivedEvents.length = 0 // Clear any unprocessed events
     },
     showMetadata() {
-      Api.get('/openc3-api/metadata').then((response) => {
-        // TODO: This is how Calendar creates new metadata items via makeMetadataEvent
-        this.inputMetadata.events = response.data.map((event) => {
-          return {
-            name: 'Metadata',
-            start: new Date(event.start * 1000),
-            end: new Date(event.start * 1000),
-            color: event.color,
-            type: event.type,
-            timed: true,
-            metadata: event,
-          }
+      Api.get('/openc3-api/metadata')
+        .then((response) => {
+          // TODO: This is how Calendar creates new metadata items via makeMetadataEvent
+          this.inputMetadata.events = response.data.map((event) => {
+            return {
+              name: 'Metadata',
+              start: new Date(event.start * 1000),
+              end: new Date(event.start * 1000),
+              color: event.color,
+              type: event.type,
+              timed: true,
+              metadata: event,
+            }
+          })
+          this.inputMetadata.show = true
         })
-        this.inputMetadata.show = true
-      })
+        .catch(console.error)
     },
     messageSortOrder(order) {
       // See ScriptLogMessages for these strings
@@ -1915,7 +1919,7 @@ export default {
               args: [this.filenameSelect, start_row],
             },
           },
-        )
+        ).catch(console.error)
       }
     },
     executeSelection: function () {
@@ -1935,7 +1939,7 @@ export default {
               args: [this.filenameSelect, start_row, end_row],
             },
           },
-        )
+        ).catch(console.error)
       }
     },
     clearBreakpoints: function () {
@@ -2056,13 +2060,15 @@ export default {
               Accept: 'application/json',
               'Content-Type': 'text/plain',
             },
-          }).then((response) => {
-            let alertText = ''
-            alertText += `<strong>${response.data.title}</strong><br/><br/>`
-            alertText += JSON.parse(response.data.description)
-            this.$dialog.alert(alertText.trim(), { html: true })
-            return
           })
+            .then((response) => {
+              let alertText = ''
+              alertText += `<strong>${response.data.title}</strong><br/><br/>`
+              alertText += JSON.parse(response.data.description)
+              this.$dialog.alert(alertText.trim(), { html: true })
+              return
+            })
+            .catch(console.error)
         }
       }
       this.mnemonicChecker
@@ -2224,21 +2230,31 @@ export default {
         this.filenameSelect = this.currentFilename
         this.fileNameChanged(this.currentFilename)
       }
-      Api.post(`/script-api/running-script/${this.scriptId}/go`)
+      Api.post(`/script-api/running-script/${this.scriptId}/go`).catch(
+        console.error,
+      )
     },
     pauseOrRetry() {
       if (this.pauseOrRetryButton === PAUSE) {
-        Api.post(`/script-api/running-script/${this.scriptId}/pause`)
+        Api.post(`/script-api/running-script/${this.scriptId}/pause`).catch(
+          console.error,
+        )
       } else {
         this.pauseOrRetryButton = PAUSE
-        Api.post(`/script-api/running-script/${this.scriptId}/retry`)
+        Api.post(`/script-api/running-script/${this.scriptId}/retry`).catch(
+          console.error,
+        )
       }
     },
     stop() {
-      Api.post(`/script-api/running-script/${this.scriptId}/stop`)
+      Api.post(`/script-api/running-script/${this.scriptId}/stop`).catch(
+        console.error,
+      )
     },
     step() {
-      Api.post(`/script-api/running-script/${this.scriptId}/step`)
+      Api.post(`/script-api/running-script/${this.scriptId}/step`).catch(
+        console.error,
+      )
     },
     // This is called by processLine no matter the current state
     handleWaiting() {
@@ -2507,7 +2523,7 @@ export default {
           prompt_id: this.activePromptId,
           multiple: this.prompt.multiple,
         },
-      })
+      }).catch(console.error)
     },
     handleScript(data) {
       if (data.prompt_complete) {
@@ -2563,7 +2579,7 @@ export default {
                   password: value, // Using password as a key automatically filters it from rails logs
                   prompt_id: this.activePromptId,
                 },
-              })
+              }).catch(console.error)
             } else {
               Api.post(`/script-api/running-script/${this.scriptId}/prompt`, {
                 data: {
@@ -2571,7 +2587,7 @@ export default {
                   answer: value,
                   prompt_id: this.activePromptId,
                 },
-              })
+              }).catch(console.error)
             }
           }
           this.ask.show = true // Display the dialog
@@ -2668,7 +2684,7 @@ export default {
                 answer: value,
                 prompt_id: this.activePromptId,
               },
-            })
+            }).catch(console.error)
           }
           this.showMetadata()
           break
@@ -2710,35 +2726,31 @@ export default {
         fileNames = []
         files.forEach((file) => {
           fileNames.push(file.name)
-          promises.push(
-            Api.get(
+          promises.push(async () => {
+            const response = await Api.get(
               `/openc3-api/storage/upload/${encodeURIComponent(
                 `${window.openc3Scope}/tmp/${file.name}`,
               )}?bucket=OPENC3_CONFIG_BUCKET`,
-            ).then((response) => {
-              // This pushes the file into storage by using the fields in the presignedRequest
-              // See storage_controller.rb get_upload_presigned_request()
-              return axios({
-                ...response.data,
-                data: file,
-              })
-            }),
-          )
+            )
+            // This pushes the file into storage by using the fields in the presignedRequest
+            // See storage_controller.rb get_upload_presigned_request()
+            return axios({
+              ...response.data,
+              data: file,
+            })
+          })
         })
       }
       // We have to wait for all the upload API requests to finish before notifying the prompt
-      Promise.all(promises).then((responses) => {
-        Api.post(`/script-api/running-script/${this.scriptId}/prompt`, {
-          data: {
-            method: this.file.multiple
-              ? 'open_files_dialog'
-              : 'open_file_dialog',
-            answer: fileNames,
-            prompt_id: this.activePromptId,
-          },
-        })
-        this.file.show = false // Close the dialog immediately to avoid race condition
-      })
+      const responses = await Promise.all(promises)
+      Api.post(`/script-api/running-script/${this.scriptId}/prompt`, {
+        data: {
+          method: this.file.multiple ? 'open_files_dialog' : 'open_file_dialog',
+          answer: fileNames,
+          prompt_id: this.activePromptId,
+        },
+      }).catch(console.error)
+      this.file.show = false // Close the dialog immediately to avoid race condition
     },
     bucketDialogCallback(response) {
       this.bucket.show = false
@@ -2748,7 +2760,7 @@ export default {
           answer: response,
           prompt_id: this.activePromptId,
         },
-      })
+      }).catch(console.error)
     },
     setError(event) {
       this.alertType = 'error'
@@ -3210,7 +3222,9 @@ class TestSuite(Suite):
       // rejects overwriting a different approved script.
       this.resetLifecycle()
       if (this.tempFilename) {
-        Api.post(`/script-api/scripts/${this.tempFilename}/delete`)
+        Api.post(`/script-api/scripts/${this.tempFilename}/delete`).catch(
+          console.error,
+        )
         this.tempFilename = null
       }
       await this.saveFile('menu')
@@ -3264,12 +3278,14 @@ class TestSuite(Suite):
           Accept: 'application/json',
           'Content-Type': 'text/plain',
         },
-      }).then((response) => {
-        this.information.title = response.data.title
-        this.information.text = JSON.parse(response.data.description)
-        this.information.show = true
-        this.information.width = '600'
       })
+        .then((response) => {
+          this.information.title = response.data.title
+          this.information.text = JSON.parse(response.data.description)
+          this.information.show = true
+          this.information.width = '600'
+        })
+        .catch(console.error)
     },
     showInstrumented() {
       Api.post(`/script-api/scripts/${this.filename}/instrumented`, {
@@ -3278,15 +3294,19 @@ class TestSuite(Suite):
           Accept: 'application/json',
           'Content-Type': 'text/plain',
         },
-      }).then((response) => {
-        this.information.title = response.data.title
-        this.information.text = JSON.parse(response.data.description)
-        this.information.show = true
-        this.information.width = '90vw'
       })
+        .then((response) => {
+          this.information.title = response.data.title
+          this.information.text = JSON.parse(response.data.description)
+          this.information.show = true
+          this.information.width = '90vw'
+        })
+        .catch(console.error)
     },
     showCallStack() {
-      Api.post(`/script-api/running-script/${this.scriptId}/backtrace`)
+      Api.post(`/script-api/running-script/${this.scriptId}/backtrace`).catch(
+        console.error,
+      )
     },
     toggleDebug() {
       this.showDebug = !this.showDebug
@@ -3311,7 +3331,7 @@ class TestSuite(Suite):
           data: {
             args: this.debug,
           },
-        })
+        }).catch(console.error)
         this.debug = ''
       } else if (event.key === 'ArrowUp') {
         this.debugHistoryIndex -= 1
@@ -3360,7 +3380,9 @@ class TestSuite(Suite):
         !this.readOnly &&
         !this.readOnlyUser
       ) {
-        Api.post(`/script-api/scripts/${this.filename}/unlock`)
+        Api.post(`/script-api/scripts/${this.filename}/unlock`).catch(
+          console.error,
+        )
       }
     },
     onVersionRestored: function () {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1675,7 +1675,7 @@ export default {
         }
       }
     }
-    this.updateInterval = setInterval(async () => {
+    this.updateInterval = setInterval(() => {
       this.processReceived()
     }, 100) // Every 100ms
   },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/autocomplete/mnemonicChecker.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/autocomplete/mnemonicChecker.js
@@ -32,24 +32,31 @@ export default class MnemonicChecker {
     this.api = new OpenC3Api()
 
     this.targets = {}
-    this.api.get_target_names().then((response) => {
-      response.forEach((target) => {
-        this.targets[target] = {
-          cmd: null,
-          tlm: null,
-        }
+    this.api
+      .get_target_names()
+      .then((response) => {
+        response.forEach((target) => {
+          this.targets[target] = {
+            cmd: null,
+            tlm: null,
+          }
+        })
       })
-    })
+      .catch(console.error)
 
     this.cmdKeywordExpressions = []
-    getKeywords('cmd').then((response) => {
-      this.cmdKeywordExpressions = response.data.map(toKeywordRegex)
-    })
+    getKeywords('cmd')
+      .then((response) => {
+        this.cmdKeywordExpressions = response.data.map(toKeywordRegex)
+      })
+      .catch(console.error)
 
     this.tlmKeywordExpressions = []
-    getKeywords('tlm').then((response) => {
-      this.tlmKeywordExpressions = response.data.map(toKeywordRegex)
-    })
+    getKeywords('tlm')
+      .then((response) => {
+        this.tlmKeywordExpressions = response.data.map(toKeywordRegex)
+      })
+      .catch(console.error)
   }
 
   async checkText(text) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/autocomplete/packetCompleter.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/autocomplete/packetCompleter.js
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -34,14 +34,18 @@ export default class PacketCompleter {
     this.keywordExpressions = [] // Keywords that trigger the autocomplete feature
     this.autocompleteData = [] // Data to populate the autocomplete list
 
-    getKeywords(type).then((response) => {
-      this.keywordExpressions = response.data.map(toMethodCallSyntaxRegex)
-      expressionsReadyCallback()
-    })
-    getAutocompleteData(type).then((response) => {
-      this.autocompleteData = response.data
-      dataReadyCallback()
-    })
+    getKeywords(type)
+      .then((response) => {
+        this.keywordExpressions = response.data.map(toMethodCallSyntaxRegex)
+        expressionsReadyCallback()
+      })
+      .catch(console.error)
+    getAutocompleteData(type)
+      .then((response) => {
+        this.autocompleteData = response.data
+        dataReadyCallback()
+      })
+      .catch(console.error)
   }
 
   getCompletions(_editor, session, position, _prefix, callback) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/buttonScriptSandbox.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/buttonScriptSandbox.js
@@ -235,7 +235,7 @@ export function runButtonScript(options) {
           })
           break
         case 'call':
-          dispatch(message)
+          dispatch(message).catch(console.error)
           break
         case 'done':
           finish(resolve, undefined)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ButtonWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ButtonWidget.vue
@@ -119,7 +119,6 @@ export default {
         })
       } catch (error) {
         if (error?.name !== 'AbortError') {
-          // eslint-disable-next-line no-console
           console.error(error)
         }
       } finally {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ButtonWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ButtonWidget.vue
@@ -163,11 +163,13 @@ export default {
       }
       Api.post(`/script-api/scripts/${scriptName}/run`, {
         data: { environment: envArray },
-      }).then((response) => {
-        if (openScript) {
-          window.open(`/tools/scriptrunner/${response.data}`, '_blank')
-        }
       })
+        .then((response) => {
+          if (openScript) {
+            window.open(`/tools/scriptrunner/${response.data}`, '_blank')
+          }
+        })
+        .catch(console.error)
     },
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/CanvasimagevalueWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/CanvasimagevalueWidget.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -112,9 +112,11 @@ export default {
           height: setting[6],
         }
       })
-    Promise.all(promises).then((images) => {
-      this.images = images
-    })
+    Promise.all(promises)
+      .then((images) => {
+        this.images = images
+      })
+      .catch(console.error)
 
     // Set default image data
     if (this.parameters[4]) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/FilechecksumWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/FilechecksumWidget.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -158,7 +158,6 @@ export default {
         file.copied = true
         setTimeout(() => (file.copied = false), 2000)
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.error('Failed to copy checksum:', err)
       }
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LabelvaluedescWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LabelvaluedescWidget.vue
@@ -82,6 +82,7 @@ export default {
           .then((details) => {
             this.description = details['description']
           })
+          .catch(console.error)
       }
     }
   },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VWidget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VWidget.js
@@ -217,8 +217,7 @@ export default {
         }
         return this.formatValueBase(value, this.formatString)
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log(
+        console.error(
           `${this.valueId} formatValue on ${value} with ${this.formatString} failed due to ${e}`,
         )
         return value

--- a/openc3-cosmos-init/plugins/pnpm-lock.yaml
+++ b/openc3-cosmos-init/plugins/pnpm-lock.yaml
@@ -16,13 +16,19 @@ importers:
         version: 10.6.0
       eslint-plugin-vue:
         specifier: 10.9.2
-        version: 10.9.2(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0))
+        version: 10.9.2(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0))
       eslint-plugin-vuetify:
         specifier: 2.7.2
-        version: 2.7.2(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0))(vuetify@4.0.7(vue@3.5.39))
+        version: 2.7.2(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0))(vuetify@4.0.7(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))
       globals:
         specifier: 17.7.0
         version: 17.7.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: 8.64.0
+        version: 8.64.0(eslint@10.6.0)(typescript@6.0.3)
       vue-eslint-parser:
         specifier: 10.4.1
         version: 10.4.1(eslint@10.6.0)
@@ -44,7 +50,7 @@ importers:
         version: 1.16.1
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -59,7 +65,7 @@ importers:
         version: 0.0.1(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-admin:
     dependencies:
@@ -78,7 +84,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -90,7 +96,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-bucketexplorer:
     dependencies:
@@ -121,7 +127,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -133,7 +139,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-cmdsender:
     dependencies:
@@ -167,7 +173,7 @@ importers:
         version: 1.16.1
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -179,7 +185,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-cmdtlmserver:
     dependencies:
@@ -197,22 +203,22 @@ importers:
         version: link:../openc3-vue-common
       '@vue-flow/background':
         specifier: 1.3.2
-        version: 1.3.2(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)
+        version: 1.3.2(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       '@vue-flow/controls':
         specifier: 1.1.3
-        version: 1.1.3(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)
+        version: 1.1.3(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       '@vue-flow/core':
         specifier: 1.48.2
-        version: 1.48.2(vue@3.5.39)
+        version: 1.48.2(vue@3.5.39(typescript@6.0.3))
       '@vue-flow/minimap':
         specifier: 1.5.4
-        version: 1.5.4(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)
+        version: 1.5.4(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       '@vue-flow/node-resizer':
         specifier: 1.5.1
-        version: 1.5.1(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)
+        version: 1.5.1(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       '@vue-flow/node-toolbar':
         specifier: 1.1.1
-        version: 1.1.1(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)
+        version: 1.1.1(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))
       axios:
         specifier: 1.18.1
         version: 1.18.1
@@ -228,7 +234,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -240,7 +246,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-dataextractor:
     dependencies:
@@ -268,7 +274,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -280,7 +286,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-dataviewer:
     dependencies:
@@ -311,7 +317,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -323,7 +329,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-handbooks:
     dependencies:
@@ -354,7 +360,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -366,7 +372,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-iframe:
     dependencies:
@@ -400,7 +406,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -412,7 +418,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-limitsmonitor:
     dependencies:
@@ -443,7 +449,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -455,7 +461,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-packetviewer:
     dependencies:
@@ -486,7 +492,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -498,7 +504,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-scriptrunner:
     dependencies:
@@ -528,14 +534,14 @@ importers:
         version: 3.0.1
       splitpanes:
         specifier: 4.1.2
-        version: 4.1.2(vue@3.5.39)
+        version: 4.1.2(vue@3.5.39(typescript@6.0.3))
       sprintf-js:
         specifier: 1.1.3
         version: 1.1.3
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -547,7 +553,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-tablemanager:
     dependencies:
@@ -578,7 +584,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -590,7 +596,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-tlmgrapher:
     dependencies:
@@ -627,7 +633,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -639,7 +645,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-cosmos-tool-tlmviewer:
     dependencies:
@@ -679,7 +685,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -691,7 +697,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-js-common:
     dependencies:
@@ -761,7 +767,7 @@ importers:
         version: 6.1.0
       pinia:
         specifier: 3.0.4
-        version: 3.0.4(vue@3.5.39)
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
       single-spa:
         specifier: 6.0.3
         version: 6.0.3
@@ -770,10 +776,10 @@ importers:
         version: 6.15.1
       vue-router:
         specifier: 4.4.4
-        version: 4.4.4(vue@3.5.39)
+        version: 4.4.4(vue@3.5.39(typescript@6.0.3))
       vuetify:
         specifier: 3.12.8
-        version: 3.12.8(vue@3.5.39)
+        version: 3.12.8(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
     devDependencies:
       '@babel/plugin-transform-modules-systemjs':
         specifier: 7.29.7
@@ -783,7 +789,7 @@ importers:
         version: 6.15.4
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -795,7 +801,7 @@ importers:
         version: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
 
   packages/openc3-vue-common:
     dependencies:
@@ -837,7 +843,7 @@ importers:
         version: 0.54.0
       pinia:
         specifier: 3.0.4
-        version: 3.0.4(vue@3.5.39)
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
       sass:
         specifier: 1.101.0
         version: 1.101.0
@@ -852,7 +858,7 @@ importers:
         version: 1.15.7
       splitpanes:
         specifier: 4.1.2
-        version: 4.1.2(vue@3.5.39)
+        version: 4.1.2(vue@3.5.39(typescript@6.0.3))
       sprintf-js:
         specifier: 1.1.3
         version: 1.1.3
@@ -861,17 +867,17 @@ importers:
         version: 1.6.32
       vue:
         specifier: 3.5.39
-        version: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
       vuetify:
         specifier: 3.12.8
-        version: 3.12.8(vue@3.5.39)
+        version: 3.12.8(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
       vuetify-sonner:
         specifier: ^0.4.2
-        version: 0.4.2(vue@3.5.39)(vuetify@3.12.8(vue@3.5.39))
+        version: 0.4.2(vue@3.5.39(typescript@6.0.3))(vuetify@3.12.8(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)
+        version: 6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))
       prettier:
         specifier: 3.8.5
         version: 3.8.5
@@ -1477,6 +1483,65 @@ packages:
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
 
+  '@typescript-eslint/eslint-plugin@8.64.0':
+    resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.64.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.64.0':
+    resolution: {integrity: sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.64.0':
+    resolution: {integrity: sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.64.0':
+    resolution: {integrity: sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.64.0':
+    resolution: {integrity: sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.64.0':
+    resolution: {integrity: sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.64.0':
+    resolution: {integrity: sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.64.0':
+    resolution: {integrity: sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.64.0':
+    resolution: {integrity: sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.64.0':
+    resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@vitejs/plugin-vue@6.0.7':
     resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1980,6 +2045,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
@@ -2330,9 +2399,27 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.64.0:
+    resolution: {integrity: sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -2956,51 +3043,142 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.64.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/type-utils': 8.64.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.64.0
+      eslint: 10.6.0
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.64.0
+      debug: 4.4.3
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.64.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.64.0':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
+
+  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.64.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.6.0)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.6.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.64.0': {}
+
+  '@typescript-eslint/typescript-estree@8.64.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.64.0(eslint@10.6.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.64.0':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      eslint-visitor-keys: 5.0.1
+
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 7.3.6(@types/node@25.0.3)(lightningcss@1.32.0)(sass@1.101.0)
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
 
-  '@vue-flow/background@1.3.2(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)':
+  '@vue-flow/background@1.3.2(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vue-flow/core': 1.48.2(vue@3.5.39)
-      vue: 3.5.39
+      '@vue-flow/core': 1.48.2(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
 
-  '@vue-flow/controls@1.1.3(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)':
+  '@vue-flow/controls@1.1.3(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vue-flow/core': 1.48.2(vue@3.5.39)
-      vue: 3.5.39
+      '@vue-flow/core': 1.48.2(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
 
-  '@vue-flow/core@1.48.2(vue@3.5.39)':
+  '@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.5.39)
+      '@vueuse/core': 10.11.1(vue@3.5.39(typescript@6.0.3))
       d3-drag: 3.0.0
       d3-interpolate: 3.0.1
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  '@vue-flow/minimap@1.5.4(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)':
+  '@vue-flow/minimap@1.5.4(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vue-flow/core': 1.48.2(vue@3.5.39)
+      '@vue-flow/core': 1.48.2(vue@3.5.39(typescript@6.0.3))
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
 
-  '@vue-flow/node-resizer@1.5.1(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)':
+  '@vue-flow/node-resizer@1.5.1(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vue-flow/core': 1.48.2(vue@3.5.39)
+      '@vue-flow/core': 1.48.2(vue@3.5.39(typescript@6.0.3))
       d3-drag: 3.0.0
       d3-selection: 3.0.0
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
 
-  '@vue-flow/node-toolbar@1.1.1(@vue-flow/core@1.48.2(vue@3.5.39))(vue@3.5.39)':
+  '@vue-flow/node-toolbar@1.1.1(@vue-flow/core@1.48.2(vue@3.5.39(typescript@6.0.3)))(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vue-flow/core': 1.48.2(vue@3.5.39)
-      vue: 3.5.39
+      '@vue-flow/core': 1.48.2(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
 
   '@vue/compiler-core@3.5.39':
     dependencies:
@@ -3077,29 +3255,29 @@ snapshots:
       '@vue/shared': 3.5.39
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.39(vue@3.5.39)':
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.39
       '@vue/shared': 3.5.39
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
 
   '@vue/shared@3.5.39': {}
 
-  '@vueuse/core@10.11.1(vue@3.5.39)':
+  '@vueuse/core@10.11.1(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.39)
-      vue-demi: 0.14.10(vue@3.5.39)
+      '@vueuse/shared': 10.11.1(vue@3.5.39(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
   '@vueuse/metadata@10.11.1': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.39)':
+  '@vueuse/shared@10.11.1(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.39)
+      vue-demi: 0.14.10(vue@3.5.39(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -3332,7 +3510,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@10.6.0)
 
-  eslint-plugin-vue@10.9.2(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0)):
+  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
       eslint: 10.6.0
@@ -3342,13 +3520,15 @@ snapshots:
       semver: 7.8.4
       vue-eslint-parser: 10.4.1(eslint@10.6.0)
       xml-name-validator: 4.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.64.0(eslint@10.6.0)(typescript@6.0.3)
 
-  eslint-plugin-vuetify@2.7.2(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0))(vuetify@4.0.7(vue@3.5.39)):
+  eslint-plugin-vuetify@2.7.2(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0))(vuetify@4.0.7(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))):
     dependencies:
       eslint: 10.6.0
-      eslint-plugin-vue: 10.9.2(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0))
+      eslint-plugin-vue: 10.9.2(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(vue-eslint-parser@10.4.1(eslint@10.6.0))
       requireindex: 1.2.0
-      vuetify: 4.0.7(vue@3.5.39)
+      vuetify: 4.0.7(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
     transitivePeerDependencies:
       - '@stylistic/eslint-plugin'
       - '@typescript-eslint/parser'
@@ -3511,6 +3691,8 @@ snapshots:
       - supports-color
 
   ignore@5.3.2: {}
+
+  ignore@7.0.6: {}
 
   immutable@5.1.5: {}
 
@@ -3684,10 +3866,12 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pinia@3.0.4(vue@3.5.39):
+  pinia@3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-api': 7.7.9
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -3779,9 +3963,9 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
-  splitpanes@4.1.2(vue@3.5.39):
+  splitpanes@4.1.2(vue@3.5.39(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
 
   sprintf-js@1.1.3: {}
 
@@ -3800,9 +3984,26 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  typescript-eslint@8.64.0(eslint@10.6.0)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@10.6.0)(typescript@6.0.3)
+      eslint: 10.6.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@6.0.3: {}
 
   undici-types@7.16.0:
     optional: true
@@ -3841,9 +4042,9 @@ snapshots:
 
   vue-component-type-helpers@3.3.6: {}
 
-  vue-demi@0.14.10(vue@3.5.39):
+  vue-demi@0.14.10(vue@3.5.39(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
 
   vue-eslint-parser@10.4.1(eslint@10.6.0):
     dependencies:
@@ -3857,39 +4058,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.4.4(vue@3.5.39):
+  vue-router@4.4.4(vue@3.5.39(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
 
   vue-sonner@2.0.9: {}
 
-  vue@3.5.39:
+  vue@3.5.39(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.39
       '@vue/compiler-sfc': 3.5.39
       '@vue/runtime-dom': 3.5.39
-      '@vue/server-renderer': 3.5.39(vue@3.5.39)
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@6.0.3))
       '@vue/shared': 3.5.39
+    optionalDependencies:
+      typescript: 6.0.3
 
-  vuetify-sonner@0.4.2(vue@3.5.39)(vuetify@3.12.8(vue@3.5.39)):
+  vuetify-sonner@0.4.2(vue@3.5.39(typescript@6.0.3))(vuetify@3.12.8(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))):
     dependencies:
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
       vue-component-type-helpers: 3.3.6
       vue-sonner: 2.0.9
-      vuetify: 3.12.8(vue@3.5.39)
+      vuetify: 3.12.8(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@nuxt/schema'
       - nuxt
 
-  vuetify@3.12.8(vue@3.5.39):
+  vuetify@3.12.8(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
-  vuetify@4.0.7(vue@3.5.39):
+  vuetify@4.0.7(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.39
+      vue: 3.5.39(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
   which@2.0.2:
     dependencies:

--- a/openc3-cosmos-init/plugins/tsconfig.json
+++ b/openc3-cosmos-init/plugins/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "strict": false
+  },
+  "include": [
+    "packages/openc3-vue-common/src/**/*.js",
+    "packages/openc3-vue-common/src/**/*.vue"
+  ]
+}


### PR DESCRIPTION
- allow console.error
- add `require-await`
- add typescript configuration
- add `@typescript-eslint/no-floating-promises` to openc3-vue-common and fix all failures
  - mostly by adding `.catch(console.error)`
  - a few rewrites to async/await