### PR TITLE
fix(command_decom_topic): log the given value for write conversion items

### DIFF
--- a/openc3/lib/openc3/topics/command_decom_topic.rb
+++ b/openc3/lib/openc3/topics/command_decom_topic.rb
@@ -33,8 +33,10 @@ module OpenC3
       # Items with a write conversion have already been transformed by the time the
       # value lands in the buffer, so reading the buffer back does not recover what
       # the user actually commanded. Use the given values (as passed to build_cmd)
-      # for those items. Raw commands bypass the write conversions entirely so their
-      # given values are raw and must not be logged as converted.
+      # for those items. State items are the exception: the user can give either the
+      # state name or the state value, so they always read from the buffer to log the
+      # normalized state name. Raw commands bypass the write conversions entirely so
+      # their given values are raw and must not be logged as converted.
       given_values = packet.raw ? nil : packet.given_values
       given_values = given_values.transform_keys { |key| key.to_s.upcase } if given_values
       # Read additional value types using given_raw to avoid re-reading from buffer
@@ -44,7 +46,7 @@ module OpenC3
         else
           given_raw = json_hash[item.name]
           if item.write_conversion or item.states
-            if item.write_conversion and given_values and given_values.key?(item.name)
+            if item.write_conversion and !item.states and given_values and given_values.key?(item.name)
               json_hash[item.name + "__C"] = given_values[item.name]
             else
               json_hash[item.name + "__C"] = packet.read_item(item, :CONVERTED, packet.buffer, given_raw)

--- a/openc3/lib/openc3/topics/command_decom_topic.rb
+++ b/openc3/lib/openc3/topics/command_decom_topic.rb
@@ -30,13 +30,26 @@ module OpenC3
                    received_count: packet.received_count }
       # Read all RAW values at once - optimized by accessor
       json_hash = packet.read_items(packet.sorted_items)
+      # Items with a write conversion have already been transformed by the time the
+      # value lands in the buffer, so reading the buffer back does not recover what
+      # the user actually commanded. Use the given values (as passed to build_cmd)
+      # for those items. Raw commands bypass the write conversions entirely so their
+      # given values are raw and must not be logged as converted.
+      given_values = packet.raw ? nil : packet.given_values
+      given_values = given_values.transform_keys { |key| key.to_s.upcase } if given_values
       # Read additional value types using given_raw to avoid re-reading from buffer
       packet.sorted_items.each do |item|
         if item.hidden
           json_hash.delete(item.name)
         else
           given_raw = json_hash[item.name]
-          json_hash[item.name + "__C"] = packet.read_item(item, :CONVERTED, packet.buffer, given_raw) if item.write_conversion or item.states
+          if item.write_conversion or item.states
+            if item.write_conversion and given_values and given_values.key?(item.name)
+              json_hash[item.name + "__C"] = given_values[item.name]
+            else
+              json_hash[item.name + "__C"] = packet.read_item(item, :CONVERTED, packet.buffer, given_raw)
+            end
+          end
           json_hash[item.name + "__F"] = packet.read_item(item, :FORMATTED, packet.buffer, given_raw) if item.format_string
         end
       end

--- a/openc3/python/openc3/topics/command_decom_topic.py
+++ b/openc3/python/openc3/topics/command_decom_topic.py
@@ -37,11 +37,22 @@ class CommandDecomTopic(Topic):
         }
         # Read all RAW values at once - optimized by accessor
         json_hash = packet.read_items(packet.sorted_items)
+        # Items with a write conversion have already been transformed by the time the
+        # value lands in the buffer, so reading the buffer back does not recover what
+        # the user actually commanded. Use the given values (as passed to build_cmd)
+        # for those items. Raw commands bypass the write conversions entirely so their
+        # given values are raw and must not be logged as converted.
+        given_values = None if packet.raw else packet.given_values
+        if given_values:
+            given_values = {str(key).upper(): value for key, value in given_values.items()}
         # Read additional value types using given_raw to avoid re-reading from buffer
         for item in packet.sorted_items:
             given_raw = json_hash[item.name]
             if item.write_conversion or item.states:
-                json_hash[item.name + "__C"] = packet.read_item(item, "CONVERTED", packet.buffer, given_raw)
+                if item.write_conversion and given_values and item.name in given_values:
+                    json_hash[item.name + "__C"] = given_values[item.name]
+                else:
+                    json_hash[item.name + "__C"] = packet.read_item(item, "CONVERTED", packet.buffer, given_raw)
             if item.format_string:
                 json_hash[item.name + "__F"] = packet.read_item(item, "FORMATTED", packet.buffer, given_raw)
         msg_hash["json_data"] = json.dumps(json_hash, cls=JsonEncoder)

--- a/openc3/python/openc3/topics/command_decom_topic.py
+++ b/openc3/python/openc3/topics/command_decom_topic.py
@@ -40,8 +40,10 @@ class CommandDecomTopic(Topic):
         # Items with a write conversion have already been transformed by the time the
         # value lands in the buffer, so reading the buffer back does not recover what
         # the user actually commanded. Use the given values (as passed to build_cmd)
-        # for those items. Raw commands bypass the write conversions entirely so their
-        # given values are raw and must not be logged as converted.
+        # for those items. State items are the exception: the user can give either the
+        # state name or the state value, so they always read from the buffer to log the
+        # normalized state name. Raw commands bypass the write conversions entirely so
+        # their given values are raw and must not be logged as converted.
         given_values = None if packet.raw else packet.given_values
         if given_values:
             given_values = {str(key).upper(): value for key, value in given_values.items()}
@@ -49,7 +51,7 @@ class CommandDecomTopic(Topic):
         for item in packet.sorted_items:
             given_raw = json_hash[item.name]
             if item.write_conversion or item.states:
-                if item.write_conversion and given_values and item.name in given_values:
+                if item.write_conversion and not item.states and given_values and item.name in given_values:
                     json_hash[item.name + "__C"] = given_values[item.name]
                 else:
                     json_hash[item.name + "__C"] = packet.read_item(item, "CONVERTED", packet.buffer, given_raw)

--- a/openc3/python/openc3/utilities/questdb_client.py
+++ b/openc3/python/openc3/utilities/questdb_client.py
@@ -1146,6 +1146,17 @@ class QuestDBClient:
                 if item.get("states"):
                     desired_columns[f"{item_name}__C"] = "varchar"
                     self.varchar_columns[f"{table_name}__{item_name}__C"] = True
+                elif cmd_or_tlm == "CMD" and item.get("write_conversion"):
+                    # Commands log the value the user gave rather than the post write
+                    # conversion value in the buffer (see CommandDecomTopic.write_packet).
+                    # Write conversions typically take engineering units so the given
+                    # value can be a float even for an integer item. Use double so the
+                    # value isn't truncated to the item data type.
+                    if item.get("data_type") in ["STRING", "BLOCK"]:
+                        desired_columns[f"{item_name}__C"] = "varchar"
+                        self.varchar_columns[f"{table_name}__{item_name}__C"] = True
+                    else:
+                        desired_columns[f"{item_name}__C"] = "double"
                 elif item.get("read_conversion"):
                     rc = item.get("read_conversion")
                     converted_type = rc.get("converted_type") if rc else None

--- a/openc3/python/test/topics/test_command_decom_topic.py
+++ b/openc3/python/test/topics/test_command_decom_topic.py
@@ -49,18 +49,23 @@ class TestCommandDecomTopic(unittest.TestCase):
     # VALUE has a write conversion which doubles the given value so the buffer
     # never holds what the user actually commanded.
     # STATE only has states and thus reads back correctly from the buffer.
+    # BOTH has states and a write conversion and must still read back the state name.
     def _make_packet(self):
         packet = Packet("TARGET", "CMD")
         item = packet.append_item("VALUE", 16, "UINT")
         item.write_conversion = PolynomialConversion(0, 2)
         item = packet.append_item("STATE", 8, "UINT")
         item.states = {"FALSE": 0, "TRUE": 1}
+        item = packet.append_item("BOTH", 8, "UINT")
+        item.states = {"OFF": 0, "ON": 1}
+        item.write_conversion = PolynomialConversion(0, 1)
         packet.packet_time = datetime.datetime.now()
         packet.received_time = datetime.datetime.now()
         packet.received_count = 1
         packet.stored = False
         packet.write("VALUE", 5)
         packet.write("STATE", "TRUE")
+        packet.write("BOTH", "ON")
         return packet
 
     def _json_data(self, packet):
@@ -108,6 +113,15 @@ class TestCommandDecomTopic(unittest.TestCase):
         hash = self._json_data(packet)
         self.assertEqual(hash["STATE"], 1)
         self.assertEqual(hash["STATE__C"], "TRUE")
+
+    def test_reads_state_name_for_items_with_states_and_write_conversion(self):
+        # States take precedence over the write conversion so the logged value is
+        # always the normalized state name rather than whatever the user gave
+        packet = self._make_packet()
+        packet.given_values = {"BOTH": 1}
+        hash = self._json_data(packet)
+        self.assertEqual(hash["BOTH"], 1)
+        self.assertEqual(hash["BOTH__C"], "ON")
 
     def test_ignores_given_values_for_raw_commands(self):
         # Raw commands skip the write conversion so the given value is the raw value

--- a/openc3/python/test/topics/test_command_decom_topic.py
+++ b/openc3/python/test/topics/test_command_decom_topic.py
@@ -1,0 +1,121 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+import datetime
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from openc3.conversions.polynomial_conversion import PolynomialConversion
+from openc3.packets.packet import Packet
+from openc3.topics.command_decom_topic import CommandDecomTopic
+from test.test_helper import mock_redis
+
+
+class TestCommandDecomTopic(unittest.TestCase):
+    def setUp(self):
+        mock_redis(self)
+        self.captured = {}
+
+        def fake_write_topic(topic, msg_hash):
+            self.captured["topic"] = topic
+            self.captured["msg_hash"] = msg_hash
+
+        self.store_instance = MagicMock()
+        self.store_instance.write_topic.side_effect = fake_write_topic
+
+        instance_patch = patch(
+            "openc3.topics.command_decom_topic.EphemeralStoreQueued.instance",
+            return_value=self.store_instance,
+        )
+        instance_patch.start()
+        self.addCleanup(instance_patch.stop)
+
+        shard_patch = patch(
+            "openc3.topics.command_decom_topic.Store.db_shard_for_target",
+            return_value=0,
+        )
+        shard_patch.start()
+        self.addCleanup(shard_patch.stop)
+
+    # VALUE has a write conversion which doubles the given value so the buffer
+    # never holds what the user actually commanded.
+    # STATE only has states and thus reads back correctly from the buffer.
+    def _make_packet(self):
+        packet = Packet("TARGET", "CMD")
+        item = packet.append_item("VALUE", 16, "UINT")
+        item.write_conversion = PolynomialConversion(0, 2)
+        item = packet.append_item("STATE", 8, "UINT")
+        item.states = {"FALSE": 0, "TRUE": 1}
+        packet.packet_time = datetime.datetime.now()
+        packet.received_time = datetime.datetime.now()
+        packet.received_count = 1
+        packet.stored = False
+        packet.write("VALUE", 5)
+        packet.write("STATE", "TRUE")
+        return packet
+
+    def _json_data(self, packet):
+        CommandDecomTopic.write_packet(packet, scope="DEFAULT")
+        return json.loads(self.captured["msg_hash"]["json_data"])
+
+    def test_writes_to_correct_topic(self):
+        CommandDecomTopic.write_packet(self._make_packet(), scope="DEFAULT")
+        self.assertEqual(self.captured["topic"], "DEFAULT__DECOMCMD__{TARGET}__CMD")
+        msg_hash = self.captured["msg_hash"]
+        self.assertEqual(msg_hash["target_name"], "TARGET")
+        self.assertEqual(msg_hash["packet_name"], "CMD")
+        self.assertEqual(msg_hash["received_count"], 1)
+
+    def test_logs_given_value_for_write_conversion_items(self):
+        packet = self._make_packet()
+        packet.given_values = {"VALUE": 5, "STATE": "TRUE"}
+        hash = self._json_data(packet)
+        self.assertEqual(hash["VALUE"], 10)  # raw value in the buffer
+        self.assertEqual(hash["VALUE__C"], 5)  # value the user commanded
+
+    def test_matches_given_values_regardless_of_key_case(self):
+        packet = self._make_packet()
+        packet.given_values = {"value": 5}
+        hash = self._json_data(packet)
+        self.assertEqual(hash["VALUE__C"], 5)
+
+    def test_reads_converted_value_when_item_not_given(self):
+        packet = self._make_packet()
+        packet.given_values = {"STATE": "TRUE"}
+        hash = self._json_data(packet)
+        self.assertEqual(hash["VALUE__C"], 10)
+
+    def test_reads_converted_value_when_no_given_values(self):
+        packet = self._make_packet()
+        self.assertIsNone(packet.given_values)
+        hash = self._json_data(packet)
+        self.assertEqual(hash["VALUE__C"], 10)
+
+    def test_reads_converted_state_rather_than_given_value(self):
+        # The user can give either the state name or the state value so always
+        # read the state name back out of the buffer
+        packet = self._make_packet()
+        packet.given_values = {"STATE": 1}
+        hash = self._json_data(packet)
+        self.assertEqual(hash["STATE"], 1)
+        self.assertEqual(hash["STATE__C"], "TRUE")
+
+    def test_ignores_given_values_for_raw_commands(self):
+        # Raw commands skip the write conversion so the given value is the raw value
+        packet = self._make_packet()
+        packet.raw = True
+        packet.write("VALUE", 10, "RAW")
+        # Deliberately different from the buffer to prove the buffer wins
+        packet.given_values = {"VALUE": 99}
+        hash = self._json_data(packet)
+        self.assertEqual(hash["VALUE"], 10)
+        self.assertEqual(hash["VALUE__C"], 10)

--- a/openc3/python/test/utilities/test_questdb_client.py
+++ b/openc3/python/test/utilities/test_questdb_client.py
@@ -69,3 +69,61 @@ class TestBuildAggregationSelects(unittest.TestCase):
             self.assertTrue(QuestDBClient.numeric_column_type(t))
         for t in ["VARCHAR", "SYMBOL", "STRING", "BOOLEAN", "TIMESTAMP", None]:
             self.assertFalse(QuestDBClient.numeric_column_type(t))
+
+
+class TestCreateTableConvertedColumns(unittest.TestCase):
+    def setUp(self):
+        self.client = QuestDBClient()
+        self.ddl = []
+        self.client._execute_ddl = lambda sql: self.ddl.append(sql)
+        # Table doesn't exist so create_table takes the CREATE TABLE path
+        self.client._get_existing_columns = lambda table_name: None
+
+    def _create(self, item, cmd_or_tlm):
+        self.client.create_table("INST", "PKT", {"items": [item]}, cmd_or_tlm, scope="DEFAULT")
+        return "\n".join(self.ddl)
+
+    def test_commands_type_write_conversion_converted_column_as_double(self):
+        # The user given value is logged into __C and is typically engineering units
+        # (a float) even when the item itself is an integer
+        item = {
+            "name": "VALUE",
+            "data_type": "UINT",
+            "bit_size": 16,
+            "write_conversion": {"class": "PolynomialConversion"},
+        }
+        sql = self._create(item, "CMD")
+        self.assertIn('"VALUE" int', sql)
+        self.assertIn('"VALUE__C" double', sql)
+
+    def test_commands_type_string_write_conversion_converted_column_as_varchar(self):
+        item = {
+            "name": "LABEL",
+            "data_type": "STRING",
+            "bit_size": 64,
+            "write_conversion": {"class": "GenericConversion"},
+        }
+        sql = self._create(item, "CMD")
+        self.assertIn('"LABEL__C" varchar', sql)
+        self.assertTrue(self.client.varchar_columns["DEFAULT__CMD__INST__PKT__LABEL__C"])
+
+    def test_states_take_precedence_over_write_conversion(self):
+        item = {
+            "name": "STATE",
+            "data_type": "UINT",
+            "bit_size": 8,
+            "states": {"FALSE": 0, "TRUE": 1},
+            "write_conversion": {"class": "GenericConversion"},
+        }
+        sql = self._create(item, "CMD")
+        self.assertIn('"STATE__C" varchar', sql)
+
+    def test_telemetry_ignores_write_conversion(self):
+        item = {
+            "name": "VALUE",
+            "data_type": "UINT",
+            "bit_size": 16,
+            "write_conversion": {"class": "PolynomialConversion"},
+        }
+        sql = self._create(item, "TLM")
+        self.assertNotIn("VALUE__C", sql)

--- a/openc3/spec/topics/command_decom_topic_spec.rb
+++ b/openc3/spec/topics/command_decom_topic_spec.rb
@@ -1,0 +1,119 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+
+require 'spec_helper'
+require 'openc3/topics/command_decom_topic'
+require 'openc3/packets/packet'
+require 'openc3/conversions/polynomial_conversion'
+
+module OpenC3
+  describe CommandDecomTopic do
+    before(:each) do
+      mock_redis()
+      allow(EphemeralStoreQueued).to receive(:write_topic)
+    end
+
+    describe "self.write_packet" do
+      # VALUE has a write conversion which doubles the given value so the
+      # buffer never holds what the user actually commanded.
+      # STATE only has states and thus reads back correctly from the buffer.
+      let(:packet) do
+        packet = Packet.new('TARGET', 'CMD')
+        item = packet.append_item('VALUE', 16, :UINT)
+        item.write_conversion = PolynomialConversion.new(0, 2)
+        item = packet.append_item('STATE', 8, :UINT)
+        item.states = { 'FALSE' => 0, 'TRUE' => 1 }
+        packet.received_time = Time.now
+        packet.packet_time = Time.now
+        packet.received_count = 1
+        packet.stored = false
+        packet.write('VALUE', 5)
+        packet.write('STATE', 'TRUE')
+        packet
+      end
+
+      def json_data(packet)
+        store_instance = EphemeralStoreQueued.instance(db_shard: 0)
+        result = nil
+        expect(store_instance).to receive(:write_topic) do |_topic, msg_hash|
+          result = JSON.parse(msg_hash['json_data'], allow_nan: true)
+        end
+        CommandDecomTopic.write_packet(packet, scope: 'DEFAULT')
+        result
+      end
+
+      it "writes packet to correct topic format" do
+        store_instance = EphemeralStoreQueued.instance(db_shard: 0)
+        expect(store_instance).to receive(:write_topic).with(
+          "DEFAULT__DECOMCMD__{TARGET}__CMD",
+          hash_including(
+            target_name: 'TARGET',
+            packet_name: 'CMD',
+            received_count: 1,
+            stored: 'false'
+          )
+        )
+        CommandDecomTopic.write_packet(packet, scope: 'DEFAULT')
+      end
+
+      it "logs the given value for items with a write conversion" do
+        packet.given_values = { 'VALUE' => 5, 'STATE' => 'TRUE' }
+        hash = json_data(packet)
+        expect(hash['VALUE']).to eq(10) # raw value in the buffer
+        expect(hash['VALUE__C']).to eq(5) # value the user commanded
+      end
+
+      it "matches given values regardless of key case" do
+        packet.given_values = { 'value' => 5 }
+        hash = json_data(packet)
+        expect(hash['VALUE__C']).to eq(5)
+      end
+
+      it "reads the converted value when the item was not given" do
+        packet.given_values = { 'STATE' => 'TRUE' }
+        hash = json_data(packet)
+        expect(hash['VALUE__C']).to eq(10)
+      end
+
+      it "reads the converted value when there are no given values" do
+        expect(packet.given_values).to be_nil
+        hash = json_data(packet)
+        expect(hash['VALUE__C']).to eq(10)
+      end
+
+      it "reads the converted state value rather than the given value" do
+        # The user can give either the state name or the state value so always
+        # read the state name back out of the buffer
+        packet.given_values = { 'STATE' => 1 }
+        hash = json_data(packet)
+        expect(hash['STATE']).to eq(1)
+        expect(hash['STATE__C']).to eq('TRUE')
+      end
+
+      it "ignores given values for raw commands" do
+        # Raw commands skip the write conversion so the given value is the raw value
+        packet.raw = true
+        packet.write('VALUE', 10, :RAW)
+        # Deliberately different from the buffer to prove the buffer wins
+        packet.given_values = { 'VALUE' => 99 }
+        hash = json_data(packet)
+        expect(hash['VALUE']).to eq(10)
+        expect(hash['VALUE__C']).to eq(10)
+      end
+
+      it "removes hidden items" do
+        packet.get_item('STATE').hidden = true
+        hash = json_data(packet)
+        expect(hash).not_to have_key('STATE')
+        expect(hash).not_to have_key('STATE__C')
+      end
+    end
+  end
+end

--- a/openc3/spec/topics/command_decom_topic_spec.rb
+++ b/openc3/spec/topics/command_decom_topic_spec.rb
@@ -24,18 +24,23 @@ module OpenC3
       # VALUE has a write conversion which doubles the given value so the
       # buffer never holds what the user actually commanded.
       # STATE only has states and thus reads back correctly from the buffer.
+      # BOTH has states and a write conversion and must still read back the state name.
       let(:packet) do
         packet = Packet.new('TARGET', 'CMD')
         item = packet.append_item('VALUE', 16, :UINT)
         item.write_conversion = PolynomialConversion.new(0, 2)
         item = packet.append_item('STATE', 8, :UINT)
         item.states = { 'FALSE' => 0, 'TRUE' => 1 }
+        item = packet.append_item('BOTH', 8, :UINT)
+        item.states = { 'OFF' => 0, 'ON' => 1 }
+        item.write_conversion = PolynomialConversion.new(0, 1)
         packet.received_time = Time.now
         packet.packet_time = Time.now
         packet.received_count = 1
         packet.stored = false
         packet.write('VALUE', 5)
         packet.write('STATE', 'TRUE')
+        packet.write('BOTH', 'ON')
         packet
       end
 
@@ -95,6 +100,15 @@ module OpenC3
         hash = json_data(packet)
         expect(hash['STATE']).to eq(1)
         expect(hash['STATE__C']).to eq('TRUE')
+      end
+
+      it "reads the state name for items with both states and a write conversion" do
+        # States take precedence over the write conversion so the logged value is
+        # always the normalized state name rather than whatever the user gave
+        packet.given_values = { 'BOTH' => 1 }
+        hash = json_data(packet)
+        expect(hash['BOTH']).to eq(1)
+        expect(hash['BOTH__C']).to eq('ON')
       end
 
       it "ignores given values for raw commands" do


### PR DESCRIPTION
Reading :CONVERTED back from the buffer returns the post write conversion result, not the value the user commanded. Use packet.given_values for items with a write conversion so __C reflects what was actually sent. State items still read from the buffer since the user can give either the state name or the state value. Raw commands bypass write conversions so their given values are raw and are ignored.

Also pre-create the QuestDB __C column as double (varchar for STRING/BLOCK) for command items with a write conversion so given engineering unit floats aren't cast down to the item data type.

Fixes #3582

🤖 Generated with [Claude Code](https://claude.com/claude-code)