### PR TITLE
Require whitelist for JsonDRb

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/config/initializers/cts.rb
+++ b/openc3-cosmos-cmd-tlm-api/config/initializers/cts.rb
@@ -33,8 +33,7 @@ module OpenC3
     @@instance = nil
 
     def initialize
-      @json_drb = JsonDRb.new
-      @json_drb.method_whitelist = Api::WHITELIST.to_set
+      @json_drb = JsonDRb.new(method_whitelist: Api::WHITELIST)
       @json_drb.object = self
     end
 

--- a/openc3/lib/openc3/io/json_drb.rb
+++ b/openc3/lib/openc3/io/json_drb.rb
@@ -17,6 +17,7 @@
 
 require 'socket'
 require 'json'
+require 'set'
 # require 'drb/acl'
 require 'drb/drb'
 require 'openc3/io/json_rpc'
@@ -47,8 +48,9 @@ module OpenC3
   # JsonDRb implements the JSON-RPC 2.0 Specification to provide an interface
   # for both internal and external tools to access the OpenC3 server. It
   # provides methods to install an access control list to control access to the
-  # API. It also limits the available methods to a known list of allowable API
-  # methods.
+  # API. Access is controlled by a required method_whitelist which names every
+  # method that may be invoked. There is no permissive fallback: any method not
+  # explicitly listed is rejected.
   class JsonDRb
     # Minimum amount of time in seconds to receive the JSON request,
     # process it, and send the response. Requests for less than this amount
@@ -62,24 +64,39 @@ module OpenC3
 
     # @return [Integer] The number of JSON-RPC requests processed
     attr_accessor :request_count
-    # @return [Array<String>] List of methods that should be allowed
-    attr_accessor :method_whitelist
+    # @return [Set<String>] Set of downcased method names which may be called
+    attr_reader :method_whitelist
     # @return [ACL] The access control list
     # attr_accessor :acl
 
     attr_accessor :object
 
-    def initialize
+    # @param method_whitelist [Enumerable<String>] Every method name which may
+    #   be called over JSON-RPC. Required and must not be empty since there is
+    #   no permissive fallback.
+    def initialize(method_whitelist:)
+      self.method_whitelist = method_whitelist
       @thread = nil
       # @acl = nil
       @object = nil
-      @method_whitelist = nil
       @request_count = 0
       @request_times = []
       @request_times_index = 0
       @request_mutex = Mutex.new
       @server = nil
       @server_mutex = Mutex.new
+    end
+
+    # Replaces the set of methods which may be called over JSON-RPC. Names are
+    # downcased to match the dispatch in {#process_request}.
+    #
+    # @param whitelist [Enumerable<String>] Every method name which may be called
+    def method_whitelist=(whitelist)
+      if whitelist.nil? or whitelist.to_a.empty?
+        raise ArgumentError, "method_whitelist is required and must not be empty"
+      end
+
+      @method_whitelist = whitelist.map { |name| name.to_s.downcase }.to_set
     end
 
     # Returns the number of connected clients
@@ -254,8 +271,7 @@ module OpenC3
         error_code = nil
         response_data = nil
 
-        if (@method_whitelist and @method_whitelist.include?(request.method.downcase())) or
-           (!@method_whitelist and !JsonRpcRequest::DANGEROUS_METHODS.include?(request.method.downcase()))
+        if @method_whitelist.include?(request.method.downcase())
           begin
             if request.keyword_params
               result = @object.public_send(request.method.downcase().intern, *request.params, **request.keyword_params)

--- a/openc3/lib/openc3/io/json_rpc.rb
+++ b/openc3/lib/openc3/io/json_rpc.rb
@@ -227,8 +227,6 @@ module OpenC3
 
   # Represents a JSON Remote Procedure Call Request
   class JsonRpcRequest < JsonRpc
-    DANGEROUS_METHODS = Set['__send__', 'send', 'instance_eval', 'instance_exec']
-
     # @param method_name [String] The name of the method to call
     # @param method_params [Array<String>] Array of strings which represent the
     #   parameters to send to the method

--- a/openc3/python/openc3/io/json_rpc.py
+++ b/openc3/python/openc3/io/json_rpc.py
@@ -62,8 +62,6 @@ class JsonRpc(dict):
 class JsonRpcRequest(JsonRpc):
     """Represents a JSON Remote Procedure Call Request"""
 
-    DANGEROUS_METHODS = ["__send__", "send", "instance_eval", "instance_exec"]
-
     def __init__(self, id: int, method_name: str, *args, **kwargs):
         """Constructor
 

--- a/openc3/spec/io/json_drb_spec.rb
+++ b/openc3/spec/io/json_drb_spec.rb
@@ -1,0 +1,112 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require 'spec_helper'
+require 'openc3/io/json_drb'
+
+module OpenC3
+  describe JsonDRb do
+    # Stands in for the object exposed over JSON-RPC. Only #greet is allowed;
+    # #secret exists to prove that a real method is still rejected when it is
+    # not in the whitelist.
+    class JsonDRbSpecTarget
+      def greet(name:)
+        "hello #{name}"
+      end
+
+      def secret
+        'unreachable'
+      end
+    end
+
+    let(:json_drb) do
+      drb = JsonDRb.new(method_whitelist: ['greet'])
+      drb.object = JsonDRbSpecTarget.new
+      drb
+    end
+
+    # Builds a JSON-RPC request, processes it, and returns the parsed response
+    def process(json_drb, method_name, params: [], keyword_params: {})
+      request = { 'jsonrpc' => '2.0', 'method' => method_name, 'id' => 1 }
+      request['params'] = params unless params.empty?
+      request['keyword_params'] = keyword_params unless keyword_params.empty?
+      response_data, error_code = json_drb.process_request(
+        request_data: JSON.generate(request), request_headers: {}, start_time: Time.now
+      )
+      return JSON.parse(response_data), error_code
+    end
+
+    describe "method_whitelist" do
+      it "is required" do
+        expect { JsonDRb.new }.to raise_error(ArgumentError, /missing keyword: :method_whitelist/)
+      end
+
+      it "rejects a nil or empty whitelist" do
+        [nil, [], Set[]].each do |whitelist|
+          expect { JsonDRb.new(method_whitelist: whitelist) }.to raise_error(
+            ArgumentError, /method_whitelist is required and must not be empty/
+          )
+        end
+      end
+
+      it "downcases the method names into a Set" do
+        drb = JsonDRb.new(method_whitelist: ['Tlm', :CMD])
+        expect(drb.method_whitelist).to eql(Set['tlm', 'cmd'])
+      end
+
+      it "can be replaced but still cannot be cleared" do
+        drb = JsonDRb.new(method_whitelist: ['tlm'])
+        drb.method_whitelist = ['cmd']
+        expect(drb.method_whitelist).to eql(Set['cmd'])
+        expect { drb.method_whitelist = [] }.to raise_error(ArgumentError)
+        expect(drb.method_whitelist).to eql(Set['cmd'])
+      end
+    end
+
+    describe "process_request" do
+      it "calls a whitelisted method" do
+        response, error_code = process(json_drb, 'greet', keyword_params: { 'name' => 'world' })
+        expect(response['result']).to eql('hello world')
+        expect(error_code).to be_nil
+      end
+
+      it "matches whitelisted methods case insensitively" do
+        response, _error_code = process(json_drb, 'GREET', keyword_params: { 'name' => 'world' })
+        expect(response['result']).to eql('hello world')
+      end
+
+      it "rejects a method that exists on the object but is not whitelisted" do
+        response, error_code = process(json_drb, 'secret')
+        expect(response['error']['message']).to eql('Cannot call unauthorized methods')
+        expect(error_code).to eql(JsonRpcError::ErrorCode::OTHER_ERROR)
+      end
+
+      # These are all public methods on Object (several added by ActiveSupport)
+      # which allow arbitrary code execution or leak server state. The whitelist
+      # is what blocks them; there is no blocklist to keep in sync.
+      it "rejects reflection and code evaluation methods" do
+        %w[send __send__ public_send try try! instance_eval instance_exec class_eval
+           method instance_variable_get instance_variable_set instance_values
+           methods public_methods singleton_class extend freeze inspect to_s
+           to_yaml to_json as_json].each do |method_name|
+          response, _error_code = process(json_drb, method_name, params: ['1+1'])
+          expect(response['error']['message']).to eql('Cannot call unauthorized methods'),
+                                                  "expected #{method_name} to be rejected"
+        end
+      end
+
+      it "rejects an unknown method" do
+        response, _error_code = process(json_drb, 'does_not_exist')
+        expect(response['error']['message']).to eql('Cannot call unauthorized methods')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Makes it so JsonDRb always has to be used securely.