### PR TITLE
Playwright bucket explorer stability improvements

### DIFF
--- a/playwright/tests/bucket-explorer.p.spec.ts
+++ b/playwright/tests/bucket-explorer.p.spec.ts
@@ -317,13 +317,14 @@ test('navigate logs and tools bucket', async ({ page, utils }) => {
     '/ DEFAULT /',
   )
   await expect(page).toHaveURL(/.*\/tools\/bucketexplorer\/logs%2FDEFAULT%2F/)
-  if (process.env.ENTERPRISE === '1') {
-    await expect(page.locator('tbody > tr').first()).toHaveText(/notebooks/)
-    await expect(page.locator('tbody > tr').last()).toHaveText(/\w+_logs/)
-  } else {
-    await expect(page.locator('tbody > tr').first()).toHaveText(/\w+_logs/)
-    await expect(page.locator('tbody > tr').last()).toHaveText(/\w+_logs/)
-  }
+  // Don't require the Enterprise 'notebooks' folder here: it is only created
+  // once a notebook is actually run (Notebook.run puts the running copy into
+  // OPENC3_LOGS_BUCKET), so it exists only if the enterprise notebooks spec
+  // already ran in this stack. Allow it, but don't depend on it.
+  await expect(page.locator('tbody > tr').first()).toHaveText(
+    /notebooks|\w+_logs/,
+  )
+  await expect(page.locator('tbody > tr').last()).toHaveText(/\w+_logs/)
   // Reload (also verifies we return to the same place) until the raw_logs
   // folder has been cut to the bucket - on a fresh instance it isn't there
   // until the first TLM_LOG_CYCLE_TIME elapses, and the listing only refreshes

--- a/playwright/tests/bucket-explorer.p.spec.ts
+++ b/playwright/tests/bucket-explorer.p.spec.ts
@@ -8,12 +8,45 @@
 # See LICENSE.md for more details.
 */
 
+import { Page } from '@playwright/test'
 import { test, expect } from './fixture'
 
 test.use({
   toolPath: '/tools/bucketexplorer',
   toolName: 'Bucket Explorer',
 })
+
+// Script Runner's File menu button is teleported into the tool bar while the
+// tool is still fetching its file list and the user's roles. A click that lands
+// mid-mount is swallowed and the menu never opens, so the follow-up
+// `text=New File` waits out the whole action timeout. Retry the open, and only
+// click when the menu is actually closed so we never toggle it shut again.
+async function openScriptRunnerFileMenu(page: Page) {
+  await expect(async () => {
+    if (!(await page.locator('text=New File').isVisible())) {
+      await page.locator('[data-test=script-runner-file]').click()
+    }
+    await expect(page.locator('text=New File')).toBeVisible({ timeout: 2000 })
+  }).toPass()
+}
+
+// Run a trivial script so that config/DEFAULT/targets_modified/__TEMP__ exists
+// and has something in it for the bucket explorer tests below.
+async function runTempScript(page: Page) {
+  await page.goto('/tools/scriptrunner')
+  await expect(page.locator('.v-app-bar')).toContainText('Script Runner')
+  await openScriptRunnerFileMenu(page)
+  await page.locator('text=New File').click()
+  await expect(page.locator('textarea')).toHaveText('')
+  await page.locator('textarea').fill(`print('hello world')`)
+  await page.locator('[data-test=start-button]').click()
+  await expect(page.locator('[data-test=state] input')).toHaveValue(
+    'completed',
+    {
+      timeout: 30000,
+    },
+  )
+}
 
 //
 // Test the basic functionality of the application
@@ -161,20 +194,7 @@ test('view file', async ({ page, utils }) => {
 
 test('upload and delete', async ({ page, utils }) => {
   // Create a file so we have something in __TEMP__
-  await page.goto('/tools/scriptrunner')
-  await expect(page.locator('.v-app-bar')).toContainText('Script Runner')
-  await page.locator('[data-test=script-runner-file]').click()
-  await page.locator('text=New File').click()
-  await expect(page.locator('textarea')).toHaveText('')
-  await page.locator('textarea').fill(`print('hello world')`)
-  await page.locator('[data-test=script-runner-file]').click()
-  await page.locator('[data-test=start-button]').click()
-  await expect(page.locator('[data-test=state] input')).toHaveValue(
-    'completed',
-    {
-      timeout: 30000,
-    },
-  )
+  await runTempScript(page)
 
   await page.goto('/tools/bucketexplorer')
   await page.getByText('config', { exact: true }).click()
@@ -343,19 +363,7 @@ test('auto refreshes to update files', async ({ page, utils, context }) => {
   const identifier = Math.ceil(Math.random() * 1000)
   const filename = `refresh_package_${identifier}.json`
   // Create a file so we have something in __TEMP__
-  await page.goto('/tools/scriptrunner')
-  await expect(page.locator('.v-app-bar')).toContainText('Script Runner')
-  await page.locator('[data-test=script-runner-file]').click()
-  await page.locator('text=New File').click()
-  await expect(page.locator('textarea')).toHaveText('')
-  await page.locator('textarea').fill(`print('hello world')`)
-  await page.locator('[data-test=start-button]').click()
-  await expect(page.locator('[data-test=state] input')).toHaveValue(
-    'completed',
-    {
-      timeout: 30000,
-    },
-  )
+  await runTempScript(page)
 
   // Open another tab and navigate to the __TEMP__ dir
   const pageTwo = await context.newPage()

--- a/playwright/tests/global.setup.ts
+++ b/playwright/tests/global.setup.ts
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 */
 
-import { test as setup, expect } from '@playwright/test'
+import { test as setup, expect, Page } from '@playwright/test'
 import { STORAGE_STATE, ADMIN_STORAGE_STATE } from './../playwright.config'
 
 // Take the demo sim targets out of QUIET mode. The demo boots quiet
@@ -23,7 +23,7 @@ import { STORAGE_STATE, ADMIN_STORAGE_STATE } from './../playwright.config'
 //
 // The command is only sent after the interfaces report CONNECTED below;
 // commanding while they are still coming up gets a 500 from the API.
-async function resetQuiet(page) {
+async function resetQuiet(page: Page) {
   for (const target of ['INST', 'INST2']) {
     const status = await page.evaluate(async (target) => {
       const response = await fetch('/openc3-api/api', {
@@ -47,11 +47,42 @@ async function resetQuiet(page) {
   }
 }
 
+// init.sh loads the demo plugin well before the rest of the tools, so
+// "INST_INT is CONNECTED" is not a signal that plugin installation has
+// finished. A tool that is not yet in /openc3-api/map.json is never registered
+// with single-spa, and tool-base renders its catch-all 404 instead - which is
+// what specs see as `.v-app-bar` never containing the tool name. Wait for the
+// last tool each init.sh installs before running anything.
+async function waitForTools(page: Page) {
+  // Keep in sync with the tail of openc3-cosmos-init/init.sh and
+  // openc3-cosmos-enterprise-init/init.sh. Only inline tools get an import map
+  // entry, so the marker is the last *inline* tool each script loads: docs and
+  // grafana are url-based (iframe) tools and never appear here.
+  const required = ['@openc3/tool-bucketexplorer']
+  if (process.env.ENTERPRISE === '1') {
+    required.push('@openc3/tool-logexplorer')
+  }
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get('/openc3-api/map.json')
+        if (!response.ok()) return []
+        const imports = (await response.json()).imports || {}
+        return required.filter((tool) => tool in imports)
+      },
+      {
+        message: `waiting for ${required.join(', ')} in the import map`,
+        timeout: 180000,
+      },
+    )
+    .toEqual(required)
+}
+
 // Wait for the services to deploy and the demo interfaces to connect. This runs
 // here rather than in a separate spec so that any single-file run
 // (e.g. `pnpm playwright test ./tests/command-sender.p.spec.ts
 // --project=chromium`) also gets a connected, non-QUIET demo.
-async function waitForBuild(page) {
+async function waitForBuild(page: Page) {
   await expect(page.locator('.v-app-bar')).toContainText('CmdTlmServer')
   // Check the 3rd column (nth starts at 0) on the row containing INST_INT says CONNECTED
   await expect(
@@ -71,7 +102,10 @@ async function waitForBuild(page) {
 }
 
 setup('global setup', async ({ page }) => {
-  setup.setTimeout(5 * 60 * 1000) // 5 minutes to build, deploy and connect
+  // 8 minutes to build, deploy and connect: waitForTools can spend up to 3
+  // minutes waiting out plugin installation before waitForBuild's own
+  // 120s + 60s interface waits even start.
+  setup.setTimeout(8 * 60 * 1000)
   await page.goto('/tools/cmdtlmserver')
   if (process.env.ENTERPRISE === '1') {
     await page.getByLabel('Username or email').fill('operator')
@@ -132,6 +166,7 @@ setup('global setup', async ({ page }) => {
     }
   }
 
+  await waitForTools(page)
   await waitForBuild(page)
   await resetQuiet(page)
 })

--- a/playwright/tests/notifications.s.spec.ts
+++ b/playwright/tests/notifications.s.spec.ts
@@ -8,7 +8,6 @@
 # See LICENSE.md for more details.
 */
 
-// @ts-check
 import { test, expect } from './fixture'
 import { STORAGE_STATE } from './../playwright.config'
 


### PR DESCRIPTION
- wait until all tools are loaded, prevents flaky failures due to test being run before tool was loaded (would pass on retry)
- removed enterprise dependency in "navigate logs and tools bucket"
  - with the new ability to skip running the enterprise playwright tests as part of the enterprise workflow, this test would fail due to the expectation/dependency that the enterprise tests had been run first and created a notebook. inter-test dependencies should be avoided, and inter-repository test dependencies even more so
  - enterprise bucket explorer check for notebooks has been moved to an enterprise test in [this PR](https://github.com/OpenC3/cosmos-enterprise/pull/710)
- retry click to open menu