### PR TITLE
Fix/3658 cmd comma whitespace

### DIFF
--- a/openc3/lib/openc3/script/extract.rb
+++ b/openc3/lib/openc3/script/extract.rb
@@ -21,9 +21,10 @@ require 'openc3/utilities/store'
 module OpenC3
   module Extract
     # Tokenizer for command parameters: matches double quoted strings, single quoted strings,
-    # bracket delimited arrays, a bare comma delimiter, or bare words (runs of non-whitespace,
-    # non-comma characters). Commas are tokenized separately so whitespace around them is optional.
-    SCANNING_REGULAR_EXPRESSION = %r{ (?:"(?:[^\\"]|\\.)*") | (?:'(?:[^\\']|\\.)*') | (?:\[(?:[^\\\[\]]|\\.)*\]) | , | [^\s,]+ }x # "
+    # bracket delimited arrays (one level of nesting), a bare comma delimiter, or bare words
+    # (runs of non-whitespace, non-comma characters). Commas are tokenized separately so
+    # whitespace around them is optional.
+    SCANNING_REGULAR_EXPRESSION = %r{ (?:"(?:[^\\"]|\\.)*") | (?:'(?:[^\\']|\\.)*') | (?:\[(?:[^\\\[\]]|\\.|\[(?:[^\\\[\]]|\\.)*\])*\]) | , | [^\s,]+ }x # "
 
     private
 
@@ -93,13 +94,13 @@ module OpenC3
         value = nil
         second_half.each do |item|
           if item == ','
-            # A comma completes the current keyword / value pair
-            if keyword
-              raise "Missing value for last command parameter: #{text}" unless value
-              add_cmd_parameter(keyword, value, packet, cmd_params)
-              keyword = nil
-              value = nil
-            end
+            # A comma completes the current keyword / value pair.
+            # A comma with nothing pending is a leading or duplicated comma.
+            raise "Missing command parameter before comma: #{text}" unless keyword
+            raise "Missing value for last command parameter: #{text}" unless value
+            add_cmd_parameter(keyword, value, packet, cmd_params)
+            keyword = nil
+            value = nil
           elsif keyword.nil?
             keyword = item
           elsif value.nil?

--- a/openc3/lib/openc3/script/extract.rb
+++ b/openc3/lib/openc3/script/extract.rb
@@ -20,7 +20,10 @@ require 'openc3/utilities/store'
 
 module OpenC3
   module Extract
-    SCANNING_REGULAR_EXPRESSION = %r{ (?:"(?:[^\\"]|\\.)*") | (?:'(?:[^\\']|\\.)*') | (?:\[(?:[^\\\[\]]|\\.)*\]) | \S+ }x # "
+    # Tokenizer for command parameters: matches double quoted strings, single quoted strings,
+    # bracket delimited arrays, a bare comma delimiter, or bare words (runs of non-whitespace,
+    # non-comma characters). Commas are tokenized separately so whitespace around them is optional.
+    SCANNING_REGULAR_EXPRESSION = %r{ (?:"(?:[^\\"]|\\.)*") | (?:'(?:[^\\']|\\.)*') | (?:\[(?:[^\\\[\]]|\\.)*\]) | , | [^\s,]+ }x # "
 
     private
 
@@ -88,35 +91,26 @@ module OpenC3
         second_half = split_string[1].scan(SCANNING_REGULAR_EXPRESSION)
         keyword = nil
         value = nil
-        comma = nil
         second_half.each do |item|
-          unless keyword
-            keyword = item
-            next
-          end
-          unless value
-            if item[-1..-1] == ','
-              value = item[0..-2]
-              comma = true
-            else
-              value = item
-              next
+          if item == ','
+            # A comma completes the current keyword / value pair
+            if keyword
+              raise "Missing value for last command parameter: #{text}" unless value
+              add_cmd_parameter(keyword, value, packet, cmd_params)
+              keyword = nil
+              value = nil
             end
+          elsif keyword.nil?
+            keyword = item
+          elsif value.nil?
+            value = item
+          else
+            raise "Missing comma in command parameters: #{text}"
           end
-          unless comma
-            raise "Missing comma in command parameters: #{text}" if item != ','
-          end
-          add_cmd_parameter(keyword, value, packet, cmd_params)
-          keyword = nil
-          value = nil
-          comma = nil
         end
         if keyword
-          if value
-            add_cmd_parameter(keyword, value, packet, cmd_params)
-          else
-            raise "Missing value for last command parameter: #{text}"
-          end
+          raise "Missing value for last command parameter: #{text}" unless value
+          add_cmd_parameter(keyword, value, packet, cmd_params)
         end
       end
 

--- a/openc3/python/openc3/utilities/extract.py
+++ b/openc3/python/openc3/utilities/extract.py
@@ -19,12 +19,14 @@ import re
 
 
 # Tokenizer for command parameters: matches double-quoted strings, single-quoted strings,
-# bracket-delimited arrays, or bare words (non-whitespace runs)
+# bracket-delimited arrays, a bare comma delimiter, or bare words. Commas are tokenized
+# separately so whitespace around them is optional.
 SCANNING_REGULAR_EXPRESSION = re.compile(
     r""" "(?:[^\\"]|\\.)*"            # double-quoted string (with escaped chars)
        | '(?:[^\\']|\\.)*'            # single-quoted string (with escaped chars)
        | \[(?:[^\\\[\]]|\\.)*\]       # bracket-delimited array (with escaped chars)
-       | \S+                          # bare word
+       | ,                            # comma delimiter
+       | [^\s,]+                      # bare word
     """,
     re.VERBOSE,
 )
@@ -167,28 +169,25 @@ def extract_fields_from_cmd_text(text):
         second_half = SCANNING_REGULAR_EXPRESSION.findall(split_string[1])
         keyword = None
         value = None
-        comma = None
         for item in second_half:
-            if keyword is None:
+            if item == ",":
+                # A comma completes the current keyword / value pair
+                if keyword is not None:
+                    if value is None:
+                        raise RuntimeError(f"Missing value for last command parameter: {text:s}")
+                    add_cmd_parameter(keyword, value, cmd_params)
+                    keyword = None
+                    value = None
+            elif keyword is None:
                 keyword = item
-                continue
-            if value is None:
-                if item.endswith(","):
-                    value = item[0:-1]
-                    comma = True
-                else:
-                    value = item
-                    continue
-            if not comma and item != ",":
+            elif value is None:
+                value = item
+            else:
                 raise RuntimeError(f"Missing comma in command parameters: {text:s}")
+        if keyword is not None:
+            if value is None:
+                raise RuntimeError(f"Missing value for last command parameter: {text:s}")
             add_cmd_parameter(keyword, value, cmd_params)
-            keyword = None
-            value = None
-            comma = None
-        if keyword is not None and value is not None:
-            add_cmd_parameter(keyword, value, cmd_params)
-        else:
-            raise RuntimeError(f"Missing value for last command parameter: {text:s}")
 
     return target_name, cmd_name, cmd_params
 

--- a/openc3/python/openc3/utilities/extract.py
+++ b/openc3/python/openc3/utilities/extract.py
@@ -19,12 +19,12 @@ import re
 
 
 # Tokenizer for command parameters: matches double-quoted strings, single-quoted strings,
-# bracket-delimited arrays, a bare comma delimiter, or bare words. Commas are tokenized
-# separately so whitespace around them is optional.
+# bracket-delimited arrays (one level of nesting), a bare comma delimiter, or bare words.
+# Commas are tokenized separately so whitespace around them is optional.
 SCANNING_REGULAR_EXPRESSION = re.compile(
     r""" "(?:[^\\"]|\\.)*"            # double-quoted string (with escaped chars)
        | '(?:[^\\']|\\.)*'            # single-quoted string (with escaped chars)
-       | \[(?:[^\\\[\]]|\\.)*\]       # bracket-delimited array (with escaped chars)
+       | \[(?:[^\\\[\]]|\\.|\[(?:[^\\\[\]]|\\.)*\])*\]   # array, one level of nesting
        | ,                            # comma delimiter
        | [^\s,]+                      # bare word
     """,
@@ -171,13 +171,15 @@ def extract_fields_from_cmd_text(text):
         value = None
         for item in second_half:
             if item == ",":
-                # A comma completes the current keyword / value pair
-                if keyword is not None:
-                    if value is None:
-                        raise RuntimeError(f"Missing value for last command parameter: {text:s}")
-                    add_cmd_parameter(keyword, value, cmd_params)
-                    keyword = None
-                    value = None
+                # A comma completes the current keyword / value pair.
+                # A comma with nothing pending is a leading or duplicated comma.
+                if keyword is None:
+                    raise RuntimeError(f"Missing command parameter before comma: {text:s}")
+                if value is None:
+                    raise RuntimeError(f"Missing value for last command parameter: {text:s}")
+                add_cmd_parameter(keyword, value, cmd_params)
+                keyword = None
+                value = None
             elif keyword is None:
                 keyword = item
             elif value is None:

--- a/openc3/python/test/utilities/test_extract.py
+++ b/openc3/python/test/utilities/test_extract.py
@@ -76,6 +76,22 @@ class TestExtractFieldsFromCmdText:
         result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1, KEY2 2, KEY3 '3', KEY4 4.0")
         assert result == ("TARGET", "PACKET", {"KEY1": "VALUE1", "KEY2": 2, "KEY3": "3", "KEY4": 4.0})
 
+    def test_does_not_require_whitespace_after_comma(self):
+        result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1,KEY2 2,KEY3 '3',KEY4 4.0")
+        assert result == ("TARGET", "PACKET", {"KEY1": "VALUE1", "KEY2": 2, "KEY3": "3", "KEY4": 4.0})
+
+        # Mixed spacing around the commas
+        result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1 ,KEY2 2, KEY3 '3' , KEY4 4.0")
+        assert result == ("TARGET", "PACKET", {"KEY1": "VALUE1", "KEY2": 2, "KEY3": "3", "KEY4": 4.0})
+
+    def test_allows_a_trailing_comma(self):
+        result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1, KEY2 2,")
+        assert result == ("TARGET", "PACKET", {"KEY1": "VALUE1", "KEY2": 2})
+
+    def test_preserves_commas_inside_quoted_strings_and_arrays(self):
+        result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 'A,B',KEY2 [1,2,3],KEY3 \"C, D\"")
+        assert result == ("TARGET", "PACKET", {"KEY1": "A,B", "KEY2": [1, 2, 3], "KEY3": "C, D"})
+
     def test_handles_multiple_array_parameters(self):
         result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 [1,2,3,4], KEY2 2, KEY3 '3', KEY4 [5, 6, 7, 8]")
         assert result == ("TARGET", "PACKET", {"KEY1": [1, 2, 3, 4], "KEY2": 2, "KEY3": "3", "KEY4": [5, 6, 7, 8]})

--- a/openc3/python/test/utilities/test_extract.py
+++ b/openc3/python/test/utilities/test_extract.py
@@ -88,9 +88,30 @@ class TestExtractFieldsFromCmdText:
         result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1, KEY2 2,")
         assert result == ("TARGET", "PACKET", {"KEY1": "VALUE1", "KEY2": 2})
 
+    def test_complains_about_a_leading_or_duplicated_comma(self):
+        for text in [
+            "TARGET PACKET with ,",
+            "TARGET PACKET with , KEY1 VALUE1",
+            "TARGET PACKET with KEY1 VALUE1,,KEY2 2",
+            "TARGET PACKET with KEY1 VALUE1,,",
+        ]:
+            with pytest.raises(RuntimeError, match="Missing command parameter before comma"):
+                extract_fields_from_cmd_text(text)
+
     def test_preserves_commas_inside_quoted_strings_and_arrays(self):
         result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 'A,B',KEY2 [1,2,3],KEY3 \"C, D\"")
         assert result == ("TARGET", "PACKET", {"KEY1": "A,B", "KEY2": [1, 2, 3], "KEY3": "C, D"})
+
+    def test_handles_nested_array_parameters(self):
+        result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 [[1,2],[3,4]]")
+        assert result == ("TARGET", "PACKET", {"KEY1": [[1, 2], [3, 4]]})
+
+        # Whitespace inside the nested array and no whitespace around the delimiter
+        result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 [[1, 2], [3, 4]],KEY2 5")
+        assert result == ("TARGET", "PACKET", {"KEY1": [[1, 2], [3, 4]], "KEY2": 5})
+
+        result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 [['1','2'],['3','4']], KEY2 [[1,2],[3,4]]")
+        assert result == ("TARGET", "PACKET", {"KEY1": [["1", "2"], ["3", "4"]], "KEY2": [[1, 2], [3, 4]]})
 
     def test_handles_multiple_array_parameters(self):
         result = extract_fields_from_cmd_text("TARGET PACKET with KEY1 [1,2,3,4], KEY2 2, KEY3 '3', KEY4 [5, 6, 7, 8]")

--- a/openc3/spec/script/extract_spec.rb
+++ b/openc3/spec/script/extract_spec.rb
@@ -126,9 +126,29 @@ module OpenC3
         )
       end
 
+      it "should complain about a leading or duplicated comma" do
+        expect { extract_fields_from_cmd_text("TARGET PACKET with ,") }.to raise_error(/Missing command parameter before comma/)
+        expect { extract_fields_from_cmd_text("TARGET PACKET with , KEY1 VALUE1") }.to raise_error(/Missing command parameter before comma/)
+        expect { extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1,,KEY2 2") }.to raise_error(/Missing command parameter before comma/)
+        expect { extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1,,") }.to raise_error(/Missing command parameter before comma/)
+      end
+
       it "should preserve commas inside quoted strings and arrays" do
         expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 'A,B',KEY2 [1,2,3],KEY3 \"C, D\"")).to eql(
           ['TARGET', 'PACKET', { 'KEY1' => 'A,B', 'KEY2' => [1, 2, 3], 'KEY3' => 'C, D' }]
+        )
+      end
+
+      it "should handle nested array parameters" do
+        expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 [[1,2],[3,4]]")).to eql(
+          ['TARGET', 'PACKET', { 'KEY1' => [[1, 2], [3, 4]] }]
+        )
+        # Whitespace inside the nested array and no whitespace around the delimiter
+        expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 [[1, 2], [3, 4]],KEY2 5")).to eql(
+          ['TARGET', 'PACKET', { 'KEY1' => [[1, 2], [3, 4]], 'KEY2' => 5 }]
+        )
+        expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 [['1','2'],['3','4']], KEY2 [[1,2],[3,4]]")).to eql(
+          ['TARGET', 'PACKET', { 'KEY1' => [['1', '2'], ['3', '4']], 'KEY2' => [[1, 2], [3, 4]] }]
         )
       end
 

--- a/openc3/spec/script/extract_spec.rb
+++ b/openc3/spec/script/extract_spec.rb
@@ -110,6 +110,28 @@ module OpenC3
         )
       end
 
+      it "should not require whitespace after the comma delimiter" do
+        expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1,KEY2 2,KEY3 '3',KEY4 4.0")).to eql(
+          ['TARGET', 'PACKET', { 'KEY1' => 'VALUE1', 'KEY2' => 2, 'KEY3' => '3', 'KEY4' => 4.0 }]
+        )
+        # Mixed spacing around the commas
+        expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1 ,KEY2 2, KEY3 '3' , KEY4 4.0")).to eql(
+          ['TARGET', 'PACKET', { 'KEY1' => 'VALUE1', 'KEY2' => 2, 'KEY3' => '3', 'KEY4' => 4.0 }]
+        )
+      end
+
+      it "should allow a trailing comma" do
+        expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 VALUE1, KEY2 2,")).to eql(
+          ['TARGET', 'PACKET', { 'KEY1' => 'VALUE1', 'KEY2' => 2 }]
+        )
+      end
+
+      it "should preserve commas inside quoted strings and arrays" do
+        expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 'A,B',KEY2 [1,2,3],KEY3 \"C, D\"")).to eql(
+          ['TARGET', 'PACKET', { 'KEY1' => 'A,B', 'KEY2' => [1, 2, 3], 'KEY3' => 'C, D' }]
+        )
+      end
+
       it "should handle multiple array parameters" do
         expect(extract_fields_from_cmd_text("TARGET PACKET with KEY1 [1,2,3,4], KEY2 2, KEY3 '3', KEY4 [5, 6, 7, 8]")).to eql(
           ['TARGET', 'PACKET', { 'KEY1' => [1, 2, 3, 4], 'KEY2' => 2, 'KEY3' => '3', 'KEY4' => [5, 6, 7, 8] }]


### PR DESCRIPTION
Commas are now tokenized as their own token instead of only being recognized when trailing a value token, so "KEY VALUE,KEY2 VALUE2" parses the same as "KEY VALUE, KEY2 VALUE2". Commas inside quoted strings and arrays are still preserved. Also aligns Python with Ruby by allowing a trailing comma.

Fixes #3658

🤖 Generated with [Claude Code](https://claude.com/claude-code)