### PR TITLE
fix(admin): disable settings fields while loading

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/AiChatSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/AiChatSettings.vue
@@ -29,6 +29,7 @@
         label="Enable the in-app AI Chatbot. When disabled, the AI
         chat button and drawer are hidden for all users."
         color="primary"
+        :disabled="settingsLoading"
         data-test="ai-chat-enabled"
       />
     </v-card-text>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/AstroSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/AstroSettings.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2024 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -24,7 +24,12 @@
       Saved! (Refresh the page to see changes)
     </v-alert>
     <v-card-text class="pb-0">
-      <v-switch v-model="hideClock" label="Hide Astro Clock" color="primary" />
+      <v-switch
+        v-model="hideClock"
+        label="Hide Astro Clock"
+        color="primary"
+        :disabled="settingsLoading"
+      />
     </v-card-text>
     <v-card-actions>
       <v-btn

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/ClassificationBannerSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/ClassificationBannerSettings.vue
@@ -29,6 +29,7 @@
           <v-text-field
             v-model="text"
             label="Text"
+            :disabled="settingsLoading"
             data-test="classification-banner-text"
           />
         </v-col>
@@ -40,6 +41,7 @@
             label="Background color"
             :items="colors"
             item-title="text"
+            :disabled="settingsLoading"
             data-test="classification-banner-background-color"
           >
             <template v-if="selectedBackgroundColor" #prepend-inner>
@@ -61,7 +63,7 @@
             v-model="customBackgroundColor"
             label="Custom background color"
             :hint="customColorHint"
-            :disabled="selectedBackgroundColor !== false"
+            :disabled="settingsLoading || selectedBackgroundColor !== false"
             :rules="[rules.customColor]"
             data-test="classification-banner-custom-background-color"
           >
@@ -81,6 +83,7 @@
             label="Font color"
             :items="colors"
             item-title="text"
+            :disabled="settingsLoading"
             data-test="classification-banner-font-color"
           >
             <template v-if="selectedFontColor" #prepend-inner>
@@ -104,7 +107,7 @@
             v-model="customFontColor"
             label="Custom font color"
             :hint="customColorHint"
-            :disabled="selectedFontColor !== false"
+            :disabled="settingsLoading || selectedFontColor !== false"
             :rules="[rules.customColor]"
             data-test="classification-banner-custom-font-color"
           >
@@ -122,6 +125,7 @@
             v-model="displayTopBanner"
             label="Display top banner"
             color="primary"
+            :disabled="settingsLoading"
             data-test="display-top-banner"
           />
         </v-col>
@@ -130,7 +134,7 @@
             v-model="topHeight"
             control-variant="stacked"
             label="Top height"
-            :disabled="!displayTopBanner"
+            :disabled="settingsLoading || !displayTopBanner"
             suffix="px"
             data-test="classification-banner-top-height"
           />
@@ -140,6 +144,7 @@
             v-model="displayBottomBanner"
             label="Display bottom banner"
             color="primary"
+            :disabled="settingsLoading"
             data-test="display-bottom-banner"
           />
         </v-col>
@@ -148,7 +153,7 @@
             v-model="bottomHeight"
             control-variant="stacked"
             label="Bottom height"
-            :disabled="!displayBottomBanner"
+            :disabled="settingsLoading || !displayBottomBanner"
             suffix="px"
             data-test="classification-banner-bottom-height"
           />

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/ContextTagSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/ContextTagSettings.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -34,7 +34,7 @@
             v-model="text"
             label="Text"
             data-test="context-tag-text"
-            :disabled="!displayContextTag"
+            :disabled="settingsLoading || !displayContextTag"
           />
         </v-col>
       </v-row>
@@ -44,6 +44,7 @@
             v-model="displayContextTag"
             label="Display context tag"
             color="primary"
+            :disabled="settingsLoading"
             data-test="display-context-tag"
           />
         </v-col>
@@ -53,6 +54,7 @@
             label="Background color"
             :items="colors"
             item-title="text"
+            :disabled="settingsLoading"
             data-test="context-tag-background-color"
           >
             <template v-if="selectedBackgroundColor" #prepend-inner>
@@ -74,7 +76,7 @@
             v-model="customBackgroundColor"
             label="Custom background color"
             :hint="customColorHint"
-            :disabled="selectedBackgroundColor !== false"
+            :disabled="settingsLoading || selectedBackgroundColor !== false"
             :rules="[rules.customColor]"
             data-test="context-tag-custom-background-color"
           >
@@ -94,6 +96,7 @@
             label="Font color"
             :items="colors"
             item-title="text"
+            :disabled="settingsLoading"
             data-test="context-tag-font-color"
           >
             <template v-if="selectedFontColor" #prepend-inner>
@@ -117,7 +120,7 @@
             v-model="customFontColor"
             label="Custom font color"
             :hint="customColorHint"
-            :disabled="selectedFontColor !== false"
+            :disabled="settingsLoading || selectedFontColor !== false"
             :rules="[rules.customColor]"
             data-test="context-tag-custom-font-color"
           >

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/EditorSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/EditorSettings.vue
@@ -46,6 +46,7 @@
         unlock. Disable to allow multiple users to edit the same script
         concurrently (last save wins)."
         color="primary"
+        :disabled="settingsLoading"
         data-test="script-locking-enabled"
       />
       <template v-if="isEnterprise">
@@ -61,7 +62,7 @@
         </v-alert>
         <v-switch
           v-model="lifecycleEnabled"
-          :disabled="!gitHistoryEnabled"
+          :disabled="settingsLoading || !gitHistoryEnabled"
           label="Script Lifecycle - When enabled, scripts are tracked through
           In Development, In Review, and Approved states. Users with the script_edit permission
           can move scripts to In Review, and users with the script_approver permission may approve scripts.

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/NewsFeedSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/NewsFeedSettings.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -29,6 +29,7 @@
         label="Allow COSMOS backend to pull the news feed from the COSMOS external news site.
         This is a low bandwidth poll which only happens every 12 hrs. To immediately update the news feed, click the 'Refresh' in the User Menu."
         color="primary"
+        :disabled="settingsLoading"
       />
     </v-card-text>
     <v-card-actions>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/PypiSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/PypiSettings.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2024 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -28,7 +28,12 @@
       Saved! (Refresh the page to see changes)
     </v-alert>
     <v-card-text class="pb-0">
-      <v-text-field v-model="pypiUrl" label="Pypi URL" data-test="pypi-url" />
+      <v-text-field
+        v-model="pypiUrl"
+        label="Pypi URL"
+        :disabled="settingsLoading"
+        data-test="pypi-url"
+      />
     </v-card-text>
     <v-card-actions>
       <v-btn

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/RubyGemsSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/RubyGemsSettings.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2024 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -31,6 +31,7 @@
       <v-text-field
         v-model="rubygemsUrl"
         label="Rubygems URL"
+        :disabled="settingsLoading"
         data-test="rubygems-url"
       />
     </v-card-text>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/SourceCodeSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/SourceCodeSettings.vue
@@ -30,6 +30,7 @@
       <v-text-field
         v-model="sourceUrl"
         label="Source URL"
+        :disabled="settingsLoading"
         data-test="source-url"
       />
     </v-card-text>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/SubtitleSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/SubtitleSettings.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2024 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -28,7 +28,12 @@
       Saved! (Refresh the page to see changes)
     </v-alert>
     <v-card-text class="pb-0">
-      <v-text-field v-model="subtitle" label="Subtitle" data-test="subtitle" />
+      <v-text-field
+        v-model="subtitle"
+        label="Subtitle"
+        :disabled="settingsLoading"
+        data-test="subtitle"
+      />
     </v-card-text>
     <v-card-actions>
       <v-btn

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/ThemeSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/ThemeSettings.vue
@@ -29,6 +29,7 @@
         :items="themeOptions"
         item-title="label"
         item-value="value"
+        :disabled="settingsLoading"
         data-test="theme-select"
       />
     </v-card-text>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/TimeFormatSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/TimeFormatSettings.vue
@@ -36,6 +36,7 @@
         hide-details
         prepend-icon="mdi-clock-outline"
         single-line
+        :disabled="settingsLoading"
         data-test="time-format"
       />
     </v-card-text>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/TimeZoneSettings.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/TimeZoneSettings.vue
@@ -36,6 +36,7 @@
         hide-details
         prepend-icon="mdi-map-clock"
         single-line
+        :disabled="settingsLoading"
         data-test="time-zone"
       />
     </v-card-text>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/settings.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/settings.js
@@ -49,6 +49,9 @@ export default {
         })
     },
     saveSetting: function (setting, jsonString, kwparams) {
+      if (this.settingsLoading) {
+        return
+      }
       this.api
         .set_setting(setting, jsonString, kwparams)
         .then(() => {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/settings.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/settings/settings.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -21,11 +21,20 @@ export default {
       errorLoading: false,
       errorSaving: false,
       successSaving: false,
+      // Number of get_setting requests still in flight. Fields are disabled
+      // while loading so a response can't overwrite what the user just typed.
+      pendingLoads: 0,
     }
+  },
+  computed: {
+    settingsLoading: function () {
+      return this.pendingLoads > 0
+    },
   },
   methods: {
     loadSetting: function (setting, kwparams) {
-      this.api
+      this.pendingLoads++
+      return this.api
         .get_setting(setting, kwparams)
         .then((response) => {
           this.parseSetting(response, { setting })
@@ -34,6 +43,9 @@ export default {
           this.parseSetting(null)
           this.errorText = error
           this.errorLoading = true
+        })
+        .finally(() => {
+          this.pendingLoads--
         })
     },
     saveSetting: function (setting, jsonString, kwparams) {


### PR DESCRIPTION
A get_setting response landing after the user started editing overwrote their input, and a following save persisted the stale value. Track in-flight loads in the settings mixin and disable API-backed fields until they resolve. Fixes a flaky rubygems-url Playwright test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)