### PR TITLE
[Enhancement] Update playback button spacing

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
@@ -27,11 +27,7 @@
     :icon="false"
   >
     <span class="d-inline-flex align-center">
-      <v-icon
-        icon="mdi-play-circle-outline"
-        size="16"
-        class="mr-2"
-      />
+      <v-icon icon="mdi-play-circle-outline" size="16" class="mr-2" />
       Playback Mode
     </span>
   </v-alert>

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/TlmViewer.vue
@@ -17,7 +17,24 @@
 
 <template>
   <top-bar :title="title" :menus="menus" />
-  <div v-if="playbackMode === 'playback'" class="playback">Playback Mode</div>
+  <v-alert
+    v-if="playbackMode === 'playback'"
+    class="playback text-overline mb-1 py-0 align-center justify-center flex-0-0"
+    type="warning"
+    variant="tonal"
+    density="compact"
+    border="start"
+    :icon="false"
+  >
+    <span class="d-inline-flex align-center">
+      <v-icon
+        icon="mdi-play-circle-outline"
+        size="16"
+        class="mr-2"
+      />
+      Playback Mode
+    </span>
+  </v-alert>
   <v-expansion-panels v-model="panel" class="mb-1">
     <v-expansion-panel>
       <v-expansion-panel-title class="pulse-i"></v-expansion-panel-title>
@@ -181,7 +198,7 @@
               suffix="secs"
               :step="1"
               data-test="playback-speed"
-              style="max-width: 120px"
+              style="max-width: 180px"
             />
             <v-number-input
               v-model="playbackSkip"
@@ -194,7 +211,7 @@
               suffix="secs"
               :step="1"
               data-test="skip"
-              style="max-width: 120px"
+              style="max-width: 180px"
             />
           </v-row>
         </div>
@@ -835,11 +852,9 @@ export default {
 </script>
 
 <style scoped>
-.playback {
-  text-align: center;
-  color: black;
-  font-weight: bold;
-  background-color: darkorange;
+.playback :deep(.v-alert__content) {
+  /* v-alert pads content to fit its default 28px icon; ours is 18px */
+  padding-block: 0;
 }
 .v-application {
   /* fix for playwright scrolling I guess? */


### PR DESCRIPTION
Wanted to give the step/skip buttons more space, and then also updated the playback banner that works better with themes.

<img width="1401" height="305" alt="Screenshot 2026-08-11 at 4 07 58 PM" src="https://github.com/user-attachments/assets/6b986f22-06af-4908-b94d-bf038c616fd0" />
