### PR TITLE
Harden script status

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
@@ -157,7 +157,6 @@ export default class Cable {
       return
     }
     this._recovery = setTimeout(() => {
-      this._recovery = null
       const subscriptions = [...this._subscriptions]
       if (this._cable) {
         this._cable.cable.disconnect()
@@ -171,6 +170,10 @@ export default class Cable {
           Promise.resolve(),
         )
         .catch((error) => console.error('failed to recover cable', error))
+        .finally(() => {
+          // clear recovery at the end of the callback to avoid overlapping recoveries
+          this._recovery = null
+        })
     }, RECOVERY_DELAY)
   }
   _cancelRecovery() {

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
@@ -25,19 +25,28 @@ const RECOVERY_DELAY = 1000
 // Wraps an anycable subscription so one that dies unrecoverably is replaced
 // transparently, keeping the object the caller holds valid across the swap.
 //
-// The anycable client only retries a subscribe itself when its own send fails
-// with a DisconnectedError. When the WebSocket has closed but the client hasn't
-// processed the close yet (e.g. the tab was starved of CPU long enough for the
-// server to drop the connection), the transport instead throws a plain
-// `Error('WebSocket is not connected')` from inside the protocol's subscribe
-// promise -- after it recorded the subscription as pending but before it armed
-// the timers that would expire it. The client logs "failed to subscribe", closes
-// the subscription, and leaves the pending entry behind forever, so every later
-// subscribe for that channel on that consumer is rejected with "Already
-// subscribing". Callers were left waiting on events that would never arrive --
-// Script Runner connecting to a running script, for instance, sat on
-// "Connecting..." indefinitely. Only a new consumer clears that state, so
-// recovery is handled by Cable rather than per subscription.
+// Works around an upstream bug in @anycable/core (through 1.1.6). When the
+// WebSocket has closed but the client hasn't processed the close yet (e.g. the
+// tab was starved of CPU long enough for the server to drop the connection),
+// WebSocketTransport#send throws a plain `Error('WebSocket is not connected')`
+// rather than the DisconnectedError that Cable#subscribe recognizes as "retry
+// on reconnect". It therefore takes the fatal branch instead: it logs "failed
+// to subscribe", closes the subscription and calls hub.unsubscribe, so the
+// channel is gone for good and is never re-subscribed when the connection comes
+// back. Callers were left waiting on events that would never arrive -- Script
+// Runner connecting to a running script, for instance, sat on "Connecting..."
+// indefinitely.
+//
+// Re-subscribing immediately isn't enough: ActionCableProtocol#subscribe
+// recorded the subscription as pending before that send and never removes it
+// (the ack timers are armed after the send, so nothing expires it). Until the
+// consumer processes the socket close and resets the protocol, a re-subscribe
+// for the same identifier is rejected with "Already subscribing" -- which is
+// itself a plain Error, so it kills the channel the same way. Rebuilding the
+// consumer clears that state deterministically, hence recovery lives on Cable
+// rather than on the individual subscription.
+//
+// Upstream fix submitted; this can go once the released client carries it.
 class ResilientSubscription {
   constructor(cable, channel, scope, callbacks, additionalOptions) {
     this._cable = cable

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
@@ -17,42 +17,173 @@
 
 import { createConsumer } from '@anycable/web'
 
+// How long to wait before rebuilding a consumer whose subscribe failed
+// unrecoverably. Long enough to not spin when the backend is unreachable, short
+// enough that a tool isn't visibly stuck.
+const RECOVERY_DELAY = 1000
+
+// Wraps an anycable subscription so one that dies unrecoverably is replaced
+// transparently, keeping the object the caller holds valid across the swap.
+//
+// The anycable client only retries a subscribe itself when its own send fails
+// with a DisconnectedError. When the WebSocket has closed but the client hasn't
+// processed the close yet (e.g. the tab was starved of CPU long enough for the
+// server to drop the connection), the transport instead throws a plain
+// `Error('WebSocket is not connected')` from inside the protocol's subscribe
+// promise -- after it recorded the subscription as pending but before it armed
+// the timers that would expire it. The client logs "failed to subscribe", closes
+// the subscription, and leaves the pending entry behind forever, so every later
+// subscribe for that channel on that consumer is rejected with "Already
+// subscribing". Callers were left waiting on events that would never arrive --
+// Script Runner connecting to a running script, for instance, sat on
+// "Connecting..." indefinitely. Only a new consumer clears that state, so
+// recovery is handled by Cable rather than per subscription.
+class ResilientSubscription {
+  constructor(cable, channel, scope, callbacks, additionalOptions) {
+    this._cable = cable
+    this._channel = channel
+    this._scope = scope
+    this._callbacks = callbacks
+    this._additionalOptions = additionalOptions
+    this._subscription = null
+    this._unsubscribed = false
+  }
+
+  get identifier() {
+    return this._subscription?.identifier
+  }
+
+  perform(action, data) {
+    return this._subscription?.perform(action, data)
+  }
+
+  send(data) {
+    return this._subscription?.send(data)
+  }
+
+  unsubscribe() {
+    this._unsubscribed = true
+    this._cable._forget(this)
+    return this._subscription?.unsubscribe()
+  }
+
+  _subscribe(consumer) {
+    // The token refresh in Cable._resubscribe is async, so the caller can
+    // unsubscribe before we ever get here.
+    if (this._unsubscribed) {
+      return
+    }
+    this._subscription = consumer.subscriptions.create(
+      {
+        channel: this._channel,
+        token: localStorage.openc3Token,
+        ...this._additionalOptions,
+      },
+      {
+        ...this._callbacks,
+        disconnected: (data) => {
+          // allowReconnect false means the client has given up on this
+          // subscription: either we unsubscribed it (nothing to do) or the
+          // subscribe failed unrecoverably and the consumer needs rebuilding.
+          if (!this._unsubscribed && data?.allowReconnect === false) {
+            this._cable._scheduleRecovery()
+          }
+          this._callbacks.disconnected?.(data)
+        },
+      },
+    )
+  }
+}
+
 export default class Cable {
   constructor(url = '/openc3-api/cable') {
     this._cable = null
     this._url = url
+    this._subscriptions = new Set()
+    this._recovery = null
   }
   disconnect() {
+    this._cancelRecovery()
+    this._subscriptions.clear()
     if (this._cable) {
       this._cable.cable.disconnect()
       this._cable = null
     }
   }
   createSubscription(channel, scope, callbacks = {}, additionalOptions = {}) {
+    const subscription = new ResilientSubscription(
+      this,
+      channel,
+      scope,
+      callbacks,
+      additionalOptions,
+    )
+    this._subscriptions.add(subscription)
+    return this._resubscribe(subscription).then(() => subscription)
+  }
+  // Subscribe (or re-subscribe) on this cable's consumer, refreshing the auth
+  // token first since the token is passed as a subscription param and a retry
+  // can happen much later than the original subscribe.
+  _resubscribe(subscription) {
+    // Create the consumer up front (createConsumer is lazy -- no socket is
+    // opened until the first subscribe) so concurrent calls can't each see a
+    // null _cable and build a consumer of their own.
+    if (this._cable == null) {
+      // Token is passed per-subscription as `params[:token]` (see
+      // ApplicationCable::Channel#authenticate_subscription!) so it stays out
+      // of the WebSocket URL — and therefore out of browser history and proxy
+      // logs.
+      const finalUrl = new URL(this._url, document.baseURI)
+      finalUrl.searchParams.set('scope', subscription._scope)
+      this._cable = createConsumer(finalUrl.href)
+    }
     return OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity).then(
       (refreshed) => {
         if (refreshed) {
           OpenC3Auth.setTokens()
         }
-        if (this._cable == null) {
-          // Token is passed per-subscription as `params[:token]` (see
-          // ApplicationCable::Channel#authenticate_subscription!) so it stays
-          // out of the WebSocket URL — and therefore out of browser history
-          // and proxy logs.
-          const finalUrl = new URL(this._url, document.baseURI)
-          finalUrl.searchParams.set('scope', scope)
-          this._cable = createConsumer(finalUrl.href)
+        if (this._cable) {
+          subscription._subscribe(this._cable)
         }
-        return this._cable.subscriptions.create(
-          {
-            channel,
-            token: localStorage.openc3Token,
-            ...additionalOptions,
-          },
-          callbacks,
-        )
       },
     )
+  }
+  // Replace the consumer and re-subscribe everything on it. Dropping the old
+  // consumer is what clears the leaked pending subscription (see
+  // ResilientSubscription), and reconnecting from scratch rather than resuming
+  // the session makes the server re-run each channel's subscribed callback.
+  _scheduleRecovery() {
+    if (this._recovery) {
+      return
+    }
+    this._recovery = setTimeout(() => {
+      this._recovery = null
+      const subscriptions = [...this._subscriptions]
+      if (this._cable) {
+        this._cable.cable.disconnect()
+        this._cable = null
+      }
+      // Sequentially so the first one creates the consumer the rest reuse
+      subscriptions
+        .reduce(
+          (chain, subscription) =>
+            chain.then(() => this._resubscribe(subscription)),
+          Promise.resolve(),
+        )
+        .catch((error) => console.error('failed to recover cable', error))
+    }, RECOVERY_DELAY)
+  }
+  _cancelRecovery() {
+    if (this._recovery) {
+      clearTimeout(this._recovery)
+      this._recovery = null
+    }
+  }
+  _forget(subscription) {
+    this._subscriptions.delete(subscription)
+    if (this._subscriptions.size === 0) {
+      this._cancelRecovery()
+    }
   }
   recordPing() {
     // Noop with Anycable

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
@@ -104,6 +104,13 @@ export default class Cable {
   }
   disconnect() {
     this._cancelRecovery()
+    // Mark the subscriptions dead before dropping them. Closing the consumer
+    // rejects any subscribe still waiting on its ack, which surfaces as
+    // disconnected with allowReconnect false -- that must not schedule a
+    // recovery, since we just cancelled one and the consumer is going away.
+    this._subscriptions.forEach((subscription) => {
+      subscription._unsubscribed = true
+    })
     this._subscriptions.clear()
     if (this._cable) {
       this._cable.cable.disconnect()

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -2276,6 +2276,9 @@ export default {
       // to a running script (which reuses the component) could carry over a
       // stale activePromptId and skip showing the dialog (see handleScript).
       this.activePromptId = ''
+      // `connected` below is called with `this` bound to the subscription, so
+      // hold onto the component to reach its methods from there.
+      const self = this
       const subscription = await this.cable.createSubscription(
         'RunningScriptChannel',
         window.openc3Scope,
@@ -2295,7 +2298,7 @@ export default {
             // a resumed session doesn't re-run it. Re-seed from the script's
             // status so the display can't be left showing a stale state.
             if (data?.reconnected) {
-              this.refreshScriptStatus()
+              self.refreshScriptStatus()
             }
           },
           received: (data) => this.received(data),

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -2970,16 +2970,17 @@ export default {
         )
         this.file.show = false // Close the dialog immediately to avoid race condition
       }
-      // We have to wait for all the upload API requests to finish before notifying the prompt
-      Promise.all(promises)
-        .then(() => respond(fileNames))
-        .catch((error) => {
-          // An upload failed. Answer with cancel so the running script
-          // doesn't wait forever on a reply that will never come (repeats
-          // of the same prompt_id are ignored, so nothing would recover).
-          respond('COSMOS__CANCEL')
-          this.setError(`File upload failed: ${error}`)
-        })
+      try {
+        // We have to wait for all the upload API requests to finish before notifying the prompt
+        await Promise.all(promises)
+        respond(fileNames)
+      } catch (error) {
+        // An upload failed. Answer with cancel so the running script
+        // doesn't wait forever on a reply that will never come (repeats
+        // of the same prompt_id are ignored, so nothing would recover).
+        respond('COSMOS__CANCEL')
+        this.setError(`File upload failed: ${error}`)
+      }
     },
     bucketDialogCallback(response) {
       this.bucket.show = false

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1990,12 +1990,18 @@ export default {
       return Api.get(`/script-api/running-script/${id}`)
         .then((response) => {
           if (response.data) {
-            let state = response.data.state
-            if (!TERMINAL_STATES.has(state)) {
+            if (!TERMINAL_STATES.has(response.data.state)) {
               this.filename = response.data.filename
               this.tryLoadSuites(response)
               this.initScriptStart()
               this.scriptStart(id)
+              // Show the state we just fetched rather than waiting on the first
+              // channel event. A script paused at an error or a prompt only
+              // republishes its state about once a second, and a script that is
+              // simply running between lines may not publish for even longer, so
+              // without this the user stares at "Connecting..." with no idea
+              // what the script is doing.
+              this.applyScriptStatus(response.data)
             } else {
               this.$notify.caution({
                 title: `Script ${id} has already completed`,
@@ -2282,8 +2288,15 @@ export default {
           // backend is told we are ready again. See RunningScriptChannel#ready.
           // Not an arrow function: `this` must be the subscription so perform()
           // targets this channel.
-          connected() {
+          connected(data) {
             this.perform('ready')
+            // A reconnect can silently cost us events: the channel's backlog
+            // replay only runs when the server processes a fresh subscribe, and
+            // a resumed session doesn't re-run it. Re-seed from the script's
+            // status so the display can't be left showing a stale state.
+            if (data?.reconnected) {
+              this.refreshScriptStatus()
+            }
           },
           received: (data) => this.received(data),
         },
@@ -2298,6 +2311,41 @@ export default {
         return
       }
       this.subscription = subscription
+    },
+    // Update the display from a script status (GET running-script/:id) rather
+    // than a channel event. The state field is otherwise only ever set from
+    // channel events, so any gap in the event stream leaves it stale.
+    applyScriptStatus(data) {
+      const filename = data.current_filename || data.filename
+      if (!filename) {
+        return
+      }
+      // Reuse processLine so the state, markers and button enable/disable all
+      // follow the same rules they would for a real 'line' event.
+      this.processLine({
+        type: 'line',
+        filename: filename,
+        line_no: data.line_no,
+        state: data.state,
+      })
+      if (TERMINAL_STATES.includes(data.state)) {
+        this.scriptComplete()
+      }
+    },
+    async refreshScriptStatus() {
+      const id = this.scriptId
+      if (!id) {
+        return
+      }
+      try {
+        const response = await Api.get(`/script-api/running-script/${id}`)
+        // Ignore a response that lost the race with a switch to another script
+        if (response.data && this.scriptId === id) {
+          this.applyScriptStatus(response.data)
+        }
+      } catch (error) {
+        // Nothing to seed from -- leave the display as is
+      }
     },
     async scriptComplete() {
       // Supersede any scriptStart still awaiting its subscription. Must

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -2331,7 +2331,7 @@ export default {
         line_no: data.line_no,
         state: data.state,
       })
-      if (TERMINAL_STATES.includes(data.state)) {
+      if (TERMINAL_STATES.has(data.state)) {
         this.scriptComplete()
       }
     },

--- a/openc3-cosmos-script-runner-api/app/channels/running_script_channel.rb
+++ b/openc3-cosmos-script-runner-api/app/channels/running_script_channel.rb
@@ -35,12 +35,12 @@ class RunningScriptChannel < ApplicationCable::Channel
     # output/state still receives what it missed (the raw anycable broadcast is
     # pub/sub with no history, which left state stuck on "Connecting..." or
     # output as "No data").
-    subscription_key = "running-script-#{uuid}"
-    stream_from subscription_key
+    key = subscription_key()
+    stream_from key
     # Guard against a duplicate broadcaster for this key (e.g. if subscribed
     # fires again before unsubscribed) which would deliver every event twice.
-    @@broadcasters[subscription_key]&.stop
-    @@broadcasters.delete(subscription_key)
+    @@broadcasters[key]&.stop
+    @@broadcasters.delete(key)
 
     # Deliver the existing backlog via transmit() rather than a stream
     # broadcast. transmit is returned with the subscription confirmation and
@@ -80,10 +80,10 @@ class RunningScriptChannel < ApplicationCable::Channel
     # has round-tripped, which guarantees the stream is registered. The delay is
     # only the fallback for legacy clients that never perform 'ready'.
     begin
-      broadcaster = RunningScriptReplayThread.new(subscription_key, params[:id], last_offset,
+      broadcaster = RunningScriptReplayThread.new(key, params[:id], last_offset,
                                                   arm_delay: LEGACY_ARM_DELAY)
       broadcaster.start
-      @@broadcasters[subscription_key] = broadcaster
+      @@broadcasters[key] = broadcaster
     rescue StandardError => e
       # Best-effort: a replay failure must not break the subscription.
       OpenC3::Logger.warn("running_script replay start failed: #{e.message}") rescue nil
@@ -101,11 +101,27 @@ class RunningScriptChannel < ApplicationCable::Channel
   end
 
   def unsubscribed
-    subscription_key = "running-script-#{uuid}"
-    if @@broadcasters[subscription_key]
-      stop_stream_from subscription_key
-      @@broadcasters[subscription_key].stop
-      @@broadcasters.delete(subscription_key)
+    key = subscription_key()
+    if @@broadcasters[key]
+      stop_stream_from key
+      @@broadcasters[key].stop
+      @@broadcasters.delete(key)
     end
+  end
+
+  private
+
+  # The stream (and @@broadcasters) key must identify this subscription, not
+  # just its connection. `uuid` is an identified_by on the connection, so it is
+  # shared by every RunningScriptChannel subscription in the same browser tab.
+  # Keying on it alone meant tearing down one subscription stopped the replay
+  # thread of another script's subscription on the same connection -- which left
+  # that script's Script Runner stuck on "Connecting..." with no live events.
+  # AnyCable is stateless between commands so this has to be derived, not
+  # generated: (connection, script id) is unique because the client dedupes
+  # subscriptions by identifier, so a connection only ever has one subscription
+  # per script.
+  def subscription_key
+    "running-script-#{uuid}-#{params[:id]}"
   end
 end

--- a/openc3-cosmos-script-runner-api/app/channels/running_script_channel.rb
+++ b/openc3-cosmos-script-runner-api/app/channels/running_script_channel.rb
@@ -18,14 +18,14 @@
 class RunningScriptChannel < ApplicationCable::Channel
   @@broadcasters = {}
 
-  # How long the live event broadcaster waits before its first read when the
-  # client has not declared itself ready to stream events via the 'ready'
-  # action. Covers legacy clients (older CLI gems / frontend bundles /
-  # third-party websocket consumers) that only subscribe and read: their events
-  # are delayed by up to this much at attach, in exchange for not being dropped
-  # by the stream-registration race described below. Current clients perform
-  # 'ready' after the subscription confirmation and get events immediately.
-  LEGACY_ARM_DELAY = 1.0
+  # Upper bound on how long the live event broadcaster waits for the client's
+  # 'ready' before starting to read anyway. This is the correctness floor for
+  # the stream-registration race described in #subscribed, not a legacy-client
+  # allowance: it also covers a 'ready' that never arrives because the client
+  # died or the perform was lost. Every in-tree client (ScriptRunner.vue, the
+  # Ruby and Python WebSocketApi) performs 'ready', so in practice this only
+  # costs latency for third-party consumers that just subscribe and read.
+  ARM_TIMEOUT = 1.0
 
   def subscribed
     # Defensive: if the auth before_subscribe callback rejected us, skip work.
@@ -74,14 +74,14 @@ class RunningScriptChannel < ApplicationCable::Channel
     # race the gateway registering our stream_from above and be silently
     # dropped. That loses any events written between the xrange and the thread's
     # first read, and a script that then goes quiet (e.g. parked in a wait) never
-    # publishes again -- leaving the client stuck on "Connecting...". Current
-    # clients declare themselves ready to stream events immediately via the
-    # 'ready' action (see #ready), performed after the subscription confirmation
-    # has round-tripped, which guarantees the stream is registered. The delay is
-    # only the fallback for legacy clients that never perform 'ready'.
+    # publishes again -- leaving the client stuck on "Connecting...". Clients
+    # declare themselves ready to stream events via the 'ready' action (see
+    # #ready), performed after the subscription confirmation has round-tripped,
+    # which guarantees the stream is registered. ARM_TIMEOUT bounds the wait for
+    # a 'ready' that never comes.
     begin
       broadcaster = RunningScriptReplayThread.new(key, params[:id], last_offset,
-                                                  arm_delay: LEGACY_ARM_DELAY)
+                                                  arm_delay: ARM_TIMEOUT)
       broadcaster.start
       @@broadcasters[key] = broadcaster
     rescue StandardError => e
@@ -93,11 +93,11 @@ class RunningScriptChannel < ApplicationCable::Channel
   # Channel action performed by the client to declare that it is ready to
   # stream events: it has received the subscription confirmation, so by now the
   # gateway has registered this subscription's stream and live broadcasts can no
-  # longer be dropped. Skips the legacy delay and starts streaming right away.
+  # longer be dropped. Skips the remaining ARM_TIMEOUT and streams right away.
   # No-ops if the script already completed (no broadcaster) or on duplicate
   # performs.
   def ready
-    @@broadcasters["running-script-#{uuid}"]&.arm
+    @@broadcasters[subscription_key()]&.arm
   end
 
   def unsubscribed

--- a/openc3-cosmos-script-runner-api/app/models/running_script_replay_thread.rb
+++ b/openc3-cosmos-script-runner-api/app/models/running_script_replay_thread.rb
@@ -26,8 +26,8 @@ require 'openc3'
 # fast-completing script's output used to be lost. For the same reason the
 # first read is deferred: current clients declare themselves ready to stream
 # events via the 'ready' channel action after their subscription confirmation
-# round-trips (proving the stream is registered), which arm()s us; legacy
-# clients that never perform 'ready' fall back to a fixed arm_delay. The
+# round-trips (proving the stream is registered), which arm()s us. A 'ready'
+# that never arrives is bounded by arm_delay. The
 # channel reads the backlog up to
 # @start_offset and starts us there, so there is no gap and no duplicate
 # delivery. Modeled on MessagesThread/TopicsThread in cmd-tlm-api.
@@ -44,7 +44,7 @@ class RunningScriptReplayThread
     # sooner. Broadcasts issued before the gateway registers the
     # subscriber's stream are silently dropped; current clients report ready
     # to stream events as soon as their subscription confirmation round-trips
-    # (proving registration), while legacy clients fall back to the fixed delay.
+    # (proving registration); arm_delay bounds a 'ready' that never arrives.
     @arm_delay = arm_delay
     @armed = arm_delay <= 0.0
     @cancel_thread = false

--- a/openc3-cosmos-script-runner-api/spec/channels/running_script_channel_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/channels/running_script_channel_spec.rb
@@ -15,7 +15,9 @@ require 'rails_helper'
 
 RSpec.describe RunningScriptChannel, type: :channel do
   let(:uuid) { 'test-uuid' }
-  let(:subscription_key) { "running-script-#{uuid}" }
+  # Keyed by (connection, script id) -- not connection alone -- so tearing down
+  # one script's subscription can't stop another's replay thread
+  let(:subscription_key) { "running-script-#{uuid}-42" }
   let(:broadcaster) { instance_double(RunningScriptReplayThread, start: nil, arm: nil, stop: nil) }
 
   before(:each) do
@@ -40,7 +42,7 @@ RSpec.describe RunningScriptChannel, type: :channel do
   end
 
   describe '#subscribed' do
-    it 'transmits the backlog and starts streaming live events with the legacy delay' do
+    it 'transmits the backlog and starts streaming live events bounded by the arm timeout' do
       backlog({ 'type' => 'line', 'line_no' => 1 }, { 'type' => 'output', 'line' => 'hi' })
       subscribe id: '42'
       expect(subscription).to be_confirmed
@@ -49,10 +51,10 @@ RSpec.describe RunningScriptChannel, type: :channel do
         { 'type' => 'output', 'line' => 'hi' },
       ])
       # Streaming must start strictly after the transmitted backlog (no gap, no
-      # duplicates) and stay unarmed for up to LEGACY_ARM_DELAY unless the
+      # duplicates) and stay unarmed for up to ARM_TIMEOUT unless the
       # client performs 'ready'
       expect(RunningScriptReplayThread).to have_received(:new).with(
-        subscription_key, '42', '101-0', arm_delay: RunningScriptChannel::LEGACY_ARM_DELAY
+        subscription_key, '42', '101-0', arm_delay: RunningScriptChannel::ARM_TIMEOUT
       )
       expect(broadcaster).to have_received(:start)
     end
@@ -76,7 +78,7 @@ RSpec.describe RunningScriptChannel, type: :channel do
   end
 
   describe '#ready' do
-    it 'starts streaming events without waiting out the legacy delay' do
+    it 'starts streaming events without waiting out the arm timeout' do
       backlog({ 'type' => 'line', 'line_no' => 1 })
       subscribe id: '42'
       perform :ready

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_replay_thread_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_replay_thread_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe RunningScriptReplayThread, type: :model do
       expect(wait_for_read(1.0)).not_to be_nil
     end
 
-    it 'falls back to reading after arm_delay for legacy clients that never report ready' do
+    it 'falls back to reading after arm_delay when ready never arrives' do
       allow(OpenC3::Topic).to receive(:read_topics) do
         reads << Time.now
         sleep 0.05

--- a/playwright/tests/script-runner/api.s.spec.ts
+++ b/playwright/tests/script-runner/api.s.spec.ts
@@ -151,7 +151,7 @@ test('runs a script', async ({ page, utils }) => {
       .map((item) => parseInt(item.name, 10))
     return Math.max(...ids).toString() // ids increase, so ours is the largest
   })
-  expect(scriptId).toMatch(/^\d+$/)
+  expect(scriptId, 'no running disconnect.rb script found via /script-api/running-script').toMatch(/^\d+$/)
 
   await page.locator('[data-test="script-runner-script"]').click()
   await page.getByText('Execution Status').click()

--- a/playwright/tests/script-runner/api.s.spec.ts
+++ b/playwright/tests/script-runner/api.s.spec.ts
@@ -133,20 +133,43 @@ test('runs a script', async ({ page, utils }) => {
     },
   )
 
+  // Ask the API which script the parent just launched instead of assuming it is
+  // the first disconnect.rb row. The table is unsorted, shows 10 rows per page
+  // and refreshes itself every 5 seconds, and a failed earlier run can leave its
+  // own disconnect.rb sitting at an error, so "first row mentioning the
+  // filename" is neither guaranteed to be on the page nor to be this script.
+  const scriptId = await page.evaluate(async () => {
+    const response = await fetch(
+      '/script-api/running-script?scope=DEFAULT&limit=100',
+      { headers: { Authorization: localStorage.openc3Token } },
+    )
+    const { items } = (await response.json()) as {
+      items: { name: string; filename: string }[]
+    }
+    const ids = items
+      .filter((item) => item.filename === 'INST/procedures/disconnect.rb')
+      .map((item) => parseInt(item.name, 10))
+    return Math.max(...ids).toString() // ids increase, so ours is the largest
+  })
+  expect(scriptId).toMatch(/^\d+$/)
+
   await page.locator('[data-test="script-runner-script"]').click()
   await page.getByText('Execution Status').click()
   await utils.sleep(1000)
-  await page.getByText('Running Scripts').click()
+  await page.getByRole('tab', { name: 'Running Scripts' }).click()
   await expect(
     page.locator('[data-test="running-scripts"] thead').getByText('Connect'),
   ).toBeVisible()
-  await page
-    .locator(
-      '[data-test="running-scripts"] tr:has-text("INST/procedures/disconnect.rb")',
-    )
-    .first()
-    .getByRole('button', { name: 'Connect' })
-    .click()
+  // Search keeps our script on the first page, and identifying its row by id
+  // (rendered as a button in the Id column) means the 5 second refresh can't
+  // shift another script's Connect button under the click.
+  await page.locator('[data-test=running-search] input').fill(scriptId)
+  const scriptRow = page
+    .locator('[data-test="running-scripts"] tbody tr')
+    .filter({ has: page.getByRole('button', { name: scriptId, exact: true }) })
+    .filter({ visible: true })
+  await expect(scriptRow).toHaveCount(1)
+  await scriptRow.getByRole('button', { name: 'Connect' }).click()
 
   await expect(page.locator('[data-test=state] input')).toHaveValue('error', {
     timeout: 20000,


### PR DESCRIPTION
"runs a script" test in Playwright was flaky, intent of this PR is to fix that -- Claude found ways to improve the actual test code and the UI logic, as well as  issues with web socket subscription errors and stream keys