### PR TITLE
fix(python): support plain dicts for microservice custom status

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/lib/sim_inst.rb
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/lib/sim_inst.rb
@@ -452,10 +452,12 @@ module OpenC3
         end
       end
 
-      # Every 10s throw an unknown packet at the server just to demo that
-      data = Array.new(10) { rand(0..255) }.pack("C*")
-      if count_100hz % 1000 == 900
-        pending_packets << Packet.new(nil, nil, :BIG_ENDIAN, nil, data)
+      unless @quiet
+        # Every 10s throw an unknown packet at the server just to demo that
+        data = Array.new(10) { rand(0..255) }.pack("C*")
+        if count_100hz % 1000 == 900
+          pending_packets << Packet.new(nil, nil, :BIG_ENDIAN, nil, data)
+        end
       end
 
       if @variable_arrays_updated

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/lib/sim_inst.py
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/lib/sim_inst.py
@@ -454,7 +454,7 @@ class SimInst(SimulatedTarget):
                     packet.write("CcsdsLength", len(packet.buffer) - 7)
 
         # Every 10s throw an unknown packet at the server just to demo that
-        if count_100hz % 1000 == 900:
+        if not self.quiet and count_100hz % 1000 == 900:
             pending_packets.append(
                 Packet(None, None, "BIG_ENDIAN", None, random.randbytes(10))
             )

--- a/openc3/python/openc3/microservices/microservice.py
+++ b/openc3/python/openc3/microservices/microservice.py
@@ -85,7 +85,12 @@ class Microservice:
         if self.error is not None:
             json["error"] = repr(self.error)
         if self.custom is not None:
-            json["custom"] = self.custom.as_json()
+            # Ruby's Hash#as_json exists but Python dicts have no as_json
+            # so allow plain dicts (or anything JSON serializable) directly
+            if hasattr(self.custom, "as_json"):
+                json["custom"] = self.custom.as_json()
+            else:
+                json["custom"] = self.custom
         return json
 
     def __init__(self, name, is_plugin=False):

--- a/openc3/python/openc3/models/microservice_status_model.py
+++ b/openc3/python/openc3/models/microservice_status_model.py
@@ -98,5 +98,10 @@ class MicroserviceStatusModel(DbShardedModel, Model):
         if self.error is not None:
             json_data["error"] = repr(self.error)
         if self.custom is not None:
-            json_data["custom"] = self.custom.as_json()
+            # Ruby's Hash#as_json exists but Python dicts have no as_json
+            # so allow plain dicts (or anything JSON serializable) directly
+            if hasattr(self.custom, "as_json"):
+                json_data["custom"] = self.custom.as_json()
+            else:
+                json_data["custom"] = self.custom
         return json_data

--- a/openc3/python/test/microservices/test_microservice.py
+++ b/openc3/python/test/microservices/test_microservice.py
@@ -49,6 +49,24 @@ class TestMicroservice(unittest.TestCase):
                 "Microservice DEFAULT__TYPE__NAME run method returned cleanly and will now shutdown."
             )
 
+    def test_as_json_supports_custom_dict(self):
+        microservice = Microservice("DEFAULT__TYPE__CUSTOM")
+        microservice.custom = {"processed": 100, "errors": 2}
+        self.assertEqual(microservice.as_json()["custom"], {"processed": 100, "errors": 2})
+        microservice.shutdown()
+        time.sleep(0.1)
+
+    def test_as_json_supports_custom_object_with_as_json(self):
+        class CustomStatus:
+            def as_json(self):
+                return {"processed": 100}
+
+        microservice = Microservice("DEFAULT__TYPE__CUSTOM")
+        microservice.custom = CustomStatus()
+        self.assertEqual(microservice.as_json()["custom"], {"processed": 100})
+        microservice.shutdown()
+        time.sleep(0.1)
+
     def test_retries_transient_bucket_failures_on_startup(self):
         os.environ["OPENC3_MICROSERVICE_NAME"] = "DEFAULT__TYPE__NAME"
         config = {

--- a/openc3/python/test/models/test_microservice_status_model.py
+++ b/openc3/python/test/models/test_microservice_status_model.py
@@ -42,6 +42,31 @@ class TestMicroserviceStatusModel(unittest.TestCase):
         microservice2.shutdown()
         time.sleep(0.1)
 
+    def test_stores_custom_status_dict(self):
+        model = MicroserviceStatusModel(
+            "DEFAULT__TYPE__TEST",
+            state="RUNNING",
+            custom={"processed": 100, "errors": 2},
+            scope="DEFAULT",
+        )
+        self.assertEqual(model.as_json()["custom"], {"processed": 100, "errors": 2})
+        MicroserviceStatusModel.set(model.as_json(), scope="DEFAULT")
+        micro = MicroserviceStatusModel.get("DEFAULT__TYPE__TEST", scope="DEFAULT")
+        self.assertEqual(micro["custom"], {"processed": 100, "errors": 2})
+
+    def test_stores_custom_status_object_with_as_json(self):
+        class CustomStatus:
+            def as_json(self):
+                return {"processed": 100}
+
+        model = MicroserviceStatusModel(
+            "DEFAULT__TYPE__TEST",
+            state="RUNNING",
+            custom=CustomStatus(),
+            scope="DEFAULT",
+        )
+        self.assertEqual(model.as_json()["custom"], {"processed": 100})
+
     def test_get_from_correct_db_shard(self):
         MicroserviceModel("DEFAULT__TYPE__TEST", scope="DEFAULT", db_shard=0).create()
         MicroserviceStatusModel.set({"name": "DEFAULT__TYPE__TEST", "state": "RUNNING"}, scope="DEFAULT")


### PR DESCRIPTION
Microservice#as_json and MicroserviceStatusModel#as_json called custom.as_json(), a direct port of Ruby where ActiveSupport defines Hash#as_json. Python dicts have no such method, so the documented `self.custom = {...}` usage raised AttributeError and killed the status thread. Fall back to the value itself when it has no as_json, keeping objects that define one working.

Also suppress the demo unknown-packet injection in INST/INST2 when quiet.

Fixes #3615

🤖 Generated with [Claude Code](https://claude.com/claude-code)