### PR TITLE
fix(settings): store system_health setting as JSON

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/VersionHistoryDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/VersionHistoryDialog.vue
@@ -61,7 +61,12 @@
                 :data-test="`version-${versions.length - idx}`"
                 @click="selectVersion(v.version_id)"
               >
-                <v-tooltip activator="parent" location="top" :open-delay="500">
+                <v-tooltip
+                  activator="parent"
+                  location="top"
+                  :open-delay="500"
+                  content-class="version-tooltip"
+                >
                   <span style="white-space: pre-line">{{
                     fullLabel(v, idx)
                   }}</span>
@@ -77,6 +82,7 @@
                     v-if="v.source === 'plugin-upgrade'"
                     :open-delay="600"
                     location="top"
+                    content-class="version-tooltip"
                   >
                     <template #activator="{ props: tt }">
                       <v-chip
@@ -102,6 +108,7 @@
                     v-if="idx !== versions.length - 1"
                     :open-delay="600"
                     location="top"
+                    content-class="version-tooltip"
                   >
                     <template #activator="{ props: tt }">
                       <v-btn
@@ -248,6 +255,13 @@ export default {
       diffLoading: false,
       differ: null,
       restoringVersionId: null,
+      // Bumped by every render request. renderView and renderDiff both await
+      // network fetches, so a newer request can complete while an older one is
+      // still in flight -- the older one then creates its editor in the shared
+      // container and stomps the newer content (a stale diff editor showing up
+      // underneath a "Viewing" header). Each render captures the token and
+      // bails after every await once it is no longer the current one.
+      renderToken: 0,
     }
   },
   computed: {
@@ -397,13 +411,17 @@ export default {
     },
     async renderView() {
       if (!this.selectedVersionId) return
+      const token = ++this.renderToken
       this.diffLoading = true
       this.teardownDiffer()
       try {
         const body = await this.fetchVersionBody(this.selectedVersionId)
+        if (token !== this.renderToken) return
         await this.$nextTick()
+        if (token !== this.renderToken) return
         this.diffLoading = false
         await this.$nextTick()
+        if (token !== this.renderToken) return
         if (this.$refs.differContainer) {
           const language = this.monacoLanguage
           const stamp = Date.now()
@@ -430,6 +448,7 @@ export default {
           this.differ = editor
         }
       } catch ({ response }) {
+        if (token !== this.renderToken) return
         this.diffLoading = false
         this.$notify.caution({
           title: 'Failed to load version',
@@ -439,6 +458,7 @@ export default {
     },
     async renderDiff() {
       if (!this.selectedVersionId || !this.diffBaseVersionId) return
+      const token = ++this.renderToken
       this.diffLoading = true
       this.teardownDiffer()
       try {
@@ -446,9 +466,12 @@ export default {
           this.fetchVersionBody(this.diffBaseVersionId),
           this.fetchVersionBody(this.selectedVersionId),
         ])
+        if (token !== this.renderToken) return
         await this.$nextTick()
+        if (token !== this.renderToken) return
         this.diffLoading = false
         await this.$nextTick()
+        if (token !== this.renderToken) return
         if (this.$refs.differContainer) {
           const language = this.monacoLanguage
           // markRaw is critical. Vue 3's Options API wraps data() refs in
@@ -496,6 +519,7 @@ export default {
           this.differ = editor
         }
       } catch ({ response }) {
+        if (token !== this.renderToken) return
         this.diffLoading = false
         this.$notify.caution({
           title: 'Failed to load version',
@@ -591,6 +615,14 @@ export default {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+/* This tooltip covers the row above its activator, and during the scale
+   transition its overlay still takes pointer events -- clicks on the
+   neighboring version row get swallowed. The tooltip is display-only, so opt
+   its whole subtree out of hit testing. */
+:global(.version-tooltip),
+:global(.version-tooltip *) {
+  pointer-events: none !important;
 }
 .differ-container {
   flex: 1 1 auto;

--- a/openc3/lib/openc3/migrations/20260731000000_system_health_json.rb
+++ b/openc3/lib/openc3/migrations/20260731000000_system_health_json.rb
@@ -1,0 +1,41 @@
+require 'json'
+require 'openc3/utilities/local_mode'
+require 'openc3/utilities/migration'
+require 'openc3/models/scope_model'
+require 'openc3/models/setting_model'
+
+module OpenC3
+  # The system_health setting was originally stored as a Ruby Hash. Local mode
+  # writes settings to disk with File.write and reads them back as a String, so
+  # the Hash round tripped into a Ruby inspect String which nothing can parse.
+  # Store it as a JSON string like every other setting and repair existing data.
+  class SystemHealthJson < Migration
+    def self.run
+      setting = SettingModel.get(name: 'system_health')
+      data = repair(setting && setting['data'])
+      SettingModel.set({ name: 'system_health', data: JSON.generate(data) }, scope: 'DEFAULT')
+      # Repair the local mode file as well or sync_settings puts the bad data back
+      LocalMode.save_setting('DEFAULT', 'system_health', JSON.generate(data))
+    end
+
+    # @return [Hash] the existing settings if they can be recovered, otherwise defaults
+    def self.repair(data)
+      return ScopeModel::SYSTEM_HEALTH_DEFAULTS if data.nil?
+      return data if Hash === data
+      return ScopeModel::SYSTEM_HEALTH_DEFAULTS unless String === data
+      begin
+        parsed = JSON.parse(data)
+      rescue JSON::ParserError
+        # Ruby inspect format, e.g. {"cpu" => {"redThreshold" => 90, ... => nil}}
+        # Ruby 3.3 and earlier had no spaces around the rocket. All the values are
+        # numbers, booleans, or nil so there's nothing to accidentally rewrite.
+        parsed = JSON.parse(data.gsub(/\s*=>\s*/, ': ').gsub(/\bnil\b/, 'null')) rescue nil
+      end
+      Hash === parsed ? parsed : ScopeModel::SYSTEM_HEALTH_DEFAULTS
+    end
+  end
+end
+
+unless ENV['OPENC3_NO_MIGRATE']
+  OpenC3::SystemHealthJson.run
+end

--- a/openc3/lib/openc3/models/scope_model.rb
+++ b/openc3/lib/openc3/models/scope_model.rb
@@ -43,6 +43,38 @@ module OpenC3
   class ScopeModel < Model
     PRIMARY_KEY = "openc3_scopes"
 
+    # Default thresholds used by the System Health tool and the metrics
+    # microservices. Stored in the 'system_health' setting as a JSON string.
+    SYSTEM_HEALTH_DEFAULTS = {
+      "cpu" => {
+        "redThreshold" => 90.0,
+        "yellowThreshold" => 80.0,
+        "snoozeMinutes" => 15,
+        "lastTriggerTimeRed" => nil,  # timestamp or nil
+        "lastTriggerTimeYellow" => nil,  # timestamp or nil
+        "sustainedSeconds" => 15
+      },
+      "memory" => {
+        "redThreshold" => 90.0,
+        "yellowThreshold" => 80.0,
+        "snoozeMinutes" => 15,
+        "lastTriggerTimeRed" => nil,  # timestamp or nil
+        "lastTriggerTimeYellow" => nil,  # timestamp or nil
+        "sustainedSeconds" => 15
+      },
+      "disk" => {
+        "redThreshold" => 90.0,
+        "yellowThreshold" => 80.0,
+        "snoozeMinutes" => 720,  # 12 hours
+        "lastTriggerTimeRed" => nil,  # timestamp or nil
+        "lastTriggerTimeYellow" => nil,  # timestamp or nil
+        "sustainedSeconds" => 60
+      },
+      "global" => {
+        "enableAlerts" => true
+      }
+    }
+
     attr_accessor :children
     attr_accessor :text_log_cycle_time
     attr_accessor :text_log_cycle_size
@@ -407,36 +439,8 @@ module OpenC3
       SettingModel.set({name: "news_feed", data: true}, scope: @scope)
 
       setting = SettingModel.get(name: "system_health")
-      system_health_data = {
-        "cpu" => {
-          "redThreshold" => 90.0,
-          "yellowThreshold" => 80.0,
-          "snoozeMinutes" => 15,
-          "lastTriggerTimeRed" => nil,  # timestamp or nil
-          "lastTriggerTimeYellow" => nil,  # timestamp or nil
-          "sustainedSeconds" => 15
-        },
-        "memory" => {
-          "redThreshold" => 90.0,
-          "yellowThreshold" => 80.0,
-          "snoozeMinutes" => 15,
-          "lastTriggerTimeRed" => nil,  # timestamp or nil
-          "lastTriggerTimeYellow" => nil,  # timestamp or nil
-          "sustainedSeconds" => 15
-        },
-        "disk" => {
-          "redThreshold" => 90.0,
-          "yellowThreshold" => 80.0,
-          "snoozeMinutes" => 720,  # 12 hours
-          "lastTriggerTimeRed" => nil,  # timestamp or nil
-          "lastTriggerTimeYellow" => nil,  # timestamp or nil
-          "sustainedSeconds" => 60
-        },
-        "global" => {
-          "enableAlerts" => true
-        }
-      }
-      SettingModel.set({name: "system_health", data: system_health_data}, scope: "DEFAULT") unless setting
+      # Settings are stored as JSON strings
+      SettingModel.set({name: "system_health", data: JSON.generate(SYSTEM_HEALTH_DEFAULTS)}, scope: "DEFAULT") unless setting
     end
   end
 end

--- a/openc3/lib/openc3/utilities/local_mode.rb
+++ b/openc3/lib/openc3/utilities/local_mode.rb
@@ -485,7 +485,10 @@ module OpenC3
       config_path = "#{OPENC3_LOCAL_MODE_PATH}/#{scope}/settings/#{name}.json"
       return unless File.expand_path(config_path).start_with?(OPENC3_LOCAL_MODE_PATH)
       FileUtils.mkdir_p(File.dirname(config_path))
-      # Anything can be stored as a setting so write it out directly
+      # Anything can be stored as a setting. Strings are written directly since
+      # they're already the serialized form. Anything else is written as JSON so
+      # sync_settings can read it back rather than a Ruby inspect string.
+      data = JSON.generate(data.as_json(:allow_nan => true)) unless String === data
       File.write(config_path, data)
     end
 

--- a/openc3/spec/migrations/system_health_json_spec.rb
+++ b/openc3/spec/migrations/system_health_json_spec.rb
@@ -1,0 +1,59 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require 'spec_helper'
+ENV['OPENC3_NO_MIGRATE'] = 'true'
+require 'openc3/migrations/20260731000000_system_health_json'
+
+module OpenC3
+  describe SystemHealthJson do
+    before(:each) do
+      mock_redis()
+    end
+
+    describe "repair" do
+      it "returns the defaults if there is no setting" do
+        expect(SystemHealthJson.repair(nil)).to eq(ScopeModel::SYSTEM_HEALTH_DEFAULTS)
+      end
+
+      it "returns a Hash stored by older versions" do
+        hash = {"cpu" => {"redThreshold" => 95.0}}
+        expect(SystemHealthJson.repair(hash)).to eq(hash)
+      end
+
+      it "parses a JSON String" do
+        hash = {"cpu" => {"redThreshold" => 95.0}}
+        expect(SystemHealthJson.repair(JSON.generate(hash))).to eq(hash)
+      end
+
+      it "recovers values from a Ruby inspect String" do
+        hash = {"cpu" => {"redThreshold" => 95.0, "lastTriggerTimeRed" => nil}}
+        expect(SystemHealthJson.repair(hash.to_s)).to eq(hash)
+      end
+
+      it "returns the defaults if the data can't be understood" do
+        expect(SystemHealthJson.repair("not a setting")).to eq(ScopeModel::SYSTEM_HEALTH_DEFAULTS)
+      end
+    end
+
+    describe "run" do
+      it "stores the setting as a JSON String" do
+        SettingModel.set({name: 'system_health', data: ScopeModel::SYSTEM_HEALTH_DEFAULTS}, scope: 'DEFAULT')
+        SystemHealthJson.run()
+        data = SettingModel.get(name: 'system_health')['data']
+        expect(data).to be_a String
+        expect(JSON.parse(data)).to eq(JSON.parse(JSON.generate(ScopeModel::SYSTEM_HEALTH_DEFAULTS)))
+      end
+    end
+  end
+end

--- a/openc3/spec/utilities/local_mode_spec.rb
+++ b/openc3/spec/utilities/local_mode_spec.rb
@@ -938,6 +938,13 @@ module OpenC3
         LocalMode.save_setting('DEFAULT', 'data', JSON.generate(json, allow_nan: true))
         expect(JSON.parse(File.read("#{@tmp_dir}/DEFAULT/settings/data.json"))).to eq(json)
       end
+
+      it "should write non-String data as JSON so it can be read back" do
+        setup_sync_test()
+        hash = {"cpu" => {"redThreshold" => 90.0, "lastTriggerTimeRed" => nil}}
+        LocalMode.save_setting('DEFAULT', 'hash', hash)
+        expect(JSON.parse(File.read("#{@tmp_dir}/DEFAULT/settings/hash.json"))).to eq(hash)
+      end
     end
 
     describe "open_local_file" do


### PR DESCRIPTION
Local mode wrote non-String setting data to disk with File.write, so a Hash became a Ruby inspect string that sync_settings read back verbatim. This corrupted the system_health setting, leaving the System Health Configuration dialog empty and silently disabling threshold alerts.

Seed system_health as JSON, write non-String settings as JSON in local mode, and add a migration to repair existing installations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)