### PR TITLE
Ensure all Playwright tests run

### DIFF
--- a/playwright/package.json
+++ b/playwright/package.json
@@ -8,7 +8,7 @@
     "test:parallel:root": "playwright test ./tests/*.p.spec.ts --project=chromium",
     "test:parallel:nested": "playwright test ./tests/**/*.p.spec.ts --project=chromium",
     "test:parallel": "pnpm test:parallel:root && pnpm test:parallel:nested",
-    "test:serial": "playwright test ./tests/**/*.s.spec.ts --project=chromium --workers=1",
+    "test:serial": "playwright test ./tests/*.s.spec.ts ./tests/**/*.s.spec.ts --project=chromium --workers=1",
     "test:enterprise": "pnpm test:enterprise:parallel && pnpm test:enterprise:serial",
     "test:enterprise:parallel": "ENTERPRISE=1 playwright test ./tests/enterprise/*.p.spec.ts --project=enterprise",
     "test:enterprise:serial": "ENTERPRISE=1 playwright test ./tests/enterprise/*.s.spec.ts --project=enterprise --workers=1",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -5,9 +5,7 @@
   "scripts": {
     "coverage": "node generate-coverage.mjs",
     "test": "pnpm test:parallel --quiet && pnpm test:serial --quiet && pnpm coverage",
-    "test:parallel:root": "playwright test ./tests/*.p.spec.ts --project=chromium",
-    "test:parallel:nested": "playwright test ./tests/**/*.p.spec.ts --project=chromium",
-    "test:parallel": "pnpm test:parallel:root && pnpm test:parallel:nested",
+    "test:parallel": "playwright test ./tests/*.p.spec.ts ./tests/**/*.p.spec.ts --project=chromium",
     "test:serial": "playwright test ./tests/*.s.spec.ts ./tests/**/*.s.spec.ts --project=chromium --workers=1",
     "test:enterprise": "pnpm test:enterprise:parallel && pnpm test:enterprise:serial",
     "test:enterprise:parallel": "ENTERPRISE=1 playwright test ./tests/enterprise/*.p.spec.ts --project=enterprise",

--- a/playwright/playwright.sh
+++ b/playwright/playwright.sh
@@ -127,8 +127,7 @@ case $1 in
         # they would only reach the last link (the coverage merge, which ignores
         # argv). Forwarding to each leaf individually keeps quoted args intact,
         # e.g. --grep='command sender'.
-        pnpm test:parallel:root --quiet "${@:2}" \
-          && pnpm test:parallel:nested --quiet "${@:2}" \
+        pnpm test:parallel --quiet "${@:2}" \
           && pnpm test:serial --quiet "${@:2}" \
           && pnpm coverage
         ;;


### PR DESCRIPTION
- `tests/*.s.spec.ts` were not being run, so we were missing 26 tests
- merged all serial tests into one script
Before:
1. parallel:root - `playwright test ./tests/*.p.spec.ts --project=chromium --quiet` - 117 tests
2. parallel:nested - `playwright test ./tests/**/*.p.spec.ts --project=chromium --quiet` - 85 tests
3. serial:nested - `playwright test ./tests/**/*.s.spec.ts --project=chromium --workers=1 --quiet` - 23 tests
<img width="622" height="404" alt="Screenshot 2026-08-19 at 10 04 01 AM" src="https://github.com/user-attachments/assets/1f75229c-fafa-42be-860b-703ffdcfeaac" />

After:
1. all parallel - `playwright test ./tests/*.p.spec.ts ./tests/**/*.p.spec.ts --project=chromium --quiet` - 201 tests
2. all serial - `playwright test ./tests/*.s.spec.ts ./tests/**/*.s.spec.ts --project=chromium --workers=1 --quiet` - 49 tests
<img width="746" height="267" alt="Screenshot 2026-08-19 at 10 05 25 AM" src="https://github.com/user-attachments/assets/c7ab4391-2dc4-4b98-8091-a3d0972f80b5" />
