### PR TITLE
fix(api): permit reaction action environment and alert params

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/reaction_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/reaction_controller.rb
@@ -101,7 +101,7 @@ class ReactionController < ApplicationController
   def create
     return unless authorization('script_run')
     begin
-      hash = params.permit(:trigger_level, :snooze, :label, :name, triggers: [:name, :group], actions: [:type, :value, :severity]).to_h
+      hash = params.permit(:trigger_level, :snooze, :label, :name, triggers: [:name, :group], actions: [:type, :value, :severity, :alert, { environment: [:key, :value] }]).to_h
       name = hash.delete('name')
       if name.nil? || name.strip.empty?
         name = @model_class.create_unique_name(scope: params[:scope])
@@ -149,7 +149,7 @@ class ReactionController < ApplicationController
         render json: { status: 'error', message: NOT_FOUND }, status: :not_found
         return
       end
-      hash = params.permit(:snooze, :trigger_level, :label, triggers: [:name, :group], actions: [:type, :value, :severity]).to_h
+      hash = params.permit(:snooze, :trigger_level, :label, triggers: [:name, :group], actions: [:type, :value, :severity, :alert, { environment: [:key, :value] }]).to_h
       model.triggers = hash['triggers'] if hash['triggers']
       model.actions = hash['actions'] if hash['actions']
       model.trigger_level = hash['trigger_level'] if hash['trigger_level']

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/reaction_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/reaction_controller_spec.rb
@@ -137,6 +137,35 @@ RSpec.describe ReactionController, type: :controller do
       expect(created["actions"][1]["value"]).to eql("Alert")
       expect(created["actions"][1]["severity"]).to eql("FATAL")
     end
+
+    it "preserves the environment on a script action" do
+      generate_trigger
+      hash = generate_reaction_hash(
+        actions: [{"type" => "script", "value" => "INST/procedures/checks.rb",
+                   "environment" => [{"key" => "USER", "value" => "JASON"}]}]
+      )
+      post :create, params: hash.merge({"scope" => "DEFAULT"})
+      expect(response).to have_http_status(:created)
+      created = JSON.parse(response.body, allow_nan: true, create_additions: true)
+      expect(created["actions"][0]["environment"]).to eql([{"key" => "USER", "value" => "JASON"}])
+
+      get :show, params: {scope: "DEFAULT", name: created["name"]}
+      expect(response).to have_http_status(:ok)
+      shown = JSON.parse(response.body, allow_nan: true, create_additions: true)
+      expect(shown["actions"][0]["environment"]).to eql([{"key" => "USER", "value" => "JASON"}])
+    end
+
+    it "preserves the alert flag on a notify action" do
+      generate_trigger
+      hash = generate_reaction_hash(
+        actions: [{"type" => "notify", "value" => "Popup", "severity" => "INFO", "alert" => true}]
+      )
+      post :create, params: hash.merge({"scope" => "DEFAULT"})
+      expect(response).to have_http_status(:created)
+      created = JSON.parse(response.body, allow_nan: true, create_additions: true)
+      # Controller specs stringify params so just verify the field survives permit
+      expect(created["actions"][0]["alert"].to_s).to eql("true")
+    end
   end
 
   describe "PUT update preserves action fields" do
@@ -162,6 +191,27 @@ RSpec.describe ReactionController, type: :controller do
       expect(updated["actions"][0]["type"]).to eql("notify")
       expect(updated["actions"][0]["value"]).to eql("Updated alert")
       expect(updated["actions"][0]["severity"]).to eql("ERROR")
+    end
+
+    it "preserves the environment on a script action" do
+      generate_trigger
+      hash = generate_reaction_hash
+      post :create, params: hash.merge({"scope" => "DEFAULT"})
+      expect(response).to have_http_status(:created)
+      created = JSON.parse(response.body, allow_nan: true, create_additions: true)
+
+      put :update, params: {
+        scope: "DEFAULT",
+        name: created["name"],
+        snooze: 300,
+        triggers: [{"name" => "TRIG1", "group" => GROUP}],
+        trigger_level: "EDGE",
+        actions: [{"type" => "script", "value" => "INST/procedures/checks.rb",
+                   "environment" => [{"key" => "MODE", "value" => "TEST"}]}],
+      }
+      expect(response).to have_http_status(:ok)
+      updated = JSON.parse(response.body, allow_nan: true, create_additions: true)
+      expect(updated["actions"][0]["environment"]).to eql([{"key" => "MODE", "value" => "TEST"}])
     end
   end
 


### PR DESCRIPTION
The reaction controller's strong parameters only permitted type, value, and severity on actions, so the environment variables set on a script action and the alert flag on a notify action were silently dropped on both create and update. The model already persists the full action hash and the reaction microservice already forwards the environment to the script API, so permitting the fields is all that was missing.