### PR TITLE
Fix Playwright failure (Enterprise)

### DIFF
--- a/.github/actions/build-cosmos/action.yml
+++ b/.github/actions/build-cosmos/action.yml
@@ -16,6 +16,15 @@ description: |
 
   Local developer builds via ./openc3.sh build are unaffected.
 
+  Enterprise checks core out at cosmos/, so its workflow uses this action as
+  ./cosmos/.github/actions/build-cosmos with working-directory: cosmos and
+  push-cache: false - the cache packages are written by core CI only. Note
+  that enterprise must also pin OPENC3_TAG to something other than "latest"
+  for the whole job: its own ./openc3.sh build calls build_core_images, which
+  re-runs `docker compose build` on every core image when the tag is "latest".
+  A pulled image does not seed the BuildKit layer cache, so that rebuild would
+  throw away everything this action just restored.
+
   The cleanup workflow at .github/workflows/cleanup-ghcr.yml prunes old
   cache entries nightly so the *-buildcache packages don't accumulate.
 
@@ -24,22 +33,59 @@ inputs:
     description: OPENC3_TAG to apply to the resulting docker.io/openc3inc/* tags.
     required: false
     default: latest
+  working-directory:
+    description: |
+      Directory holding compose.yaml, compose-build.yaml, .env and the image
+      build contexts. Must be inside a git checkout - the cache keys come from
+      `git ls-tree HEAD`.
+    required: false
+    default: .
+  push-cache:
+    description: |
+      Whether to push newly built images to the GHCR cache. Only the core repo
+      may write these packages: they are keyed on core's `git ls-tree HEAD`, so
+      an entry pushed from anywhere else could be built from a different core
+      tree than its hash claims. Consumers outside this repo (enterprise) pass
+      false and read the cache only.
+    required: false
+    default: "true"
+
+outputs:
+  images-file:
+    description: |
+      Path to a file of `<image>=<hash>` lines in topological order. A
+      downstream action that builds images FROM these can read it to chain
+      its own parent hashes.
+    value: ${{ steps.hashes.outputs.images-file }}
 
 runs:
   using: composite
   steps:
     - name: Compute per-image hashes
+      id: hashes
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        WORKDIR: ${{ inputs.working-directory }}
       # Spec rows are <name>|<context paths>|<parent images>, in topological
       # order (parents before children). Each image's hash chains its parents'
       # hashes so a base change cascades. 12 hex chars is plenty at our scale.
       run: |
         set -e
+        # Key the bookkeeping files on the working directory so a second
+        # invocation in the same job (enterprise builds core at cosmos/, then
+        # its own images at the workspace root) doesn't clobber the first.
+        slug=$(printf '%s' "$WORKDIR" | tr -c 'A-Za-z0-9' '-')
+        images_file="$RUNNER_TEMP/cosmos-images-${slug}.env"
+        misses_file="$RUNNER_TEMP/cosmos-misses-${slug}.txt"
+        echo "images-file=$images_file" >> "$GITHUB_OUTPUT"
+        echo "misses-file=$misses_file" >> "$GITHUB_OUTPUT"
+
         common=$(git ls-tree -r HEAD compose.yaml compose-build.yaml .env \
           | sha256sum | cut -c1-12)
 
         declare -A HASH
-        : > "$RUNNER_TEMP/cosmos-images.env"
+        : > "$images_file"
 
         while IFS='|' read -r name ctx_str parents_str; do
           [ -z "$name" ] && continue
@@ -59,7 +105,7 @@ runs:
           h=$(printf '%s %s %s' "$common" "$own" "$parent_hashes" \
             | sha256sum | cut -c1-12)
           HASH[$name]=$h
-          echo "${name}=${h}" >> "$RUNNER_TEMP/cosmos-images.env"
+          echo "${name}=${h}" >> "$images_file"
           echo "Hash[$name] = $h"
         done <<'EOF'
         openc3-ruby|openc3-ruby|
@@ -87,12 +133,14 @@ runs:
       shell: bash
       env:
         TAG: ${{ inputs.tag }}
+        IMAGES_FILE: ${{ steps.hashes.outputs.images-file }}
+        MISSES_FILE: ${{ steps.hashes.outputs.misses-file }}
       # For each image, attempt to pull its per-hash cache tag. On hit, retag
       # to docker.io/openc3inc/${name}:${TAG} so it serves as a local FROM
       # source for any downstream miss. Misses are recorded for the build step.
       run: |
         set -e
-        : > "$RUNNER_TEMP/cosmos-misses.txt"
+        : > "$MISSES_FILE"
         hits=0
         misses=0
         while IFS='=' read -r name hash; do
@@ -103,24 +151,26 @@ runs:
             hits=$((hits+1))
             echo "::notice::Cache HIT  ${name} (${hash})"
           else
-            echo "$name" >> "$RUNNER_TEMP/cosmos-misses.txt"
+            echo "$name" >> "$MISSES_FILE"
             misses=$((misses+1))
             echo "::notice::Cache MISS ${name} (${hash})"
           fi
-        done < "$RUNNER_TEMP/cosmos-images.env"
+        done < "$IMAGES_FILE"
         echo "::notice::Build cache: ${hits} hit, ${misses} miss"
 
     - name: Build missed images
       # script -q -e -c works around https://github.com/actions/runner/issues/241
       shell: 'script -q -e -c "bash {0}"'
+      working-directory: ${{ inputs.working-directory }}
       env:
         OPENC3_TAG: ${{ inputs.tag }}
+        MISSES_FILE: ${{ steps.hashes.outputs.misses-file }}
       # Misses are already in topological order (the hash step writes them
       # that way). Pulled parents are tagged locally as openc3inc/${name}:${TAG},
       # so a child-only miss resolves its FROM without rebuilding the parent.
       run: |
         set -e
-        if [ ! -s "$RUNNER_TEMP/cosmos-misses.txt" ]; then
+        if [ ! -s "$MISSES_FILE" ]; then
           echo "::notice::All images cached - skipping build"
           exit 0
         fi
@@ -132,17 +182,20 @@ runs:
           echo "::group::docker compose build ${name}"
           docker compose -f compose.yaml -f compose-build.yaml build "$name"
           echo "::endgroup::"
-        done < "$RUNNER_TEMP/cosmos-misses.txt"
+        done < "$MISSES_FILE"
 
     - name: Push built images to GHCR cache
+      if: ${{ inputs.push-cache == 'true' }}
       shell: bash
       env:
         TAG: ${{ inputs.tag }}
+        IMAGES_FILE: ${{ steps.hashes.outputs.images-file }}
+        MISSES_FILE: ${{ steps.hashes.outputs.misses-file }}
       # Best-effort: a push failure (e.g. fork PR with no packages:write) is
       # logged but does not fail the run.
       run: |
         set +e
-        if [ ! -s "$RUNNER_TEMP/cosmos-misses.txt" ]; then
+        if [ ! -s "$MISSES_FILE" ]; then
           echo "::notice::No images to push (all cached)"
           exit 0
         fi
@@ -150,7 +203,7 @@ runs:
         while IFS='=' read -r name hash; do
           [ -z "$name" ] && continue
           H[$name]=$hash
-        done < "$RUNNER_TEMP/cosmos-images.env"
+        done < "$IMAGES_FILE"
 
         while read -r name; do
           [ -z "$name" ] && continue
@@ -159,4 +212,4 @@ runs:
           if ! docker push "$dst"; then
             echo "::warning::Push failed for ${dst}"
           fi
-        done < "$RUNNER_TEMP/cosmos-misses.txt"
+        done < "$MISSES_FILE"

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,79 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+name: Setup Playwright
+description: |
+  Install the Playwright node dependencies and browsers with both expensive
+  pieces restored from actions/cache: the pnpm content-addressable store and
+  the ms-playwright browser binaries.
+
+  `playwright.sh install-playwright` is invoked with --no-clean so it keeps
+  the restored directories instead of deleting them (its default clean-slate
+  behavior is for developer machines).
+
+  The apt packages installed by `playwright install --with-deps` cannot be
+  cached, so that part still runs on every invocation. `playwright install`
+  is idempotent for binaries that are already present, so a browser cache hit
+  reduces it to the apt step.
+
+  Enterprise checks core out at cosmos/, so its workflow can use this action
+  as ./cosmos/.github/actions/setup-playwright with working-directory set to
+  cosmos/playwright.
+
+inputs:
+  working-directory:
+    description: Directory containing playwright.sh and package.json.
+    required: false
+    default: playwright
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve cache paths
+      id: paths
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        # The pnpm store location depends on the pnpm/action-setup config, so
+        # ask pnpm rather than hardcoding ~/.local/share/pnpm/store.
+        echo "store=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+        # Key the browser cache on the @playwright/test version rather than a
+        # lockfile hash: the lockfile churns on every unrelated dependabot bump,
+        # which would re-download all three browsers for no reason. Fail loudly
+        # rather than baking "null" into the key, which would never invalidate.
+        pw=$(jq -r '.dependencies["@playwright/test"] // .devDependencies["@playwright/test"] // ""' package.json)
+        if [[ -z "$pw" ]]; then
+          echo "ERROR: @playwright/test not found in package.json"
+          exit 1
+        fi
+        echo "pw=$pw" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ${{ steps.paths.outputs.store }}
+        key: pnpm-store-${{ runner.os }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', inputs.working-directory)) }}
+        restore-keys: pnpm-store-${{ runner.os }}-
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ms-playwright
+        # restore-keys is safe here because browsers install into per-version
+        # subdirectories (chromium-1234), so an older entry only costs disk and
+        # `playwright install` still fetches whatever is missing.
+        key: ms-playwright-${{ runner.os }}-${{ steps.paths.outputs.pw }}
+        restore-keys: ms-playwright-${{ runner.os }}-
+
+    - name: Install playwright dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: ./playwright.sh install-playwright --no-clean

--- a/.github/workflows/playwright-firefox-nightly.yml
+++ b/.github/workflows/playwright-firefox-nightly.yml
@@ -70,8 +70,18 @@ jobs:
           docker logs cosmos-openc3-operator-1
           docker logs cosmos-openc3-cosmos-cmd-tlm-api-1
           docker logs cosmos-openc3-cosmos-script-runner-api-1
-        # Build a test plugin for playwright and a copy so we can 'upgrade'
+        # Build a test plugin for playwright and a copy so we can 'upgrade'.
+        # The gems are a pure function of the plugin/target templates and the
+        # generator, so cache them rather than paying ~1.5 min of container
+        # startup and `gem build` on every run.
+      - name: Cache test plugin gems
+        id: pw_test_plugin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: playwright/openc3-cosmos-pw-test
+          key: pw-test-plugin-${{ hashFiles('openc3/templates/plugin/**', 'openc3/templates/target/**', 'openc3/lib/openc3/utilities/cli_generator.rb', 'playwright/playwright.sh') }}
       - name: Build plugin
+        if: steps.pw_test_plugin.outputs.cache-hit != 'true'
         shell: 'script -q -e -c "bash {0}"'
         run: ./playwright.sh build-plugin
         working-directory: playwright

--- a/.github/workflows/playwright-firefox-nightly.yml
+++ b/.github/workflows/playwright-firefox-nightly.yml
@@ -47,9 +47,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11
-      - name: Install playwright dependencies
-        run: ./playwright.sh install-playwright
-        working-directory: playwright
+      - uses: ./.github/actions/setup-playwright
       - name: Check for test.only
         run: pnpm playwright test --list --forbid-only
         working-directory: playwright

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,9 +62,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11
-      - name: Install playwright dependencies
-        run: ./playwright.sh install-playwright
-        working-directory: playwright
+      - uses: ./.github/actions/setup-playwright
       - name: Check for test.only
         run: pnpm playwright test --list --forbid-only
         working-directory: playwright

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -93,8 +93,18 @@ jobs:
             echo "ERROR: One or more containers are unhealthy"
             exit 1
           fi
-        # Build a test plugin for playwright and a copy so we can 'upgrade'
+        # Build a test plugin for playwright and a copy so we can 'upgrade'.
+        # The gems are a pure function of the plugin/target templates and the
+        # generator, so cache them rather than paying ~1.5 min of container
+        # startup and `gem build` on every run.
+      - name: Cache test plugin gems
+        id: pw_test_plugin
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: playwright/openc3-cosmos-pw-test
+          key: pw-test-plugin-${{ hashFiles('openc3/templates/plugin/**', 'openc3/templates/target/**', 'openc3/lib/openc3/utilities/cli_generator.rb', 'playwright/playwright.sh') }}
       - name: Build plugin
+        if: steps.pw_test_plugin.outputs.cache-hit != 'true'
         shell: 'script -q -e -c "bash {0}"'
         run: ./playwright.sh build-plugin
         working-directory: playwright

--- a/playwright/playwright.sh
+++ b/playwright/playwright.sh
@@ -2,7 +2,7 @@
 
 usage() {
   echo "Usage: $1 [install-playwright, build-plugin, reset-storage-state, run-chromium, run-aws]" >&2
-  echo "*  install-playwright: installs playwright and its dependencies" >&2
+  echo "*  install-playwright [--no-clean]: installs playwright and its dependencies" >&2
   echo "*  build-plugin: builds the plugin to be used in the playwright tests" >&2
   echo "*  reset-storage-state: clear out cached data" >&2
   echo "*  run-chromium: runs the playwright tests against a locally running version of Cosmos using Chrome" >&2
@@ -23,27 +23,36 @@ fi
 case $1 in
     install-playwright )
         if [[ "$2" == "--help" ]] || [[ "$2" == "-h" ]]; then
-            echo "Usage: $0 install-playwright"
+            echo "Usage: $0 install-playwright [--no-clean]"
             echo ""
             echo "Install Playwright and its dependencies."
             echo ""
             echo "This command:"
-            echo "  - Removes cached Playwright browser binaries"
-            echo "  - Removes node_modules directory"
+            echo "  - Removes cached Playwright browser binaries (unless --no-clean)"
+            echo "  - Removes node_modules directory (unless --no-clean)"
             echo "  - Runs pnpm install with frozen lockfile"
             echo "  - Installs Playwright browsers with dependencies"
             echo "  - Resets storage state"
             echo ""
             echo "Options:"
             echo "  -h, --help    Show this help message"
+            echo "  --no-clean    Keep the browser cache and node_modules. Used by CI,"
+            echo "                where those directories are restored from an"
+            echo "                actions/cache entry that a wipe would discard."
             exit 0
         fi
-        # Attempt to clean up downloaded browser binaries
-        #   https://playwright.dev/docs/ci#directories-to-cache
-        [[ -d $HOME/.cache/ms-playwright ]] && rm -rf $HOME/.cache/ms-playwright # linux
-        [[ -d $HOME/Library/Caches/ms-playwright ]] && rm -rf $HOME/Library/Caches/ms-playwright # mac
+        # The wipes give a clean slate on a developer machine, where stale browser
+        # binaries left over from an older @playwright/test produce "Executable
+        # doesn't exist" at run time. CI passes --no-clean because the runner
+        # starts fresh anyway and the directories come from a restored cache.
+        if [[ "$2" != "--no-clean" ]]; then
+            # Attempt to clean up downloaded browser binaries
+            #   https://playwright.dev/docs/ci#directories-to-cache
+            [[ -d $HOME/.cache/ms-playwright ]] && rm -rf $HOME/.cache/ms-playwright # linux
+            [[ -d $HOME/Library/Caches/ms-playwright ]] && rm -rf $HOME/Library/Caches/ms-playwright # mac
 
-        rm -rf node_modules
+            rm -rf node_modules
+        fi
 
         pnpm install --frozen-lockfile --ignore-scripts; pnpm exec playwright install --with-deps; pnpm playwright --version
 

--- a/playwright/tests/script-runner/api.s.spec.ts
+++ b/playwright/tests/script-runner/api.s.spec.ts
@@ -151,7 +151,10 @@ test('runs a script', async ({ page, utils }) => {
       .map((item) => parseInt(item.name, 10))
     return Math.max(...ids).toString() // ids increase, so ours is the largest
   })
-  expect(scriptId, 'no running disconnect.rb script found via /script-api/running-script').toMatch(/^\d+$/)
+  expect(
+    scriptId,
+    'no running disconnect.rb script found via /script-api/running-script',
+  ).toMatch(/^\d+$/)
 
   await page.locator('[data-test="script-runner-script"]').click()
   await page.getByText('Execution Status').click()
@@ -204,6 +207,11 @@ test('test python stash apis', async ({ page, utils }) => {
   await runScript(page, utils, 'stash.py')
 })
 
+// Tagged @admin because the redis clear below hits POST /openc3-api/redis/exec,
+// which requires the 'admin' permission. The Enterprise fixture picks
+// credentials once at setup from the @admin tag or an 'admin' toolPath, and this
+// spec's toolPath is /tools/scriptrunner, so without the tag the session is the
+// operator and the clear comes back 403.
 async function testMetadataApis(
   page: Page,
   utils: Utilities,
@@ -278,7 +286,7 @@ async function testMetadataApis(
   )
 }
 
-test('test ruby metadata apis', async ({ page, utils }) => {
+test('test ruby metadata apis', { tag: '@admin' }, async ({ page, utils }) => {
   await testMetadataApis(page, utils, 'metadata.rb')
   await expect(page.locator('[data-test=output-messages]')).toContainText(
     '"setkey" => 1',
@@ -294,21 +302,25 @@ test('test ruby metadata apis', async ({ page, utils }) => {
   )
 })
 
-test('test python metadata apis', async ({ page, utils }) => {
-  await testMetadataApis(page, utils, 'metadata.py')
-  await expect(page.locator('[data-test=output-messages]')).toContainText(
-    "'setkey': 1",
-  )
-  await expect(page.locator('[data-test=output-messages]')).toContainText(
-    "'setkey': 2",
-  )
-  await expect(page.locator('[data-test=output-messages]')).toContainText(
-    "'updatekey': 3",
-  )
-  await expect(page.locator('[data-test=output-messages]')).toContainText(
-    "'inputkey_metadata.py': 'inputvalue'",
-  )
-})
+test(
+  'test python metadata apis',
+  { tag: '@admin' },
+  async ({ page, utils }) => {
+    await testMetadataApis(page, utils, 'metadata.py')
+    await expect(page.locator('[data-test=output-messages]')).toContainText(
+      "'setkey': 1",
+    )
+    await expect(page.locator('[data-test=output-messages]')).toContainText(
+      "'setkey': 2",
+    )
+    await expect(page.locator('[data-test=output-messages]')).toContainText(
+      "'updatekey': 3",
+    )
+    await expect(page.locator('[data-test=output-messages]')).toContainText(
+      "'inputkey_metadata.py': 'inputvalue'",
+    )
+  },
+)
 
 // The screen APIs were originally exercised by a single long script that
 // chained ~10 transient-state assertions. Each screen was only visible for a

--- a/playwright/tests/script-runner/api.s.spec.ts
+++ b/playwright/tests/script-runner/api.s.spec.ts
@@ -15,6 +15,7 @@
 import type { Page } from '@playwright/test'
 import { Utilities } from '../../utilities'
 import { test, expect } from './../fixture'
+import { ADMIN_STORAGE_STATE } from './../../playwright.config'
 
 test.use({
   toolPath: '/tools/scriptrunner',
@@ -207,11 +208,12 @@ test('test python stash apis', async ({ page, utils }) => {
   await runScript(page, utils, 'stash.py')
 })
 
-// Tagged @admin because the redis clear below hits POST /openc3-api/redis/exec,
-// which requires the 'admin' permission. The Enterprise fixture picks
-// credentials once at setup from the @admin tag or an 'admin' toolPath, and this
-// spec's toolPath is /tools/scriptrunner, so without the tag the session is the
-// operator and the clear comes back 403.
+// The redis clear below hits POST /openc3-api/redis/exec, which requires the
+// 'admin' permission (RedisController#execute_raw). The @admin tag alone is not
+// enough: the fixture only consults it inside `if (signin.isVisible())`, and the
+// project-level storageState is already a valid *operator* session, so no signin
+// appears and the tag never fires. That made the test pass only when the stored
+// token happened to be stale. The callers pin ADMIN_STORAGE_STATE instead.
 async function testMetadataApis(
   page: Page,
   utils: Utilities,
@@ -286,41 +288,52 @@ async function testMetadataApis(
   )
 }
 
-test('test ruby metadata apis', { tag: '@admin' }, async ({ page, utils }) => {
-  await testMetadataApis(page, utils, 'metadata.rb')
-  await expect(page.locator('[data-test=output-messages]')).toContainText(
-    '"setkey" => 1',
+test.describe('metadata apis', () => {
+  // Start from the admin session so the redis clear in testMetadataApis is
+  // authorized deterministically. The @admin tag stays for the case where this
+  // session has expired and the fixture has to sign in again.
+  test.use({ storageState: ADMIN_STORAGE_STATE })
+
+  test(
+    'test ruby metadata apis',
+    { tag: '@admin' },
+    async ({ page, utils }) => {
+      await testMetadataApis(page, utils, 'metadata.rb')
+      await expect(page.locator('[data-test=output-messages]')).toContainText(
+        '"setkey" => 1',
+      )
+      await expect(page.locator('[data-test=output-messages]')).toContainText(
+        '"setkey" => 2',
+      )
+      await expect(page.locator('[data-test=output-messages]')).toContainText(
+        '"updatekey" => 3',
+      )
+      await expect(page.locator('[data-test=output-messages]')).toContainText(
+        '"inputkey_metadata.rb" => "inputvalue"',
+      )
+    },
   )
-  await expect(page.locator('[data-test=output-messages]')).toContainText(
-    '"setkey" => 2',
-  )
-  await expect(page.locator('[data-test=output-messages]')).toContainText(
-    '"updatekey" => 3',
-  )
-  await expect(page.locator('[data-test=output-messages]')).toContainText(
-    '"inputkey_metadata.rb" => "inputvalue"',
+
+  test(
+    'test python metadata apis',
+    { tag: '@admin' },
+    async ({ page, utils }) => {
+      await testMetadataApis(page, utils, 'metadata.py')
+      await expect(page.locator('[data-test=output-messages]')).toContainText(
+        "'setkey': 1",
+      )
+      await expect(page.locator('[data-test=output-messages]')).toContainText(
+        "'setkey': 2",
+      )
+      await expect(page.locator('[data-test=output-messages]')).toContainText(
+        "'updatekey': 3",
+      )
+      await expect(page.locator('[data-test=output-messages]')).toContainText(
+        "'inputkey_metadata.py': 'inputvalue'",
+      )
+    },
   )
 })
-
-test(
-  'test python metadata apis',
-  { tag: '@admin' },
-  async ({ page, utils }) => {
-    await testMetadataApis(page, utils, 'metadata.py')
-    await expect(page.locator('[data-test=output-messages]')).toContainText(
-      "'setkey': 1",
-    )
-    await expect(page.locator('[data-test=output-messages]')).toContainText(
-      "'setkey': 2",
-    )
-    await expect(page.locator('[data-test=output-messages]')).toContainText(
-      "'updatekey': 3",
-    )
-    await expect(page.locator('[data-test=output-messages]')).toContainText(
-      "'inputkey_metadata.py': 'inputvalue'",
-    )
-  },
-)
 
 // The screen APIs were originally exercised by a single long script that
 // chained ~10 transient-state assertions. Each screen was only visible for a


### PR DESCRIPTION
redis exectuion requires admin permissions in Enterprise, add the `@admin` tag to the metadata API tests. Tests were failing when run in Enterprise, as seen [here](https://github.com/OpenC3/cosmos-enterprise/actions/runs/31545125749/job/93955837488)