### PR TITLE
Make Enterprise API key message not dismissable

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStore.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStore.vue
@@ -54,6 +54,28 @@
       />
     </div>
     <v-spacer />
+    <v-alert
+      v-if="showApiKeyBanner"
+      class="my-3"
+      type="info"
+      density="compact"
+      data-test="api-key-banner"
+    >
+      You're using COSMOS Enterprise, but you haven't set an OpenC3 Store API
+      key yet. You must set this to access Enterprise plugins.
+      <br />
+      Visit the
+      <a :href="accountSettingsUrl" target="_blank" class="text-white">
+        OpenC3 Store account settings<v-icon
+          icon="mdi-open-in-new"
+          size="x-small"
+        />
+      </a>
+      to generate an API key. Then, return here and open the Plugin Store
+      settings with the
+      <v-icon icon="mdi-cog" size="small" /> icon above, and finally paste your
+      API key into the API key field.
+    </v-alert>
     <span class=""> Click on a plugin to see more information about it </span>
     <v-alert
       v-if="storeError"
@@ -111,10 +133,19 @@ export default {
       storeUrl: DEFAULT_STORE_URL,
       isEnterprise: false,
       isAdmin: true,
+      isApiKeySet: localStorage.getItem('pluginStore.isApiKeySet') === 'true',
       loading: false,
     }
   },
   computed: {
+    showApiKeyBanner: function () {
+      return this.isEnterprise && !this.isApiKeySet
+    },
+    accountSettingsUrl: function () {
+      const url = this.storeUrl || DEFAULT_STORE_URL
+      const navigableHost = url.replace('host.docker.internal', 'localhost')
+      return new URL('account', navigableHost)
+    },
     filteredPlugins: function () {
       let filtered = this.plugins
       if (this.search.length) {
@@ -129,6 +160,14 @@ export default {
     },
     installAllowed: function () {
       return !this.isEnterprise || this.isAdmin
+    },
+  },
+  watch: {
+    showSettingsDialog: function (val) {
+      if (!val) {
+        this.isApiKeySet =
+          localStorage.getItem('pluginStore.isApiKeySet') === 'true'
+      }
     },
   },
   mounted: function () {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStoreSettingsDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginStoreSettingsDialog.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -44,41 +44,9 @@
       </v-card-actions>
     </v-card>
   </v-dialog>
-
-  <v-dialog v-model="showApiKeyAlert">
-    <v-card class="pa-3">
-      <v-card-text class="pb-0">
-        You're using COSMOS Enterprise, but you haven't set an OpenC3 Store API
-        key yet. You must set this to access Enterprise plugins.
-        <br />
-        <br />
-        Visit the
-        <a :href="accountSettingsUrl" target="_blank">
-          OpenC3 Store account settings<v-icon
-            icon="mdi-open-in-new"
-            size="x-small"
-          />
-        </a>
-        to generate an API key. Then, return here and open the Plugin Store
-        settings with the
-        <v-icon icon="mdi-cog" size="small" /> icon and paste your API key into
-        the API key field.
-      </v-card-text>
-      <v-card-actions>
-        <v-checkbox
-          v-model="suppressApiKeyAlert"
-          class="px-3"
-          label="Don't show this message again"
-          hide-details
-        />
-        <v-btn variant="elevated" text="OK" @click="closeApiKeyAlert" />
-      </v-card-actions>
-    </v-card>
-  </v-dialog>
 </template>
 
 <script>
-import { Api } from '@openc3/js-common/services'
 import Settings from '@/tools/admin/tabs/settings/settings.js'
 
 const URL_SETTING_NAME = 'store_url'
@@ -97,9 +65,6 @@ export default {
       showDialog: false,
       storeUrl: '',
       apiKey: null,
-      isEnterprise: false,
-      showApiKeyAlert: false,
-      suppressApiKeyAlert: false,
       rules: {
         required: (value) => !!value || 'Required',
         url: (value) => {
@@ -113,25 +78,9 @@ export default {
       },
     }
   },
-  computed: {
-    accountSettingsUrl: function () {
-      const navigableHost = this.storeUrl.replace(
-        'host.docker.internal',
-        'localhost',
-      )
-      return new URL('account', navigableHost)
-    },
-  },
   watch: {
     apiKey: function (val) {
-      this.checkEnterpriseKey()
       localStorage.setItem('pluginStore.isApiKeySet', !!val)
-    },
-    isEnterprise: function (val) {
-      this.checkEnterpriseKey()
-    },
-    suppressApiKeyAlert: function (val) {
-      localStorage.setItem('pluginStore.suppressApiKeyAlert', val)
     },
     modelValue: function (val) {
       if (val) {
@@ -145,27 +94,11 @@ export default {
     },
   },
   created: function () {
-    Api.get('/openc3-api/info').then(({ data }) => {
-      this.isEnterprise = data.enterprise
-    })
     this.loadSetting(URL_SETTING_NAME, { scope: SETTING_SCOPE })
     this.loadSetting(API_KEY_SETTING_NAME, { scope: SETTING_SCOPE })
     this.$emit('update:storeUrl', this.storeUrl)
   },
   methods: {
-    checkEnterpriseKey: function () {
-      if (this.isEnterprise && this.apiKey === '') {
-        this.openApiKeyAlert()
-      }
-    },
-    openApiKeyAlert: function () {
-      if (localStorage.getItem('pluginStore.suppressApiKeyAlert') !== 'true') {
-        this.showApiKeyAlert = true
-      }
-    },
-    closeApiKeyAlert: function () {
-      this.showApiKeyAlert = false
-    },
     save: function () {
       this.saveSetting(URL_SETTING_NAME, this.storeUrl, {
         scope: SETTING_SCOPE,


### PR DESCRIPTION
Users were checking the "don't show this again" box and then didn't know to add the API key. I replaced the dismissable dialog with a persistent banner (since I don't like dialogs that show every time and don't have a "don't show this again" option). Only way to dismiss it now is to add an API key, but it's less intrusive.

<img width="1714" height="385" alt="image" src="https://github.com/user-attachments/assets/e84f5f67-728e-40fc-8a42-868ed597eb83" />
