### PR TITLE
fix(tools): always install tools to the DEFAULT scope

### DIFF
--- a/docs.openc3.com/docs/configuration/plugins.md
+++ b/docs.openc3.com/docs/configuration/plugins.md
@@ -877,9 +877,7 @@ STOPPED
 ## TOOL
 **Define a tool**
 
-Defines a tool that the plugin adds to the OpenC3 system. Tools are web based applications that make use of the Single-SPA javascript library that allows them to be dynamically added to the running system as independent frontend microservices.
-Tools are global to the entire COSMOS installation. Regardless of the scope a plugin is installed into, its tools are always installed into the DEFAULT scope and are available in every scope.
-
+Defines a tool that the plugin adds to the OpenC3 system. Tools are web based applications that make use of the Single-SPA javascript library that allows them to by dynamically added to the running system as independent frontend microservices.
 
 | Parameter | Description | Required |
 |-----------|-------------|----------|

--- a/docs.openc3.com/docs/configuration/plugins.md
+++ b/docs.openc3.com/docs/configuration/plugins.md
@@ -568,13 +568,6 @@ Sets the retention time directly on QuestDB tables for automatic data expiration
 |-----------|-------------|----------|
 | Time | Retention time value with unit (e.g., "24h" for 24 hours, "30d" for 30 days, "1y" for 1 year). Supported units are h (hours), d (days), w (weeks), M (months), y (years). Default = nil = Forever | True |
 
-### DECOM_FLUSH_PERIOD
-**Period in seconds between flushing rows to the TSDB. Higher values use less CPU.**
-
-| Parameter | Description | Required |
-|-----------|-------------|----------|
-| Period | Number of seconds between flushing rows to the TSDB (default = 5.0) | True |
-
 ### LOG_RETAIN_TIME
 **How long to keep all regular telemetry logs in seconds.**
 

--- a/docs.openc3.com/docs/configuration/plugins.md
+++ b/docs.openc3.com/docs/configuration/plugins.md
@@ -568,6 +568,13 @@ Sets the retention time directly on QuestDB tables for automatic data expiration
 |-----------|-------------|----------|
 | Time | Retention time value with unit (e.g., "24h" for 24 hours, "30d" for 30 days, "1y" for 1 year). Supported units are h (hours), d (days), w (weeks), M (months), y (years). Default = nil = Forever | True |
 
+### DECOM_FLUSH_PERIOD
+**Period in seconds between flushing rows to the TSDB. Higher values use less CPU.**
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| Period | Number of seconds between flushing rows to the TSDB (default = 5.0) | True |
+
 ### LOG_RETAIN_TIME
 **How long to keep all regular telemetry logs in seconds.**
 
@@ -870,7 +877,9 @@ STOPPED
 ## TOOL
 **Define a tool**
 
-Defines a tool that the plugin adds to the OpenC3 system. Tools are web based applications that make use of the Single-SPA javascript library that allows them to by dynamically added to the running system as independent frontend microservices.
+Defines a tool that the plugin adds to the OpenC3 system. Tools are web based applications that make use of the Single-SPA javascript library that allows them to be dynamically added to the running system as independent frontend microservices.
+Tools are global to the entire COSMOS installation. Regardless of the scope a plugin is installed into, its tools are always installed into the DEFAULT scope and are available in every scope.
+
 
 | Parameter | Description | Required |
 |-----------|-------------|----------|

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/tools_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/tools_controller_spec.rb
@@ -102,6 +102,11 @@ RSpec.describe ToolsController, type: :controller do
     end
 
     it "handles tools with no import_map_items" do
+      # tool1 has no import_map_items and no inline_url
+      allow(OpenC3::ToolModel).to receive(:all_scopes).and_return({
+        "DEFAULT__tool1" => @tool1
+      })
+
       get :importmap
 
       expect(response).to have_http_status(:ok)

--- a/openc3/data/config/tool.yaml
+++ b/openc3/data/config/tool.yaml
@@ -2,7 +2,9 @@
 TOOL:
   summary: Define a tool
   example: TOOL DEMO Demo
-  description: Defines a tool that the plugin adds to the OpenC3 system. Tools are web based applications that make use of the Single-SPA javascript library that allows them to by dynamically added to the running system as independent frontend microservices.
+  description: |
+    Defines a tool that the plugin adds to the OpenC3 system. Tools are web based applications that make use of the Single-SPA javascript library that allows them to be dynamically added to the running system as independent frontend microservices.
+    Tools are global to the entire COSMOS installation. Regardless of the scope a plugin is installed into, its tools are always installed into the DEFAULT scope and are available in every scope.
   parameters:
     - name: Tool Folder Name
       description: The exact name of the tool folder in the plugin. ie. tools/ToolFolderName

--- a/openc3/lib/openc3/models/tool_model.rb
+++ b/openc3/lib/openc3/models/tool_model.rb
@@ -25,6 +25,13 @@ module OpenC3
   class ToolModel < Model
     PRIMARY_KEY = 'openc3_tools'
 
+    # Tools are global to the entire COSMOS installation and are always stored
+    # in the DEFAULT scope. The frontend navigation always requests the tool
+    # list from DEFAULT, so a tool installed into any other scope would be
+    # inaccessible. Every scope parameter in this class is therefore ignored
+    # and replaced with TOOL_SCOPE.
+    TOOL_SCOPE = 'DEFAULT'
+
     attr_accessor :folder_name
     attr_accessor :icon
     attr_accessor :url
@@ -40,7 +47,7 @@ module OpenC3
     # NOTE: The following three class methods are used by the ModelController
     # and are reimplemented to enable various Model class methods to work
     def self.get(name:, scope: nil)
-      super("#{scope}__#{PRIMARY_KEY}", name: name)
+      super("#{TOOL_SCOPE}__#{PRIMARY_KEY}", name: name)
     end
 
     def self.names(scope: nil)
@@ -53,7 +60,7 @@ module OpenC3
 
     def self.all(scope: nil)
       ordered_array = []
-      tools = unordered_all(scope: scope)
+      tools = unordered_all()
       tools.each do |_name, tool|
         ordered_array << tool
       end
@@ -65,14 +72,10 @@ module OpenC3
       ordered_hash
     end
 
+    # Tools only exist in the DEFAULT scope. Kept for backwards compatibility
+    # with the ToolsController importmap endpoint.
     def self.all_scopes
-      result = {}
-      scopes = OpenC3::ScopeModel.all
-      scopes.each do |key, _scope|
-        tools = unordered_all(scope: key)
-        result.merge!(tools)
-      end
-      result
+      unordered_all()
     end
 
     # Called by the PluginModel to allow this class to validate it's top-level keyword: "TOOL"
@@ -80,7 +83,8 @@ module OpenC3
       case keyword
       when 'TOOL'
         parser.verify_num_parameters(2, 2, "TOOL <Folder Name> <Name>")
-        return self.new(folder_name: parameters[0], name: parameters[1], plugin: plugin, needs_dependencies: needs_dependencies, scope: scope)
+        # NOTE: scope is intentionally ignored, see TOOL_SCOPE
+        return self.new(folder_name: parameters[0], name: parameters[1], plugin: plugin, needs_dependencies: needs_dependencies, scope: TOOL_SCOPE)
       else
         raise ConfigParser::Error.new(parser, "Unknown keyword and parameters for Tool: #{keyword} #{parameters.join(" ")}")
       end
@@ -89,7 +93,8 @@ module OpenC3
 
     # The ToolsTab.vue calls the ToolsController which uses this method to reorder the tools
     # Position is index in the list starting with 0 = first
-    def self.set_position(name:, position:, scope:)
+    def self.set_position(name:, position:, scope: nil)
+      scope = TOOL_SCOPE
       moving = from_json(get(name: name, scope: scope), scope: scope)
       old_pos = moving.position
       new_pos = position
@@ -134,9 +139,11 @@ module OpenC3
       needs_dependencies: false,
       disable_erb: nil,
       import_map_items: nil,
-      scope:
+      scope: nil
     )
-      super("#{scope}__#{PRIMARY_KEY}", name: name, plugin: plugin, updated_at: updated_at, scope: scope)
+      # Tools are always created in the DEFAULT scope regardless of the scope
+      # the plugin is being installed into, see TOOL_SCOPE
+      super("#{TOOL_SCOPE}__#{PRIMARY_KEY}", name: name, plugin: plugin, updated_at: updated_at, scope: TOOL_SCOPE)
       @folder_name = folder_name
       @icon = icon
       @url = url
@@ -159,11 +166,12 @@ module OpenC3
       tools = self.class.all(scope: @scope)
 
       # Make sure a tool with this folder_name doesn't already exist
+      # NOTE: Tools are global (TOOL_SCOPE) so this check is across all scopes
       unless update
         if @folder_name
           tools.each do |_tool_name, tool|
             if tool['folder_name'] == @folder_name
-              raise "Tool with folder_name #{@folder_name} already exists at create"
+              raise "Tool with folder_name #{@folder_name} already exists at create. Tools are global to the entire COSMOS installation and can only be installed once."
             end
           end
         end
@@ -309,7 +317,7 @@ module OpenC3
 
     # Returns the list of tools or the default OpenC3 tool set if no tools have been created
     def self.unordered_all(scope: nil)
-      tools = Store.hgetall("#{scope}__#{PRIMARY_KEY}")
+      tools = Store.hgetall("#{TOOL_SCOPE}__#{PRIMARY_KEY}")
       tools.each do |key, value|
         tools[key] = JSON.parse(value, allow_nan: true, create_additions: true)
       end

--- a/openc3/lib/openc3/models/tool_model.rb
+++ b/openc3/lib/openc3/models/tool_model.rb
@@ -46,18 +46,21 @@ module OpenC3
 
     # NOTE: The following three class methods are used by the ModelController
     # and are reimplemented to enable various Model class methods to work
+    # NOTE: scope is deprecated since 7.3.0 as tools always live in the DEFAULT scope, see TOOL_SCOPE
     def self.get(name:, scope: nil)
       super("#{TOOL_SCOPE}__#{PRIMARY_KEY}", name: name)
     end
 
+    # NOTE: scope is deprecated since 7.3.0 as tools always live in the DEFAULT scope, see TOOL_SCOPE
     def self.names(scope: nil)
       array = []
-      all(scope: scope).each do |name, _tool|
+      all().each do |name, _tool|
         array << name
       end
       array
     end
 
+    # NOTE: scope is deprecated since 7.3.0 as tools always live in the DEFAULT scope, see TOOL_SCOPE
     def self.all(scope: nil)
       ordered_array = []
       tools = unordered_all()
@@ -93,9 +96,10 @@ module OpenC3
 
     # The ToolsTab.vue calls the ToolsController which uses this method to reorder the tools
     # Position is index in the list starting with 0 = first
+    # NOTE: scope is deprecated since 7.3.0 as tools always live in the DEFAULT scope, see TOOL_SCOPE
     def self.set_position(name:, position:, scope: nil)
-      scope = TOOL_SCOPE
-      moving = from_json(get(name: name, scope: scope), scope: scope)
+      tool_scope = TOOL_SCOPE
+      moving = from_json(get(name: name, scope: tool_scope), scope: tool_scope)
       old_pos = moving.position
       new_pos = position
       direction = :down
@@ -106,8 +110,8 @@ module OpenC3
       end
 
       # Go through all the tools and reorder
-      all(scope: scope).each do |_tool_name, tool|
-        tool_model = from_json(tool, scope: scope)
+      all(scope: tool_scope).each do |_tool_name, tool|
+        tool_model = from_json(tool, scope: tool_scope)
         # Update the requested model to the new position
         if tool_model.name == name
           tool_model.position = position
@@ -139,7 +143,7 @@ module OpenC3
       needs_dependencies: false,
       disable_erb: nil,
       import_map_items: nil,
-      scope: nil
+      scope: nil  # NOTE: deprecated since 7.3.0 as tools are always created in the DEFAULT scope, see TOOL_SCOPE
     )
       # Tools are always created in the DEFAULT scope regardless of the scope
       # the plugin is being installed into, see TOOL_SCOPE
@@ -163,7 +167,7 @@ module OpenC3
     end
 
     def create(update: false, force: false, queued: false)
-      tools = self.class.all(scope: @scope)
+      tools = self.class.all()
 
       # Make sure a tool with this folder_name doesn't already exist
       # NOTE: Tools are global (TOOL_SCOPE) so this check is across all scopes
@@ -316,6 +320,7 @@ module OpenC3
     ##################################################
 
     # Returns the list of tools or the default OpenC3 tool set if no tools have been created
+    # NOTE: scope is deprecated since 7.3.0 as tools always live in the DEFAULT scope, see TOOL_SCOPE
     def self.unordered_all(scope: nil)
       tools = Store.hgetall("#{TOOL_SCOPE}__#{PRIMARY_KEY}")
       tools.each do |key, value|

--- a/openc3/spec/models/tool_model_spec.rb
+++ b/openc3/spec/models/tool_model_spec.rb
@@ -41,12 +41,36 @@ module OpenC3
         model.create
         model = ToolModel.new(folder_name: "SPEC", name: "SPEC", scope: "DEFAULT")
         model.create
+        # Tools are always created in DEFAULT regardless of the requested scope
         model = ToolModel.new(folder_name: "OTHER", name: "OTHER", scope: "OTHER")
         model.create
         names = ToolModel.names(scope: "DEFAULT")
-        expect(names).to contain_exactly("TEST", "SPEC")
+        expect(names).to contain_exactly("TEST", "SPEC", "OTHER")
         names = ToolModel.names(scope: "OTHER")
-        expect(names).to contain_exactly("OTHER")
+        expect(names).to contain_exactly("TEST", "SPEC", "OTHER")
+      end
+    end
+
+    describe "scope handling" do
+      it "always creates tools in the DEFAULT scope" do
+        model = ToolModel.new(folder_name: "OTHER", name: "OTHER", scope: "OTHER")
+        expect(model.scope).to eql "DEFAULT"
+        model.create
+        expect(Store.hgetall("OTHER__#{ToolModel::PRIMARY_KEY}")).to be_empty
+        expect(ToolModel.get(name: "OTHER", scope: "OTHER")["name"]).to eql "OTHER"
+        expect(ToolModel.get(name: "OTHER", scope: "DEFAULT")["name"]).to eql "OTHER"
+      end
+
+      it "ignores scope in handle_config" do
+        parser = double("ConfigParser").as_null_object
+        tool = ToolModel.handle_config(parser, "TOOL", ["FOLDER", "NAME"], scope: "OTHER")
+        expect(tool.scope).to eql "DEFAULT"
+      end
+
+      it "returns tools from DEFAULT in all_scopes" do
+        model = ToolModel.new(folder_name: "OTHER", name: "OTHER", scope: "OTHER")
+        model.create
+        expect(ToolModel.all_scopes.keys).to contain_exactly("OTHER")
       end
     end
 


### PR DESCRIPTION
Closes OpenC3/cosmos-enterprise#486

## Problem

Installing a tool plugin into a non-DEFAULT scope makes the tool inaccessible: the frontend navigation (`AppNav.vue`) always requests the tool list from the DEFAULT scope.

## Change

Tools are global to the entire COSMOS installation, so `ToolModel` now ignores the scope it is handed and always reads/writes `DEFAULT__openc3_tools` (`ToolModel::TOOL_SCOPE`). This affects `get`, `all`, `unordered_all`, `all_scopes`, `set_position`, `initialize`, and `handle_config`. `all_scopes` is kept for the `ToolsController#importmap` endpoint but now simply returns the DEFAULT tools.

Docs: the `TOOL` keyword description in `tool.yaml` (and the regenerated `plugins.md`) now states that tools are installed to DEFAULT and are available in every scope.

## Notes

- No migration is included. Tools previously installed into another scope remain as orphaned Redis keys and can be cleaned up manually; this is expected to be rare.
- Because the duplicate `folder_name` check is now installation-wide, the same tool plugin can no longer be installed into two scopes. The error message was updated to explain why.
- The `plugins.md` diff also includes a pre-existing `DECOM_FLUSH_PERIOD` section that was already in the YAML but missing from the generated docs.

## Testing

- `openc3`: `bundle exec rspec spec/models/tool_model_spec.rb` — 15 examples, 2 failures, both pre-existing on this branch point (`ConfigTopic` / `OpenStruct` uninitialized constants in the deploy/undeploy tests).
- `openc3-cosmos-cmd-tlm-api`: `bundle exec rspec spec/controllers/tools_controller_spec.rb` — 9 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)