### PR TITLE
feat: add received_time to inject_tlm

### DIFF
--- a/openc3/lib/openc3/api/tlm_api.rb
+++ b/openc3/lib/openc3/api/tlm_api.rb
@@ -117,7 +117,8 @@ module OpenC3
     # @param packet_name [String] Packet name of the packet
     # @param item_hash [Hash] Hash of item_name and value for each item you want to change from the current value table
     # @param type [Symbol] Telemetry type, :RAW, :CONVERTED (default), :FORMATTED
-    def inject_tlm(target_name, packet_name, item_hash = nil, type: :CONVERTED, stored: false, manual: false, scope: $openc3_scope, token: $openc3_token)
+    # @param received_time [Integer, nil] Optional received time as nanoseconds since Unix epoch
+    def inject_tlm(target_name, packet_name, item_hash = nil, type: :CONVERTED, stored: false, received_time: nil, manual: false, scope: $openc3_scope, token: $openc3_token)
       authorize(permission: 'tlm_set', target_name: target_name, packet_name: packet_name, manual: manual, scope: scope, token: token)
       type = type.to_s.intern
       target_name = target_name.upcase
@@ -155,9 +156,9 @@ module OpenC3
 
       # Use an interface microservice if it exists, other use the decom microservice
       if interface_name
-        InterfaceTopic.inject_tlm(interface_name, target_name, packet_name, item_hash, type: type, stored: stored, scope: scope)
+        InterfaceTopic.inject_tlm(interface_name, target_name, packet_name, item_hash, type: type, stored: stored, received_time: received_time, scope: scope)
       else
-        DecomInterfaceTopic.inject_tlm(target_name, packet_name, item_hash, type: type, stored: stored, scope: scope)
+        DecomInterfaceTopic.inject_tlm(target_name, packet_name, item_hash, type: type, stored: stored, received_time: received_time, scope: scope)
       end
     end
 
@@ -249,7 +250,7 @@ module OpenC3
       items = packet["items"].reject { | item | item["hidden"] }
       items = items.map { | item | item['name'].upcase }
       cvt_items = items.map { | item | [target_name, packet_name, item, type] }
-      current_values = CvtModel.get_tlm_values(cvt_items, stale_time: stale_time, cache_timeout: cache_timeout, scope: scope)
+      current_values = CvtModel.get_tlm_values(cvt_items, stale_time: stale_time, cache_timeout: cache_timeout, start_time: nil, end_time: nil, scope: scope)
       items.zip(current_values).map { | item , values | [item, values[0], values[1]]}
     end
 
@@ -421,9 +422,6 @@ module OpenC3
     # @return [Hash] Telemetry packet item hash
     def get_item(*args, manual: false, scope: $openc3_scope, token: $openc3_token, cache_timeout: nil)
       target_name, packet_name, item_name = _extract_target_packet_item_names('get_item', *args)
-      if packet_name == 'LATEST'
-        packet_name = CvtModel.determine_latest_packet_for_item(target_name, item_name, cache_timeout: cache_timeout, scope: scope)
-      end
       authorize(permission: 'tlm', target_name: target_name, packet_name: packet_name, manual: manual, scope: scope, token: token)
       TargetModel.packet_item(target_name, packet_name, item_name, scope: scope)
     end

--- a/openc3/lib/openc3/api/tlm_api.rb
+++ b/openc3/lib/openc3/api/tlm_api.rb
@@ -250,7 +250,7 @@ module OpenC3
       items = packet["items"].reject { | item | item["hidden"] }
       items = items.map { | item | item['name'].upcase }
       cvt_items = items.map { | item | [target_name, packet_name, item, type] }
-      current_values = CvtModel.get_tlm_values(cvt_items, stale_time: stale_time, cache_timeout: cache_timeout, start_time: nil, end_time: nil, scope: scope)
+      current_values = CvtModel.get_tlm_values(cvt_items, stale_time: stale_time, cache_timeout: cache_timeout, scope: scope)
       items.zip(current_values).map { | item , values | [item, values[0], values[1]]}
     end
 
@@ -422,6 +422,9 @@ module OpenC3
     # @return [Hash] Telemetry packet item hash
     def get_item(*args, manual: false, scope: $openc3_scope, token: $openc3_token, cache_timeout: nil)
       target_name, packet_name, item_name = _extract_target_packet_item_names('get_item', *args)
+      if packet_name == 'LATEST'
+        packet_name = CvtModel.determine_latest_packet_for_item(target_name, item_name, cache_timeout: cache_timeout, scope: scope)
+      end
       authorize(permission: 'tlm', target_name: target_name, packet_name: packet_name, manual: manual, scope: scope, token: token)
       TargetModel.packet_item(target_name, packet_name, item_name, scope: scope)
     end

--- a/openc3/lib/openc3/microservices/interface_decom_common.rb
+++ b/openc3/lib/openc3/microservices/interface_decom_common.rb
@@ -33,7 +33,8 @@ module OpenC3
       end
       stored = inject_tlm_hash.fetch('stored', false)
       packet.stored = stored.to_s.downcase == 'true'
-      packet.received_time = Time.now.sys
+      received_time = inject_tlm_hash['received_time']
+      packet.received_time = received_time.nil? ? Time.now.sys : Time.from_nsec_from_epoch(received_time).sys
       packet.received_count = TargetModel.increment_telemetry_count(packet.target_name, packet.packet_name, 1, scope: @scope)
       TelemetryTopic.write_packet(packet, scope: @scope)
     end

--- a/openc3/lib/openc3/script/telemetry.rb
+++ b/openc3/lib/openc3/script/telemetry.rb
@@ -40,9 +40,15 @@ module OpenC3
     # inject_tlm, set_tlm, override_tlm, and normalize_tlm are implemented here simply to add a puts
     # these methods modify the telemetry so the user should be notified in the Script Runner log messages
 
-    def inject_tlm(target_name, packet_name, item_hash = nil, type: :CONVERTED, stored: false, scope: $openc3_scope, token: $openc3_token)
-      puts "inject_tlm(\"#{target_name}\", \"#{packet_name}\", #{item_hash}, type: #{type}, stored: #{stored})"
-      $api_server.method_missing(:inject_tlm, target_name, packet_name, item_hash, type: type, stored: stored, scope: scope, token: token)
+    def inject_tlm(target_name, packet_name, item_hash = nil, type: :CONVERTED, stored: false, received_time: nil, scope: $openc3_scope, token: $openc3_token)
+      message = "inject_tlm(\"#{target_name}\", \"#{packet_name}\", #{item_hash}, type: #{type}, stored: #{stored}"
+      kwargs = { type: type, stored: stored, scope: scope, token: token }
+      unless received_time.nil?
+        message << ", received_time: #{received_time}"
+        kwargs[:received_time] = received_time
+      end
+      puts "#{message})"
+      $api_server.method_missing(:inject_tlm, target_name, packet_name, item_hash, **kwargs)
     end
 
     def set_tlm(*args, type: :ALL, scope: $openc3_scope, token: $openc3_token)

--- a/openc3/lib/openc3/topics/decom_interface_topic.rb
+++ b/openc3/lib/openc3/topics/decom_interface_topic.rb
@@ -46,7 +46,7 @@ module OpenC3
       raise "Timeout of #{timeout}s waiting for cmd ack. Does target '#{target_name}' exist?"
     end
 
-    def self.inject_tlm(target_name, packet_name, item_hash = nil, type: :CONVERTED, stored: false, timeout: 5, scope:)
+    def self.inject_tlm(target_name, packet_name, item_hash = nil, type: :CONVERTED, stored: false, timeout: 5, received_time: nil, scope:)
       data = {}
       data['target_name'] = target_name.to_s.upcase
       data['packet_name'] = packet_name.to_s.upcase
@@ -55,6 +55,7 @@ module OpenC3
 
       db_shard = Store.db_shard_for_target(target_name, scope: scope)
       data['stored'] = stored
+      data['received_time'] = received_time unless received_time.nil?
       ack_topic = "{#{scope}__ACKCMD}TARGET__#{target_name}"
       Topic.update_topic_offsets([ack_topic], db_shard: db_shard)
       decom_id = Topic.write_topic("#{scope}__DECOMINTERFACE__{#{target_name}}",

--- a/openc3/lib/openc3/topics/interface_topic.rb
+++ b/openc3/lib/openc3/topics/interface_topic.rb
@@ -148,7 +148,7 @@ module OpenC3
       Topic.write_topic("{#{scope}__CMD}INTERFACE__#{interface_name}", { 'protocol_cmd' => JSON.generate(data, allow_nan: true) }, '*', 100, db_shard: db_shard)
     end
 
-    def self.inject_tlm(interface_name, target_name, packet_name, item_hash = nil, type: :CONVERTED, stored: false, timeout: nil, scope:)
+    def self.inject_tlm(interface_name, target_name, packet_name, item_hash = nil, type: :CONVERTED, stored: false, timeout: nil, received_time: nil, scope:)
       interface_name = interface_name.upcase
       db_shard = _db_shard_for_interface(interface_name, scope: scope)
 
@@ -162,6 +162,7 @@ module OpenC3
       data['item_hash'] = item_hash
       data['type'] = type
       data['stored'] = stored
+      data['received_time'] = received_time unless received_time.nil?
       cmd_id = Topic.write_topic("{#{scope}__CMD}INTERFACE__#{interface_name}", { 'inject_tlm' => JSON.generate(data, allow_nan: true) }, '*', 100, db_shard: db_shard)
       time = Time.now
       while (Time.now - time) < timeout

--- a/openc3/python/openc3/api/tlm_api.py
+++ b/openc3/python/openc3/api/tlm_api.py
@@ -131,7 +131,16 @@ def set_tlm(*args, type="CONVERTED", cache_timeout=0.1, scope=OPENC3_SCOPE):
 # @param packet_name [String] Packet name of the packet
 # @param item_hash [Hash] Hash of item_name and value for each item you want to change from the current value table
 # @param type [Symbol] Telemetry type, :RAW, :CONVERTED (default), :FORMATTED
-def inject_tlm(target_name, packet_name, item_hash=None, type="CONVERTED", stored=False, scope=OPENC3_SCOPE):
+# @param received_time [Integer|None] Optional received time as nanoseconds since Unix epoch
+def inject_tlm(
+    target_name,
+    packet_name,
+    item_hash=None,
+    type="CONVERTED",
+    stored=False,
+    scope=OPENC3_SCOPE,
+    received_time=None,
+):
     authorize(
         permission="tlm_set",
         target_name=target_name,
@@ -169,10 +178,25 @@ def inject_tlm(target_name, packet_name, item_hash=None, type="CONVERTED", store
     # Use an interface microservice if it exists, other use the decom microservice
     if interface_name:
         InterfaceTopic.inject_tlm(
-            interface_name, target_name, packet_name, item_hash, type=type, stored=stored, scope=scope
+            interface_name,
+            target_name,
+            packet_name,
+            item_hash,
+            type=type,
+            stored=stored,
+            scope=scope,
+            received_time=received_time,
         )
     else:
-        DecomInterfaceTopic.inject_tlm(target_name, packet_name, item_hash, type=type, stored=stored, scope=scope)
+        DecomInterfaceTopic.inject_tlm(
+            target_name,
+            packet_name,
+            item_hash,
+            type=type,
+            stored=stored,
+            scope=scope,
+            received_time=received_time,
+        )
 
 
 # Override the current value table such that a particular item always

--- a/openc3/python/openc3/microservices/interface_decom_common.py
+++ b/openc3/python/openc3/microservices/interface_decom_common.py
@@ -21,7 +21,7 @@ from openc3.topics.telemetry_topic import TelemetryTopic
 from openc3.topics.topic import Topic
 from openc3.utilities.json import JsonDecoder, JsonEncoder
 from openc3.utilities.store import Store
-from openc3.utilities.time import to_nsec_from_epoch
+from openc3.utilities.time import from_nsec_from_epoch, to_nsec_from_epoch
 
 
 def handle_inject_tlm(inject_tlm_json, scope):
@@ -36,7 +36,10 @@ def handle_inject_tlm(inject_tlm_json, scope):
             packet.write(str(name), value, data_type)
     stored = inject_tlm_hash.get("stored", False)
     packet.stored = str(stored).lower() == "true"
-    packet.received_time = datetime.now(timezone.utc)
+    received_time = inject_tlm_hash.get("received_time")
+    packet.received_time = (
+        from_nsec_from_epoch(received_time) if received_time is not None else datetime.now(timezone.utc)
+    )
     packet.received_count = TargetModel.increment_telemetry_count(
         packet.target_name, packet.packet_name, 1, scope=scope
     )

--- a/openc3/python/openc3/script/telemetry.py
+++ b/openc3/python/openc3/script/telemetry.py
@@ -56,9 +56,15 @@ def inject_tlm(
     type: str = "CONVERTED",
     stored: bool = False,
     scope: str = OPENC3_SCOPE,
+    received_time: int | None = None,
 ):
-    print(f'inject_tlm("{target_name}", "{packet_name}", {item_hash}, type="{type}", stored={stored})')
-    openc3.script.API_SERVER.inject_tlm(target_name, packet_name, item_hash, type=type, stored=stored, scope=scope)
+    message = f'inject_tlm("{target_name}", "{packet_name}", {item_hash}, type="{type}", stored={stored}'
+    kwargs = {"type": type, "stored": stored, "scope": scope}
+    if received_time is not None:
+        message += f", received_time={received_time}"
+        kwargs["received_time"] = received_time
+    print(f"{message})")
+    openc3.script.API_SERVER.inject_tlm(target_name, packet_name, item_hash, **kwargs)
 
 
 def set_tlm(*args, type: str = "CONVERTED", scope: str = OPENC3_SCOPE):

--- a/openc3/python/openc3/topics/decom_interface_topic.py
+++ b/openc3/python/openc3/topics/decom_interface_topic.py
@@ -72,6 +72,7 @@ class DecomInterfaceTopic(Topic):
         stored=False,
         timeout=5,
         scope=OPENC3_SCOPE,
+        received_time=None,
     ):
         data = {}
         data["target_name"] = target_name.upper()
@@ -81,6 +82,8 @@ class DecomInterfaceTopic(Topic):
 
         db_shard = Store.db_shard_for_target(target_name, scope=scope)
         data["stored"] = stored
+        if received_time is not None:
+            data["received_time"] = received_time
         ack_topic = f"{{{scope}__ACKCMD}}TARGET__{target_name}"
         Topic.update_topic_offsets([ack_topic], db_shard=db_shard)
         decom_id = Topic.write_topic(

--- a/openc3/python/openc3/topics/interface_topic.py
+++ b/openc3/python/openc3/topics/interface_topic.py
@@ -185,6 +185,7 @@ class InterfaceTopic(Topic):
         stored=False,
         timeout=None,
         scope=OPENC3_SCOPE,
+        received_time=None,
     ):
         interface_name = interface_name.upper()
         db_shard = cls._db_shard_for_interface(interface_name, scope)
@@ -200,6 +201,8 @@ class InterfaceTopic(Topic):
         data["item_hash"] = item_hash
         data["type"] = type
         data["stored"] = stored
+        if received_time is not None:
+            data["received_time"] = received_time
         cmd_id = Topic.write_topic(
             f"{{{scope}__CMD}}INTERFACE__{interface_name}",
             {"inject_tlm": json.dumps(data)},

--- a/openc3/python/test/api/test_inject_tlm_received_time.py
+++ b/openc3/python/test/api/test_inject_tlm_received_time.py
@@ -1,0 +1,150 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+
+import json
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+from openc3.api.tlm_api import inject_tlm
+from openc3.microservices.interface_decom_common import handle_inject_tlm
+from openc3.script.telemetry import inject_tlm as script_inject_tlm
+
+
+class TestInjectTlmReceivedTime(unittest.TestCase):
+    @patch("openc3.api.tlm_api.DecomInterfaceTopic.inject_tlm")
+    @patch("openc3.api.tlm_api.InterfaceModel.all", return_value={})
+    @patch("openc3.api.tlm_api.TargetModel.packet")
+    @patch("openc3.api.tlm_api.authorize")
+    def test_api_passes_received_time_without_interface(
+        self, _authorize, _packet, _interfaces, decom_inject
+    ):
+        received_time = 1_609_459_200_123_456_000
+
+        inject_tlm("INST", "HEALTH_STATUS", received_time=received_time)
+
+        decom_inject.assert_called_once_with(
+            "INST",
+            "HEALTH_STATUS",
+            None,
+            type="CONVERTED",
+            stored=False,
+            scope="DEFAULT",
+            received_time=received_time,
+        )
+
+    @patch("openc3.api.tlm_api.InterfaceTopic.inject_tlm")
+    @patch(
+        "openc3.api.tlm_api.InterfaceModel.all",
+        return_value={
+            "INST_INT": {
+                "name": "INST_INT",
+                "tlm_target_names": ["INST"],
+            }
+        },
+    )
+    @patch("openc3.api.tlm_api.TargetModel.packet")
+    @patch("openc3.api.tlm_api.authorize")
+    def test_api_passes_received_time_with_interface(
+        self, _authorize, _packet, _interfaces, interface_inject
+    ):
+        received_time = 1_609_459_200_123_456_000
+
+        inject_tlm("INST", "HEALTH_STATUS", received_time=received_time)
+
+        interface_inject.assert_called_once_with(
+            "INST_INT",
+            "INST",
+            "HEALTH_STATUS",
+            None,
+            type="CONVERTED",
+            stored=False,
+            scope="DEFAULT",
+            received_time=received_time,
+        )
+
+    @patch("openc3.microservices.interface_decom_common.TelemetryTopic.write_packet")
+    @patch(
+        "openc3.microservices.interface_decom_common.TargetModel.increment_telemetry_count",
+        return_value=1,
+    )
+    @patch("openc3.microservices.interface_decom_common.System")
+    def test_handler_uses_historical_received_time(self, system, _increment, write_packet):
+        packet = Mock()
+        packet.target_name = "INST"
+        packet.packet_name = "HEALTH_STATUS"
+        system.telemetry.packet.return_value = packet
+        received_time = 1_609_459_200_123_456_000
+
+        handle_inject_tlm(
+            json.dumps(
+                {
+                    "target_name": "INST",
+                    "packet_name": "HEALTH_STATUS",
+                    "item_hash": None,
+                    "type": "CONVERTED",
+                    "stored": False,
+                    "received_time": received_time,
+                }
+            ),
+            "DEFAULT",
+        )
+
+        self.assertEqual(
+            packet.received_time,
+            datetime(2021, 1, 1, 0, 0, 0, 123456, tzinfo=timezone.utc),
+        )
+        write_packet.assert_called_once_with(packet, "DEFAULT")
+
+    @patch("openc3.microservices.interface_decom_common.TelemetryTopic.write_packet")
+    @patch(
+        "openc3.microservices.interface_decom_common.TargetModel.increment_telemetry_count",
+        return_value=1,
+    )
+    @patch("openc3.microservices.interface_decom_common.System")
+    def test_handler_accepts_unix_epoch_zero(self, system, _increment, _write_packet):
+        packet = Mock()
+        packet.target_name = "INST"
+        packet.packet_name = "HEALTH_STATUS"
+        system.telemetry.packet.return_value = packet
+
+        handle_inject_tlm(
+            json.dumps(
+                {
+                    "target_name": "INST",
+                    "packet_name": "HEALTH_STATUS",
+                    "item_hash": None,
+                    "type": "CONVERTED",
+                    "stored": False,
+                    "received_time": 0,
+                }
+            ),
+            "DEFAULT",
+        )
+
+        self.assertEqual(packet.received_time, datetime(1970, 1, 1, tzinfo=timezone.utc))
+
+    @patch("openc3.script.telemetry.openc3.script.API_SERVER")
+    def test_script_wrapper_forwards_received_time(self, api_server):
+        received_time = 1_609_459_200_123_456_000
+
+        script_inject_tlm("INST", "HEALTH_STATUS", received_time=received_time)
+
+        api_server.inject_tlm.assert_called_once_with(
+            "INST",
+            "HEALTH_STATUS",
+            None,
+            type="CONVERTED",
+            stored=False,
+            scope="DEFAULT",
+            received_time=received_time,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openc3/spec/microservices/interface_decom_common_received_time_spec.rb
+++ b/openc3/spec/microservices/interface_decom_common_received_time_spec.rb
@@ -1,0 +1,64 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require 'spec_helper'
+require 'openc3/microservices/interface_decom_common'
+
+module OpenC3
+  describe InterfaceDecomCommon do
+    class InjectTlmReceivedTimeHarness
+      include InterfaceDecomCommon
+
+      def initialize
+        @scope = 'DEFAULT'
+      end
+    end
+
+    before(:each) do
+      @handler = InjectTlmReceivedTimeHarness.new
+      @telemetry = double('Telemetry')
+      @packet = double('Packet', target_name: 'INST', packet_name: 'HEALTH_STATUS')
+      allow(@packet).to receive(:write)
+      allow(@packet).to receive(:stored=)
+      allow(@packet).to receive(:received_count=)
+      allow(System).to receive(:telemetry).and_return(@telemetry)
+      allow(@telemetry).to receive(:packet).with('INST', 'HEALTH_STATUS').and_return(@packet)
+      allow(TargetModel).to receive(:increment_telemetry_count).and_return(1)
+      allow(TelemetryTopic).to receive(:write_packet)
+    end
+
+    def inject(received_time)
+      @handler.handle_inject_tlm(JSON.generate({
+        'target_name' => 'INST',
+        'packet_name' => 'HEALTH_STATUS',
+        'item_hash' => nil,
+        'type' => 'CONVERTED',
+        'stored' => false,
+        'received_time' => received_time
+      }, allow_nan: true))
+    end
+
+    it 'uses a supplied received time in nanoseconds since Unix epoch' do
+      received_time = 1_609_459_200_123_456_000
+      expect(@packet).to receive(:received_time=).with(Time.from_nsec_from_epoch(received_time).sys)
+
+      inject(received_time)
+    end
+
+    it 'preserves Unix epoch zero as a supplied received time' do
+      expect(@packet).to receive(:received_time=).with(Time.from_nsec_from_epoch(0).sys)
+
+      inject(0)
+    end
+  end
+end


### PR DESCRIPTION
Adds an optional received_time parameter to Python inject_tlm so scripts can inject historical telemetry while still using the normal COSMOS packet path instead of modifying TSDB data directly.

received_time is represented as nanoseconds since the Unix epoch, matching COSMOS's existing packet timestamp serialization. When omitted, behavior is unchanged and the receive time is still set to the current UTC time.

Implementation:
- thread received_time through the public inject_tlm API
- forward it through InterfaceTopic and DecomInterfaceTopic
- convert nanoseconds back to a UTC datetime in handle_inject_tlm
- expose the option through the Python Script Runner wrapper
- preserve 0 as a valid Unix-epoch timestamp
- add regression coverage for both routing paths, conversion, epoch zero, and Script Runner forwarding

Compatibility:
Existing callers remain unchanged because the new argument is optional and appended after scope. The Script Runner wrapper only forwards the new keyword when explicitly supplied.

Closes #3521