### PR TITLE
fix(test): wait for microservice run thread before writing to topics

### DIFF
--- a/openc3/python/test/api/test_limits_api.py
+++ b/openc3/python/test/api/test_limits_api.py
@@ -67,7 +67,10 @@ class TestLimitsApi(unittest.TestCase):
         self.dm = DecomMicroservice("DEFAULT__DECOM__INST_INT")
         self.dm_thread = threading.Thread(target=self.dm.run)
         self.dm_thread.start()
-        time.sleep(0.001)  # Allow the threads to run
+        # Allow the run thread to start reading. Tests here call inject_tlm,
+        # which writes to the DECOMINTERFACE topic and waits 5s for an ack from
+        # this thread: anything written before its first read is skipped.
+        wait_for_first_topic_read(redis, self.dm_thread)
 
     def tearDown(self):
         self.dm.shutdown()

--- a/openc3/python/test/microservices/test_decom_microservice.py
+++ b/openc3/python/test/microservices/test_decom_microservice.py
@@ -29,7 +29,7 @@ from openc3.topics.limits_event_topic import LimitsEventTopic
 from openc3.topics.telemetry_topic import TelemetryTopic
 from openc3.topics.topic import Topic
 from openc3.utilities.store import Store
-from test.test_helper import capture_io, mock_redis, setup_system
+from test.test_helper import capture_io, mock_redis, setup_system, wait_for_first_topic_read
 
 
 class TestDecomMicroservice(unittest.TestCase):
@@ -75,7 +75,7 @@ class TestDecomMicroservice(unittest.TestCase):
         self.dm = DecomMicroservice("DEFAULT__DECOM__INST_INT")
         self.dm_thread = threading.Thread(target=self.dm.run)
         self.dm_thread.start()
-        time.sleep(0.01)  # Allow the thread to start
+        wait_for_first_topic_read(redis, self.dm_thread)  # Allow the thread to start reading
 
     def tearDown(self):
         self.dm.shutdown()
@@ -368,7 +368,7 @@ class TestDecomMicroservice(unittest.TestCase):
         for stdout in capture_io():
             TelemetryTopic.write_packet(packet, scope="DEFAULT")
             # Wait for async processing to complete with retries for CI reliability
-            for _ in range(20):
+            for _ in range(500):
                 time.sleep(0.01)
                 if "Bad response" in stdout.getvalue():
                     break
@@ -429,7 +429,7 @@ class TestDecomMicroserviceStoredLimitsMode(unittest.TestCase):
             self.dm = DecomMicroservice("DEFAULT__DECOM__INST_INT")
         self.dm_thread = threading.Thread(target=self.dm.run)
         self.dm_thread.start()
-        time.sleep(0.01)
+        wait_for_first_topic_read(redis, self.dm_thread)
 
     def tearDown(self):
         if hasattr(self, "dm"):

--- a/openc3/python/test/test_helper.py
+++ b/openc3/python/test/test_helper.py
@@ -23,6 +23,8 @@ import io
 import json
 import queue
 import sys
+import threading
+import time
 
 import fakeredis
 
@@ -119,6 +121,27 @@ def setup_system(targets=None):
             pass
 
 
+class XreadTracker:
+    """Wraps xread to record which threads have issued a read.
+
+    Topic offsets are tracked per thread (see StoreImplementation.read_topics),
+    so a microservice run thread only receives messages written after its own
+    first read. Tests use wait_for_first_topic_read to wait for that read rather
+    than sleeping a fixed amount.
+    """
+
+    def __init__(self, xread):
+        self.xread = xread
+        self.thread_ids = set()
+
+    def __call__(self, *args, **kwargs):
+        # Record before delegating: read_topics has already snapshotted the
+        # topic offsets by the time it calls xread, so anything written from
+        # here on is guaranteed to be delivered to this thread.
+        self.thread_ids.add(threading.get_native_id())
+        return self.xread(*args, **kwargs)
+
+
 def mock_redis(self):
     """Ensure the store builds a new instance of valkey and doesn't
     reuse the existing instance which results in a reused FakeValkey.
@@ -131,6 +154,11 @@ def mock_redis(self):
     """
     redis = fakeredis.FakeValkey()
     redis.flushall()
+    # Track reads by thread so tests can wait for a microservice run thread to
+    # start reading. Tests that replace redis.xread themselves wrap this
+    # tracker, so it still sees every read.
+    redis.openc3_xread_tracker = XreadTracker(redis.xread)
+    redis.xread = redis.openc3_xread_tracker
     patcher = patch("valkey.Valkey", return_value=redis)
     patcher.start()
     self.addCleanup(patcher.stop)
@@ -175,6 +203,30 @@ class BucketMock:
     def data(self, key):
         data = self.objs[key]
         return zlib.decompress(data)
+
+
+def wait_for_first_topic_read(redis, thread, timeout=5):
+    """Block until the given thread has issued its first xread.
+
+    Call this after starting a microservice run thread, instead of sleeping.
+
+    Topic offsets are tracked per thread (see StoreImplementation.read_topics),
+    so the offsets recorded by Topic.update_topic_offsets when a microservice is
+    constructed on the main thread do not apply to its run thread. That thread
+    records its own start offset on its first read_topics call, which is the
+    current end of the stream, so anything written before then is skipped and
+    never processed. Sleeping a fixed amount after Thread.start() is racy: on a
+    loaded CI runner the run thread can reach its first read after the test has
+    already written to the topic.
+    """
+    tracker = redis.openc3_xread_tracker
+    start = time.time()
+    while (time.time() - start) < timeout:
+        # native_id is only assigned once the thread is actually running
+        if thread.native_id is not None and thread.native_id in tracker.thread_ids:
+            return
+        time.sleep(0.001)
+    raise RuntimeError(f"Thread {thread.name} never read from its topics")
 
 
 def capture_io():


### PR DESCRIPTION
## Problem

Two Python unit tests recently failed randomly in CI, but a re-run passed:

- `test_decom_microservice.py::TestDecomMicroserviceStoredLimitsMode::test_log_mode_logs_but_skips_reactions_for_stored_packets` — `AssertionError: 'INST HEALTH_STATUS TEMP1' not found in ''` ([run](https://github.com/OpenC3/cosmos/actions/runs/31612899828/job/94168447716))
- `test_limits_api.py::TestLimitsApi::test_get_overall_limits_state_returns_the_overall_system_limits_state` — `RuntimeError: Timeout of 5s waiting for cmd ack. Does target 'INST' exist?` ([run](https://github.com/OpenC3/cosmos/actions/runs/31740807774/job/94583432022))

Both are the same root cause. Topic offsets are tracked per thread in `StoreImplementation.read_topics`:

```python
thread_id = threading.get_native_id()
if thread_id not in self.topic_offsets:
    self.topic_offsets[thread_id] = {}
...
if not offsets:
    offsets = self.update_topic_offsets(topics)   # -> get_last_offset()
```

`DecomMicroservice.__init__` calls `Topic.update_topic_offsets` on the **main** thread, so those offsets do not apply to its run thread. The run thread lazily records its own start offset — the current end of the stream — on its first `read_topics` call. Anything already in the topic at that moment is skipped forever.

The tests only guarded this with `time.sleep(0.001)` / `time.sleep(0.01)` after `Thread.start()`. On a loaded CI runner (4 matrix jobs, `coverage` tracing) thread startup plus `setup_microservice_topic()` exceeds that, the test's write lands first, and the message is dropped: no limits logs at all, or no ack for `inject_tlm` within its 5s timeout.

## Changes

- `test_helper.py`: `XreadTracker` wraps `xread` in `mock_redis` and records which threads have read. Tests that replace `redis.xread` themselves wrap the tracker, so it still sees every read.
- `test_helper.py`: `wait_for_first_topic_read(redis, thread)` blocks until that specific thread has issued its first read.
- `test_decom_microservice.py`, `test_limits_api.py`: replaced the fixed sleeps after `Thread.start()` with the new helper.
- `test_decom_microservice.py`: raised the `test_handles_exceptions_in_limits_responses` wait budget from 0.2s to 5s. Its assertion needs the third of three sequential log writes from `LimitsResponseThread`, which does not land inside 0.2s under coverage tracing — that test failed 18/20 runs locally under `coverage run`.

## Verification

- Injected a 0.3s delay into `DecomMicroservice.run` to force the losing interleaving: reproduces both failures exactly on `main` (`captured_bytes=0`, and the 5s ack timeout), and both pass with this change.
- 6x consecutive `coverage run -m pytest test/api/test_limits_api.py test/api/test_tlm_api.py test/microservices` — 224 passed each time.
- Full suite under coverage: 2730 passed. `ruff format --check` and `ruff check` clean.

## Not addressed

`test_interface_microservice.py` and `test_router_microservice.py` have the same shape of race but 0.1s of slack. This helper does not fit them: `InterfaceMicroservice.run` only reaches `read_topics` after the interface connects, and several tests deliberately prevent connecting, so waiting on a first read hangs and leaves the reconnect loop spinning. Guarding those sites needs a wait on connection state instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)