### PR TITLE
Add per-command metadata propagation to interfaces

### DIFF
--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -840,6 +840,7 @@ cmd("<Target Name>", "<Command Name>", "Param #1 Name" => <Param #1 Value>, "Par
 | timeout        | Optional named parameter to change the default timeout value of 5 seconds                            |
 | log_message    | Optional named parameter to prevent logging of the command                                           |
 | validate       | Optional named parameter to enable/disable validation (default is True)                              |
+| extra          | Optional metadata Hash/dict carried with the command packet to the interface                          |
 
 <Tabs groupId="script-language">
 <TabItem value="python" label="Python Example">
@@ -848,6 +849,7 @@ cmd("<Target Name>", "<Command Name>", "Param #1 Name" => <Param #1 Value>, "Par
 cmd("INST COLLECT with DURATION 10, TYPE NORMAL")
 cmd("INST", "COLLECT", { "DURATION": 10, "TYPE": "NORMAL" })
 cmd("INST ABORT", timeout=10, log_message=False, validate=False)
+cmd("INST ABORT", extra={ "request_id": "1234-5678" })
 ```
 
 </TabItem>
@@ -860,6 +862,7 @@ cmd("INST COLLECT with DURATION 10, TYPE NORMAL")
 cmd("INST", "COLLECT", "DURATION" => 10, "TYPE" => "NORMAL")
 cmd("INST", "COLLECT", { "DURATION" => 10, "TYPE" => "NORMAL" })
 cmd("INST ABORT", timeout: 10, log_message: false, validate: false)
+cmd("INST ABORT", extra: { "request_id" => "1234-5678" })
 ```
 
 </TabItem>

--- a/openc3/lib/openc3/api/cmd_api.rb
+++ b/openc3/lib/openc3/api/cmd_api.rb
@@ -450,7 +450,7 @@ module OpenC3
 
     # NOTE: When adding new keywords to this method, make sure to update script/commands.rb
     def _cmd_implementation(method_name, *args, range_check:, hazardous_check:, raw:, timeout: nil, log_message: nil, manual: false, validate: true, queue: nil,
-                            queue_username: nil, scope: $openc3_scope, token: $openc3_token, **kwargs)
+                            queue_username: nil, extra: nil, scope: $openc3_scope, token: $openc3_token, **kwargs)
       extract_string_kwargs_to_args(args, kwargs)
       unless [nil, true, false].include?(log_message)
         raise "Invalid log_message parameter: #{log_message}. Must be true or false."
@@ -461,6 +461,9 @@ module OpenC3
         rescue ArgumentError, TypeError
           raise "Invalid timeout parameter: #{timeout}. Must be numeric."
         end
+      end
+      unless extra.nil? || extra.is_a?(Hash)
+        raise "Invalid extra parameter: #{extra}. Must be a Hash."
       end
 
       case args.length
@@ -535,6 +538,7 @@ module OpenC3
         'log_message' => log_message.to_s,
         'obfuscated_items' => packet['obfuscated_items'].to_s
       }
+      command['extra'] = extra unless extra.nil?
       # Record the original queuing user (author) separately from 'username' (the
       # user or process that actually executed the command). Command History shows
       # 'username' as "Executed By" and queue_username as "Queued By".
@@ -550,6 +554,7 @@ module OpenC3
           target_name: target_name,
           cmd_name: cmd_name,
           cmd_params: cmd_params,
+          extra: extra,
           validate: validate,
           timeout: timeout,
           username: username,

--- a/openc3/lib/openc3/microservices/interface_microservice.rb
+++ b/openc3/lib/openc3/microservices/interface_microservice.rb
@@ -284,6 +284,9 @@ module OpenC3
             end
 
             command.extra ||= {}
+            if msg_hash['extra']
+              command.extra.merge!(JSON.parse(msg_hash['extra'], allow_nan: true, create_additions: true))
+            end
             command.extra['cmd_string'] = msg_hash['cmd_string']
             command.extra['username'] = msg_hash['username']
             command.extra['interface_name'] = @interface.name

--- a/openc3/lib/openc3/microservices/queue_microservice.rb
+++ b/openc3/lib/openc3/microservices/queue_microservice.rb
@@ -78,12 +78,12 @@ module OpenC3
               timeout = command['timeout']
               # Pass queue_username so Command History is attributed to the original
               # author rather than the queue microservice name
-              cmd(command['target_name'], command['cmd_name'], cmd_params, queue: false, validate: validate, timeout: timeout, queue_username: command['username'], scope: @scope)
+              cmd(command['target_name'], command['cmd_name'], cmd_params, queue: false, validate: validate, timeout: timeout, queue_username: command['username'], extra: command['extra'], scope: @scope)
             elsif command['value']
               # Legacy format: use single string parameter for backwards compatibility
               validate = command.key?('validate') ? command['validate'] : true
               timeout = command['timeout']
-              cmd(command['value'], queue: false, validate: validate, timeout: timeout, queue_username: command['username'], scope: @scope)
+              cmd(command['value'], queue: false, validate: validate, timeout: timeout, queue_username: command['username'], extra: command['extra'], scope: @scope)
             else
               @logger.error "QueueProcessor: Invalid command format, missing required fields"
             end

--- a/openc3/lib/openc3/models/queue_model.rb
+++ b/openc3/lib/openc3/models/queue_model.rb
@@ -40,7 +40,7 @@ module OpenC3
     end
     # END NOTE
 
-    def self.queue_command(name, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, validate: true, timeout: nil, username:, scope:)
+    def self.queue_command(name, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, extra: nil, validate: true, timeout: nil, username:, scope:)
       model = get_model(name: name, scope: scope)
       raise QueueError, "Queue '#{name}' not found in scope '#{scope}'" unless model
 
@@ -53,7 +53,7 @@ module OpenC3
       id = result.empty? ? 1.0 : result[0][1].to_f + 1
 
       command_data = build_command_data(username: username, command: command, target_name: target_name,
-                                        cmd_name: cmd_name, cmd_params: cmd_params, validate: validate, timeout: timeout)
+                                        cmd_name: cmd_name, cmd_params: cmd_params, extra: extra, validate: validate, timeout: timeout)
       Store.zadd("#{scope}:#{name}", id, command_data.to_json)
       model.notify(kind: 'command')
     end
@@ -61,7 +61,7 @@ module OpenC3
     # Build the hash that gets serialized into Redis. Always uses symbol keys so
     # downstream code in this class can access values consistently. cmd_params is
     # JSON-encoded as a string so binary data survives the round-trip via as_json.
-    def self.build_command_data(username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, validate: nil, timeout: nil)
+    def self.build_command_data(username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, extra: nil, validate: nil, timeout: nil)
       command_data = { username: username, timestamp: Time.now.to_nsec_from_epoch }
       if target_name && cmd_name
         command_data[:target_name] = target_name
@@ -74,6 +74,7 @@ module OpenC3
       end
       command_data[:validate] = validate unless validate.nil?
       command_data[:timeout] = timeout unless timeout.nil?
+      command_data[:extra] = extra unless extra.nil?
       command_data
     end
 
@@ -118,7 +119,7 @@ module OpenC3
       QueueTopic.write_notification(notification, scope: @scope)
     end
 
-    def insert_command(id: nil, username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, validate: nil, timeout: nil)
+    def insert_command(id: nil, username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, extra: nil, validate: nil, timeout: nil)
       if @state == 'DISABLE'
         command_name = command || "#{target_name} #{cmd_name}"
         raise QueueError, "Queue '#{@name}' is disabled. Command '#{command_name}' not queued."
@@ -130,12 +131,12 @@ module OpenC3
       end
 
       command_data = self.class.build_command_data(username: username, command: command, target_name: target_name,
-                                                   cmd_name: cmd_name, cmd_params: cmd_params, validate: validate, timeout: timeout)
+                                                   cmd_name: cmd_name, cmd_params: cmd_params, extra: extra, validate: validate, timeout: timeout)
       Store.zadd("#{@scope}:#{@name}", id, command_data.to_json)
       notify(kind: 'command')
     end
 
-    def update_command(id:, username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, validate: nil, timeout: nil)
+    def update_command(id:, username:, command: nil, target_name: nil, cmd_name: nil, cmd_params: nil, extra: nil, validate: nil, timeout: nil)
       if @state == 'DISABLE'
         raise QueueError, "Queue '#{@name}' is disabled. Command at id #{id} not updated."
       end
@@ -147,7 +148,7 @@ module OpenC3
 
       Store.zremrangebyscore("#{@scope}:#{@name}", id, id)
       command_data = self.class.build_command_data(username: username, command: command, target_name: target_name,
-                                                   cmd_name: cmd_name, cmd_params: cmd_params, validate: validate, timeout: timeout)
+                                                   cmd_name: cmd_name, cmd_params: cmd_params, extra: extra, validate: validate, timeout: timeout)
       Store.zadd("#{@scope}:#{@name}", id, command_data.to_json)
       notify(kind: 'command')
     end

--- a/openc3/lib/openc3/script/commands.rb
+++ b/openc3/lib/openc3/script/commands.rb
@@ -117,7 +117,7 @@ module OpenC3
     # except for range_check, hazardous_check, and raw as they are part of the cmd name
     # manual is always false since this is called from script and that is the default
     # NOTE: This is a helper method and should not be called directly
-    def _cmd(cmd, cmd_no_hazardous, *args, timeout: nil, log_message: nil, validate: true, queue: nil, scope: $openc3_scope, token: $openc3_token, **kwargs)
+    def _cmd(cmd, cmd_no_hazardous, *args, timeout: nil, log_message: nil, validate: true, queue: nil, extra: nil, scope: $openc3_scope, token: $openc3_token, **kwargs)
       extract_string_kwargs_to_args(args, kwargs)
       raw = cmd.include?('raw')
       no_range = cmd.include?('no_range') || cmd.include?('no_checks')
@@ -127,7 +127,7 @@ module OpenC3
       else
         begin
           begin
-            command = $api_server.method_missing(cmd, *args, timeout: timeout, log_message: log_message, validate: validate, queue: queue, scope: scope, token: token)
+            command = $api_server.method_missing(cmd, *args, timeout: timeout, log_message: log_message, validate: validate, queue: queue, extra: extra, scope: scope, token: token)
             if log_message.nil? or log_message
               _log_cmd(command, raw, no_range, no_hazardous)
             end
@@ -135,7 +135,7 @@ module OpenC3
             # This opens a prompt at which point they can cancel and stop the script
             # or say Yes and send the command. Thus we don't care about the return value.
             prompt_for_hazardous(e.target_name, e.cmd_name, e.hazardous_description)
-            command = $api_server.method_missing(cmd_no_hazardous, *args, timeout: timeout, log_message: log_message, validate: validate, queue: queue, scope: scope, token: token)
+            command = $api_server.method_missing(cmd_no_hazardous, *args, timeout: timeout, log_message: log_message, validate: validate, queue: queue, extra: extra, scope: scope, token: token)
             if log_message.nil? or log_message
               _log_cmd(command, raw, no_range, no_hazardous)
             end

--- a/openc3/lib/openc3/topics/command_topic.rb
+++ b/openc3/lib/openc3/topics/command_topic.rb
@@ -45,6 +45,8 @@ module OpenC3
       # Save the existing cmd_params Hash and JSON generate before writing to the topic
       cmd_params = command['cmd_params']
       command['cmd_params'] = JSON.generate(command['cmd_params'].as_json, allow_nan: true)
+      extra = command['extra']
+      command['extra'] = JSON.generate(extra.as_json, allow_nan: true) if extra
       OpenC3.inject_context(command)
 
       db_shard = Store.db_shard_for_target(command['target_name'], scope: scope)
@@ -53,6 +55,7 @@ module OpenC3
       if timeout <= 0
         Topic.write_topic("{#{scope}__CMD}TARGET__#{command['target_name']}", command, '*', 100, db_shard: db_shard)
         command["cmd_params"] = cmd_params # Restore the original cmd_params Hash
+        command['extra'] = extra if extra
         return command
       end
 
@@ -60,6 +63,7 @@ module OpenC3
       Topic.update_topic_offsets([ack_topic], db_shard: db_shard)
       cmd_id = Topic.write_topic("{#{scope}__CMD}TARGET__#{command['target_name']}", command, '*', 100, db_shard: db_shard)
       command["cmd_params"] = cmd_params # Restore the original cmd_params Hash
+      command['extra'] = extra if extra
       time = Time.now
       while (Time.now - time) < timeout
         Topic.read_topics([ack_topic], db_shard: db_shard) do |_topic, _msg_id, msg_hash, _redis|

--- a/openc3/python/openc3/api/cmd_api.py
+++ b/openc3/python/openc3/api/cmd_api.py
@@ -610,6 +610,9 @@ def _cmd_implementation(
         manual=manual,
     )
     queue_username = kwargs.get("queue_username")
+    extra = kwargs.get("extra")
+    if extra is not None and not isinstance(extra, dict):
+        raise RuntimeError(f"Invalid extra parameter: {extra}. Must be a dict.")
     if not user:
         user = {}
         user["username"] = os.environ.get("OPENC3_MICROSERVICE_NAME")
@@ -689,6 +692,8 @@ def _cmd_implementation(
         "log_message": str(log_message),
         "obfuscated_items": json.dumps(packet.get("obfuscated_items", [])),
     }
+    if extra is not None:
+        command["extra"] = extra
     # Record the original queuing user (author) separately from 'username' (the
     # user or process that actually executed the command). Command History shows
     # 'username' as "Executed By" and queue_username as "Queued By".
@@ -704,7 +709,7 @@ def _cmd_implementation(
         # Pull the command out of the script string, e.g. cmd("INST ABORT")
         queued = cmd_string.split('("')[1].split('")')[0]
         QueueModel.queue_command(
-            queue, command=queued, username=username, scope=scope, validate=validate, timeout=timeout
+            queue, command=queued, username=username, scope=scope, validate=validate, timeout=timeout, extra=extra
         )
     else:
         CommandTopic.send_command(command, timeout=timeout, scope=scope)

--- a/openc3/python/openc3/microservices/interface_microservice.py
+++ b/openc3/python/openc3/microservices/interface_microservice.py
@@ -321,6 +321,8 @@ class InterfaceCmdHandlerThread:
                 return str(e)
 
             command.extra = command.extra or {}
+            if msg_hash.get(b"extra"):
+                command.extra.update(json.loads(msg_hash[b"extra"], cls=JsonDecoder))
             command.extra["cmd_string"] = msg_hash.get(b"cmd_string", b"").decode()
             command.extra["username"] = msg_hash.get(b"username", b"").decode()
             command.extra["interface_name"] = self.interface.name

--- a/openc3/python/openc3/models/queue_model.py
+++ b/openc3/python/openc3/models/queue_model.py
@@ -48,7 +48,14 @@ class QueueModel(Model):
     # However we need a lot of methods to enable cls.get_model and model.notify
     @classmethod
     def queue_command(
-        cls, name: str, command: str, username: str, scope: str, validate: bool = True, timeout: float = None
+        cls,
+        name: str,
+        command: str,
+        username: str,
+        scope: str,
+        validate: bool = True,
+        timeout: float = None,
+        extra: dict | None = None,
     ):
         model = cls.get_model(name=name, scope=scope)
         if not model:
@@ -68,6 +75,8 @@ class QueueModel(Model):
                 "timeout": timeout,
                 "timestamp": time.time_ns(),
             }
+            if extra is not None:
+                command_data["extra"] = extra
             Store.zadd(f"{scope}:{name}", {json.dumps(command_data): index})
             model.notify(kind="command")
         else:

--- a/openc3/python/openc3/script/commands.py
+++ b/openc3/python/openc3/script/commands.py
@@ -228,6 +228,7 @@ def _cmd(
     log_message=None,
     validate=True,
     queue=None,
+    extra=None,
     scope=OPENC3_SCOPE,
 ):
     """Send the command and log the results
@@ -249,6 +250,7 @@ def _cmd(
                     log_message=log_message,
                     validate=validate,
                     queue=queue,
+                    extra=extra,
                     scope=scope,
                 )
                 if log_message is None or log_message:
@@ -270,6 +272,7 @@ def _cmd(
                     log_message=log_message,
                     validate=validate,
                     queue=queue,
+                    extra=extra,
                     scope=scope,
                 )
                 if log_message is None or log_message:

--- a/openc3/python/openc3/topics/command_topic.py
+++ b/openc3/python/openc3/topics/command_topic.py
@@ -57,6 +57,9 @@ class CommandTopic(Topic):
         # Save the existing cmd_params Hash and JSON generate before writing to the topic
         cmd_params = command["cmd_params"]
         command["cmd_params"] = json.dumps(command["cmd_params"], cls=JsonEncoder)
+        extra = command.get("extra")
+        if extra is not None:
+            command["extra"] = json.dumps(extra, cls=JsonEncoder)
 
         db_shard = Store.db_shard_for_target(command["target_name"], scope=scope)
 
@@ -70,6 +73,8 @@ class CommandTopic(Topic):
                 db_shard=db_shard,
             )
             command["cmd_params"] = cmd_params  # Restore the original cmd_params dict
+            if extra is not None:
+                command["extra"] = extra
             return command
 
         ack_topic = f"{{{scope}__ACKCMD}}TARGET__{command['target_name']}"
@@ -82,6 +87,8 @@ class CommandTopic(Topic):
             db_shard=db_shard,
         )
         command["cmd_params"] = cmd_params  # Restore the original cmd_params dict
+        if extra is not None:
+            command["extra"] = extra
         start_time = time.time()
         while (time.time() - start_time) < timeout:
             for _, _, msg_hash, _ in Topic.read_topics([ack_topic], db_shard=db_shard):

--- a/openc3/python/test/api/test_cmd_api.py
+++ b/openc3/python/test/api/test_cmd_api.py
@@ -247,6 +247,25 @@ class TestCmdApi(unittest.TestCase):
             # username is the executing user/process, not the author
             self.assertNotEqual(command["username"], "original_author")
 
+    def test_cmd_carries_extra_metadata(self):
+        extra = {"flow_uuid": "1234-5678", "hv_id": 42}
+        for name in [
+            "cmd",
+            "cmd_no_range_check",
+            "cmd_no_hazardous_check",
+            "cmd_no_checks",
+            "cmd_raw",
+            "cmd_raw_no_range_check",
+            "cmd_raw_no_hazardous_check",
+            "cmd_raw_no_checks",
+        ]:
+            command = globals()[name]("INST", "ABORT", extra=extra)
+            self.assertEqual(command["extra"], extra)
+
+    def test_cmd_rejects_invalid_extra_metadata(self):
+        with self.assertRaisesRegex(RuntimeError, "Invalid extra parameter: invalid. Must be a dict"):
+            cmd("INST", "ABORT", extra="invalid")
+
     def test_cmd_warns_about_required_parameters(self):
         for name in [
             "cmd",

--- a/openc3/python/test/microservices/test_interface_microservice.py
+++ b/openc3/python/test/microservices/test_interface_microservice.py
@@ -532,6 +532,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
             b"hazardous_check": b"TRUE",
             b"cmd_string": b"cmd('INST ABORT')",
             b"username": b"test_user",
+            b"extra": json.dumps({"flow_uuid": "1234-5678", "username": "untrusted"}).encode(),
             b"queue_username": b"DEFAULT__MULTI__INST",
             b"validate": b"TRUE",
             b"manual": b"FALSE",
@@ -543,6 +544,7 @@ class TestInterfaceMicroservice(unittest.TestCase):
         # queue_username must be copied into the command extra so Command History
         # can show "Queued By" for queued commands
         command = mock_write.call_args[0][0]
+        self.assertEqual(command.extra["flow_uuid"], "1234-5678")
         self.assertEqual(command.extra["username"], "test_user")
         self.assertEqual(command.extra.get("queue_username"), "DEFAULT__MULTI__INST")
 

--- a/openc3/python/test/models/test_queue_model.py
+++ b/openc3/python/test/models/test_queue_model.py
@@ -97,6 +97,26 @@ class TestQueueModel(unittest.TestCase):
 
     @patch("openc3.models.queue_model.Store")
     @patch("openc3.models.queue_model.QueueModel.get_model")
+    def test_queue_command_with_extra_metadata(self, mock_get_model, mock_store):
+        mock_model = Mock()
+        mock_model.state = "RUNNING"
+        mock_get_model.return_value = mock_model
+        mock_store.zrevrange.return_value = []
+
+        with patch("time.time_ns", return_value=1234567890):
+            QueueModel.queue_command(
+                "TEST",
+                command="CMD",
+                username="user",
+                scope="DEFAULT",
+                extra={"flow_uuid": "1234-5678"},
+            )
+
+        queued = json.loads(next(iter(mock_store.zadd.call_args.args[1])))
+        self.assertEqual(queued["extra"], {"flow_uuid": "1234-5678"})
+
+    @patch("openc3.models.queue_model.Store")
+    @patch("openc3.models.queue_model.QueueModel.get_model")
     def test_queue_command_with_existing_items(self, mock_get_model, mock_store):
         mock_model = Mock()
         mock_model.state = "RUNNING"

--- a/openc3/python/test/script/test_commands.py
+++ b/openc3/python/test/script/test_commands.py
@@ -149,6 +149,12 @@ class TestCommands(unittest.TestCase):
             )
         self.assertEqual(gArgs, ("INST ABORT",))
 
+    def test_sends_extra_metadata(self):
+        extra = {"flow_uuid": "1234-5678", "hv_id": 42}
+        for _stdout in capture_io():
+            cmd("INST ABORT", extra=extra)
+        self.assertEqual(gKwargs["extra"], extra)
+
     def test_sends_a_cmd_raw(self):
         global gArgs
         global gKwargs

--- a/openc3/spec/api/cmd_api_spec.rb
+++ b/openc3/spec/api/cmd_api_spec.rb
@@ -147,6 +147,18 @@ module OpenC3
           expect(command['username']).to_not eql 'original_author'
         end
 
+        it "carries extra metadata" do
+          extra = { 'flow_uuid' => '1234-5678', 'hv_id' => 42 }
+          command = @api.send(method, "INST", "ABORT", extra: extra)
+          expect(command['extra']).to eql extra
+        end
+
+        it "rejects invalid extra metadata" do
+          expect { @api.send(method, "INST", "ABORT", extra: 'invalid') }.to raise_error(
+            "Invalid extra parameter: invalid. Must be a Hash."
+          )
+        end
+
         it "warns about required parameters" do
           expect { @api.send(method, "INST COLLECT with DURATION 5") }.to raise_error(/Required/)
         end

--- a/openc3/spec/microservices/interface_microservice_spec.rb
+++ b/openc3/spec/microservices/interface_microservice_spec.rb
@@ -281,13 +281,16 @@ module OpenC3
 
         # queue_username is the original author (shown as "Queued By"), passed
         # by the queue microservice when a command is released from a queue
-        @api.cmd("INST", "ABORT", queue_username: "DEFAULT__MULTI__INST")
+        @api.cmd("INST", "ABORT", queue_username: "DEFAULT__MULTI__INST",
+          extra: { 'flow_uuid' => '1234-5678', 'username' => 'untrusted' })
         sleep 0.01
         im.shutdown
 
         expect(captured).to_not be_nil
         expect(captured.target_name).to eql("INST")
         expect(captured.packet_name).to eql("ABORT")
+        expect(captured.extra['flow_uuid']).to eql('1234-5678')
+        expect(captured.extra['username']).to_not eql('untrusted')
         expect(captured.extra['queue_username']).to eql("DEFAULT__MULTI__INST")
       end
 

--- a/openc3/spec/microservices/queue_microservice_spec.rb
+++ b/openc3/spec/microservices/queue_microservice_spec.rb
@@ -86,7 +86,10 @@ module OpenC3
     describe '#process_queued_commands' do
       let(:command1) { { 'username' => 'test_user', 'value' => 'cmd("TARGET", "COMMAND", {"PARAM": 1})' } }
       let(:command2) { { 'username' => 'test_user', 'value' => 'cmd("TARGET", "COMMAND2", {"PARAM": 2})' } }
-      let(:command3_new_format) { { 'username' => 'test_user', 'target_name' => 'TARGET', 'cmd_name' => 'COMMAND3', 'cmd_params' => JSON.generate({ 'PARAM' => 3 }) } }
+      let(:command3_new_format) do
+        { 'username' => 'test_user', 'target_name' => 'TARGET', 'cmd_name' => 'COMMAND3',
+          'cmd_params' => JSON.generate({ 'PARAM' => 3 }), 'extra' => { 'flow_uuid' => '1234-5678' } }
+      end
       let(:command4_new_format) { { 'username' => 'test_user', 'target_name' => 'TARGET', 'cmd_name' => 'COMMAND4' } }
 
       before do
@@ -114,9 +117,9 @@ module OpenC3
 
         expect(Store).to have_received(:bzpopmin).exactly(3).times
         expect(processor).to have_received(:cmd)
-          .with(command1['value'], queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user')
+          .with(command1['value'], queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user', extra: nil)
         expect(processor).to have_received(:cmd)
-          .with(command2['value'], queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user')
+          .with(command2['value'], queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user', extra: nil)
       end
 
       it 'processes commands with new format (target_name, cmd_name, cmd_params)' do
@@ -136,7 +139,8 @@ module OpenC3
 
         expect(Store).to have_received(:bzpopmin).exactly(2).times
         expect(processor).to have_received(:cmd)
-          .with('TARGET', 'COMMAND3', { 'PARAM' => 3 }, queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user')
+          .with('TARGET', 'COMMAND3', { 'PARAM' => 3 }, queue: false, scope: scope, timeout: nil, validate: true,
+            queue_username: 'test_user', extra: { 'flow_uuid' => '1234-5678' })
       end
 
       it 'processes commands with new format without cmd_params' do
@@ -156,7 +160,7 @@ module OpenC3
 
         expect(Store).to have_received(:bzpopmin).exactly(2).times
         expect(processor).to have_received(:cmd)
-          .with('TARGET', 'COMMAND4', {}, queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user')
+          .with('TARGET', 'COMMAND4', {}, queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user', extra: nil)
       end
 
       it 'processes mixed legacy and new format commands' do
@@ -178,9 +182,10 @@ module OpenC3
 
         expect(Store).to have_received(:bzpopmin).exactly(3).times
         expect(processor).to have_received(:cmd)
-          .with(command1['value'], queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user')
+          .with(command1['value'], queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user', extra: nil)
         expect(processor).to have_received(:cmd)
-          .with('TARGET', 'COMMAND3', { 'PARAM' => 3 }, queue: false, scope: scope, timeout: nil, validate: true, queue_username: 'test_user')
+          .with('TARGET', 'COMMAND3', { 'PARAM' => 3 }, queue: false, scope: scope, timeout: nil, validate: true,
+            queue_username: 'test_user', extra: { 'flow_uuid' => '1234-5678' })
       end
 
       it 'processes legacy command with validate false and timeout 0' do
@@ -200,7 +205,7 @@ module OpenC3
         processor.process_queued_commands
 
         expect(processor).to have_received(:cmd)
-          .with(command_no_validate['value'], queue: false, scope: scope, timeout: 0, validate: false, queue_username: 'test_user')
+          .with(command_no_validate['value'], queue: false, scope: scope, timeout: 0, validate: false, queue_username: 'test_user', extra: nil)
       end
 
       it 'processes new format command with validate false and timeout 0' do
@@ -220,7 +225,7 @@ module OpenC3
         processor.process_queued_commands
 
         expect(processor).to have_received(:cmd)
-          .with('TARGET', 'COMMAND3', { 'PARAM' => 3 }, queue: false, scope: scope, timeout: 0, validate: false, queue_username: 'test_user')
+          .with('TARGET', 'COMMAND3', { 'PARAM' => 3 }, queue: false, scope: scope, timeout: 0, validate: false, queue_username: 'test_user', extra: nil)
       end
 
       it 'logs error for invalid command format (missing required fields)' do

--- a/openc3/spec/models/queue_model_spec.rb
+++ b/openc3/spec/models/queue_model_spec.rb
@@ -152,7 +152,8 @@ module OpenC3
         model.create
         allow(QueueTopic).to receive(:write_notification)
 
-        QueueModel.queue_command("TEST", target_name: "INST", cmd_name: "COLLECT", cmd_params: { "TYPE" => "NORMAL" }, username: 'test_user', scope: "DEFAULT")
+        QueueModel.queue_command("TEST", target_name: "INST", cmd_name: "COLLECT", cmd_params: { "TYPE" => "NORMAL" },
+          extra: { "flow_uuid" => "1234-5678" }, username: 'test_user', scope: "DEFAULT")
 
         commands = Store.zrange("DEFAULT:TEST", 0, -1).map { |cmd| JSON.parse(cmd) }
         expect(commands).to contain_exactly({
@@ -160,6 +161,7 @@ module OpenC3
           "target_name" => "INST",
           "cmd_name" => "COLLECT",
           "cmd_params" => "{\"TYPE\":\"NORMAL\"}",
+          "extra" => { "flow_uuid" => "1234-5678" },
           "validate" => true,
           "timestamp" => anything
         })

--- a/openc3/spec/script/commands_spec.rb
+++ b/openc3/spec/script/commands_spec.rb
@@ -32,6 +32,7 @@ module OpenC3
       include Extract
       include Api
       include Authorization
+      attr_reader :last_kw_params
       def shutdown
       end
 
@@ -43,6 +44,7 @@ module OpenC3
       end
 
       def method_missing(name, *params, **kw_params)
+        @last_kw_params = kw_params
         self.send(name, *params, **kw_params)
       end
     end
@@ -136,6 +138,14 @@ module OpenC3
               stdout.rewind
               cmd("INST", "ABORT")
               expect(stdout.string).to match(/#{@prefix}cmd\(\"INST ABORT\"\)/) # "
+            end
+          end
+
+          if connect == 'connected'
+            it "sends extra metadata" do
+              extra = { 'flow_uuid' => '1234-5678', 'hv_id' => 42 }
+              capture_io { cmd("INST ABORT", extra: extra) }
+              expect(@api.last_kw_params[:extra]).to eql(extra)
             end
           end
 


### PR DESCRIPTION
## Summary

- add an optional `extra` Hash/dict to the `cmd` API family and scripting wrappers
- JSON-encode metadata through the command topic and merge it into `command.extra` before interface write
- preserve metadata through command queues and hazardous-command retries
- keep COSMOS-owned audit fields authoritative when caller keys conflict
- document the new command option for Ruby and Python

`Commands.build_cmd` continues to clear `command.extra`; caller metadata is applied to the newly built packet in `InterfaceMicroservice`, avoiding stale template metadata.

## Testing

- Python focused suite on current `main`: 99 tests passed
- Ruby focused suite on current `main`: 346 examples, 0 failures
- Python focused suite on a `v7.2.1` backport: 95 tests passed
- Ruby focused suite on a `v7.2.1` backport: 346 examples, 0 failures
- Ruff formatting/checks and `git diff --check` passed
- Built patched Core and Enterprise 7.2.1 API/operator images locally
- End-to-end CGE test: JSON-RPC command with `extra={flow_uuid,hv_id}` produced a native 19-byte CCSDS APID 552 command and the write protocol received the same metadata in its JSON envelope