### PR TITLE
Eslint allow console error

### DIFF
--- a/openc3-cosmos-init/plugins/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/eslint.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig([
     },
 
     rules: {
-      'no-console': 'error',
+      'no-console': ['error', { allow: ['error'] }],
       'no-debugger': 'error',
 
       'prettier/prettier': [

--- a/openc3-cosmos-init/plugins/lint-all.mjs
+++ b/openc3-cosmos-init/plugins/lint-all.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/*
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+*/
+/* eslint-disable no-console */
+// Run ESLint across every package that has its own eslint config file, so each
+// package's source is checked against its *closest* config.
+//
+// ESLint's flat config (v9+) does not cascade like the old .eslintrc: a single
+// run uses only the nearest config to the working directory. We therefore run
+// ESLint once per config directory (with that directory as cwd) so each picks
+// up its own config. Following the per-package `lint` scripts, we lint `src`
+// only -- this skips build output (tools/) and vendored bundles (public/).
+//
+// Usage:
+//   node lint-all.mjs            # lint every package's src
+//   node lint-all.mjs --fix      # extra args are forwarded to eslint
+import { spawnSync } from 'node:child_process'
+import { existsSync, readdirSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = dirname(fileURLToPath(import.meta.url))
+const CONFIG_RE = /^eslint\.config\.[mc]?[jt]s$/
+
+// Run eslint via the current Node binary and eslint's own JS entry point rather
+// than resolving a `pnpm`/`eslint` command name through $PATH (which is
+// hijackable). eslint's bin isn't exposed through its package `exports`, so we
+// resolve the package root and append the known bin path.
+const require = createRequire(import.meta.url)
+const ESLINT_BIN = join(
+  dirname(require.resolve('eslint/package.json')),
+  'bin',
+  'eslint.js',
+)
+
+// Recursively collect every directory that contains an eslint config file.
+function findConfigDirs(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue
+    if (entry.isDirectory()) {
+      findConfigDirs(join(dir, entry.name), acc)
+    } else if (CONFIG_RE.test(entry.name)) {
+      acc.push(dir)
+    }
+  }
+  return acc
+}
+
+const configDirs = findConfigDirs(ROOT).sort((a, b) => a.localeCompare(b))
+const extraArgs = process.argv.slice(2)
+
+if (configDirs.length === 0) {
+  console.error('No eslint config files found under', ROOT)
+  process.exit(1)
+}
+
+// A folder under packages/ that has source but no eslint.config.mjs would be
+// linted by no one -- flag it as an error so it can't slip through unchecked.
+const PACKAGES = join(ROOT, 'packages')
+const configDirSet = new Set(configDirs)
+const missingConfig = []
+if (existsSync(PACKAGES)) {
+  for (const entry of readdirSync(PACKAGES, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const pkgDir = join(PACKAGES, entry.name)
+    if (existsSync(join(pkgDir, 'src')) && !configDirSet.has(pkgDir)) {
+      missingConfig.push(relative(ROOT, pkgDir))
+    }
+  }
+}
+
+let overall = 0
+const failed = []
+const skipped = []
+
+for (const dir of configDirs) {
+  const relDir = relative(ROOT, dir) || '.'
+
+  // The per-package convention is `eslint src`; a config dir without a src/
+  // (e.g. the workspace root) has nothing of its own to lint.
+  if (!existsSync(join(dir, 'src'))) {
+    skipped.push(relDir)
+    console.log(`\n==> Skipping ${relDir} (no src/)`)
+    continue
+  }
+
+  console.log(
+    `\n==> Linting ${relDir}/src (closest config: ${relDir}/eslint.config.*)`,
+  )
+
+  const result = spawnSync(
+    process.execPath,
+    [ESLINT_BIN, 'src', ...extraArgs],
+    {
+      cwd: dir,
+      stdio: 'inherit',
+    },
+  )
+
+  const status = result.status ?? 1
+  if (status !== 0) {
+    overall = status
+    failed.push(relDir)
+    console.log(`    ✗ ${relDir} reported problems`)
+  } else {
+    console.log(`    ✓ ${relDir} clean`)
+  }
+}
+
+const linted = configDirs.length - skipped.length
+console.log(`\n${'='.repeat(60)}`)
+if (failed.length === 0) {
+  console.log(
+    `All ${linted} linted package(s) clean. (${skipped.length} skipped)`,
+  )
+} else {
+  console.log(`${failed.length}/${linted} package(s) reported problems:`)
+  for (const f of failed) console.log(`  - ${f}`)
+}
+
+if (missingConfig.length > 0) {
+  overall = overall || 1
+  console.log(
+    `\n${missingConfig.length} package(s) have a src/ but no eslint.config.mjs (source would go unlinted):`,
+  )
+  for (const p of missingConfig) console.log(`  - ${p}`)
+}
+
+process.exit(overall)

--- a/openc3-cosmos-init/plugins/package.json
+++ b/openc3-cosmos-init/plugins/package.json
@@ -2,7 +2,8 @@
   "name": "openc3",
   "private": true,
   "scripts": {
-    "build:common": "pnpm -F @openc3/*-common build"
+    "build:common": "pnpm -F @openc3/*-common build",
+    "lint": "./lint-all.mjs"
   },
   "devDependencies": {
     "@vue/eslint-config-prettier": "10.2.0",

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/eslint.config.mjs
@@ -1,11 +1,1 @@
-import { defineConfig } from 'eslint/config'
-import baseConfig from '../../eslint.config.mjs'
-
-export default defineConfig([
-  baseConfig,
-  {
-    rules: {
-      'no-console': 'warn',
-    },
-  },
-])
+export { default } from '../../eslint.config.mjs'

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/eslint.config.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/eslint.config.mjs
@@ -5,7 +5,6 @@ export default defineConfig([
   baseConfig,
   {
     rules: {
-      'no-console': 'warn',
       'vue/no-side-effects-in-computed-properties': 'warn',
       'vuetify/no-deprecated-props': 'warn',
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/InterfacesTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/InterfacesTab.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -223,7 +223,6 @@ export default {
           this.detailsDialog = true
         })
         .catch((error) => {
-          // eslint-disable-next-line no-console
           console.error('Failed to fetch interface details:', error)
           this.interfaceDetails = null
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/RoutersTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/RoutersTab.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -207,7 +207,6 @@ export default {
           this.detailsDialog = true
         })
         .catch((error) => {
-          // eslint-disable-next-line no-console
           console.error('Failed to fetch router details:', error)
           this.routerDetails = null
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/src/tools/PacketViewer/PacketViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-packetviewer/src/tools/PacketViewer/PacketViewer.vue
@@ -706,10 +706,7 @@ export default {
               .then((values) => {
                 this.latestGetTlmValues(values)
               })
-              .catch((error) => {
-                // eslint-disable-next-line no-console
-                console.log(error)
-              })
+              .catch(console.error)
           } else {
             this.api
               .get_all_tlm_item_names(this.targetName)
@@ -729,10 +726,7 @@ export default {
               .then((values) => {
                 this.latestGetTlmValues(values)
               })
-              .catch((error) => {
-                // eslint-disable-next-line no-console
-                console.log(error)
-              })
+              .catch(console.error)
           }
         } else {
           // Regular packet handling using get_tlm_packet
@@ -786,10 +780,7 @@ export default {
             // Catch errors but just log to the console
             // We don't clear the updater because errors can happen on upgrade
             // and we want to continue updating once the new plugin comes online
-            .catch((error) => {
-              // eslint-disable-next-line no-console
-              console.log(error)
-            })
+            .catch(console.error)
         }
         if (loadingFirstTlm) {
           loadingFirstTlm = false

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
@@ -489,7 +489,6 @@ export default {
         }
       })
       .catch((error) => {
-        // eslint-disable-next-line no-console
         console.error('Error loading screens:', error)
       })
     Api.get('/openc3-api/autocomplete/keywords/screen')
@@ -497,7 +496,6 @@ export default {
         this.keywords = response.data
       })
       .catch((error) => {
-        // eslint-disable-next-line no-console
         console.error('Error loading screen keywords:', error)
       })
 
@@ -608,7 +606,6 @@ export default {
           'Ignore-Errors': '404',
         },
       }).catch((error) => {
-        // eslint-disable-next-line no-console
         console.error(
           `Error loading screen ${screen} for target ${target}:`,
           error,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
@@ -252,7 +252,6 @@ export default {
               return this.api.get_cmd(this.targetName, this.commandName)
             },
             (error) => {
-              // eslint-disable-next-line no-console
               console.error('Error getting ignored parameters:', error)
             },
           )
@@ -338,7 +337,6 @@ export default {
               }
             },
             (error) => {
-              // eslint-disable-next-line no-console
               console.error('Error getting command parameters:', error)
               this.$emit('command-loaded', null)
             },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -674,7 +674,6 @@ export default {
               this.updateGraphData()
             })
             .catch((error) => {
-              // eslint-disable-next-line no-console
               console.error('Error fetching playback telemetry:', error)
             })
             .finally(() => {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -1095,8 +1095,7 @@ export default {
         // This must be the same or we're going to have problems
         // because the data comes back in an ordered array
         if (screenItems.length != data.length) {
-          // eslint-disable-next-line no-console
-          console.log(
+          console.error(
             'Error getting tlm available',
             screenItems,
             this.graphItems,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -1057,8 +1057,7 @@ export default {
         values.length != this.screenItems.length ||
         values.length != this.actualScreenItems.length
       ) {
-        // eslint-disable-next-line no-console
-        console.log(
+        console.error(
           `get_tlm_values mismatch: data.length: ${values.length}, screenItems.length: ${this.screenItems.length}, actualScreenItems.length: ${this.actualScreenItems.length}`,
           JSON.stringify(values),
           JSON.stringify(this.screenItems),
@@ -1087,8 +1086,7 @@ export default {
             // This must be the same or we're going to have problems
             // because the data comes back in an ordered array
             if (this.screenItems.length != data.length) {
-              // eslint-disable-next-line no-console
-              console.log(
+              console.error(
                 'Error getting tlm available',
                 this.screenItems,
                 this.actualScreenItems,
@@ -1126,8 +1124,7 @@ export default {
             }
           })
           .catch((error) => {
-            // eslint-disable-next-line no-console
-            console.log('Error getting tlm available', error)
+            console.error('Error getting tlm available', error)
             this.actualScreenItems = this.screenItems
           })
         this.tlmAvailableTimeout = null

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/ScreenEditor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/ScreenEditor.vue
@@ -159,7 +159,6 @@ export default {
         )
         this.loadedKeywords = response.data
       } catch (error) {
-        // eslint-disable-next-line no-console
         console.error('Error loading screen keywords:', error)
       }
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/TargetPacketItemChooser.vue
@@ -476,7 +476,6 @@ export default {
           }
         })
         .catch((error) => {
-          // eslint-disable-next-line no-console
           console.error('Error fetching queues:', error)
           // Keep default "None" option even if fetch fails
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ContextTag.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ContextTag.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -64,10 +64,7 @@ export default {
             }
           }
         })
-        .catch((error) => {
-          // eslint-disable-next-line no-console
-          console.error(error)
-        })
+        .catch(console.error)
     },
     startContextTagAutoRefresh() {
       this.stopContextTagAutoRefresh()

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ButtonWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ButtonWidget.vue
@@ -119,7 +119,6 @@ export default {
         })
       } catch (error) {
         if (error?.name !== 'AbortError') {
-          // eslint-disable-next-line no-console
           console.error(error)
         }
       } finally {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/FilechecksumWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/FilechecksumWidget.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -158,7 +158,6 @@ export default {
         file.copied = true
         setTimeout(() => (file.copied = false), 2000)
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.error('Failed to copy checksum:', err)
       }
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VWidget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/VWidget.js
@@ -217,8 +217,7 @@ export default {
         }
         return this.formatValueBase(value, this.formatString)
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log(
+        console.error(
           `${this.valueId} formatValue on ${value} with ${this.formatString} failed due to ${e}`,
         )
         return value


### PR DESCRIPTION
No real code changes here, other than a few `console.log` converted to `console.error`

- allow `console.error`
- remove unused `eslint-disable` directives
- copy `lint-all.mjs` script from Enterprise