### PR TITLE
fix(api): prevent update_news auth bypass from broad rescue

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/UserMenu.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/UserMenu.vue
@@ -78,6 +78,8 @@
                 color="primary"
                 density="compact"
                 block
+                :disabled="!isAdmin"
+                data-test="refresh-news"
                 @click="refreshNews"
               >
                 Refresh
@@ -144,6 +146,8 @@ export default {
       activeUsers: ['None'],
       newsFeed: false,
       news: [],
+      // update_news requires the admin permission
+      isAdmin: (OpenC3Auth.userroles() || []).includes('admin'),
     }
   },
   computed: {

--- a/openc3/lib/openc3/api/settings_api.rb
+++ b/openc3/lib/openc3/api/settings_api.rb
@@ -81,26 +81,30 @@ module OpenC3
 
     # Update the news feed on demand to respond to frontend setting changes
     def update_news(manual: false, scope: $openc3_scope, token: $openc3_token)
+      # Authorize outside the begin/rescue so AuthError propagates to the caller
+      # rather than being swallowed and written into the news feed
       authorize(permission: 'admin', manual: manual, scope: scope, token: token)
-      conn = Faraday.new(
-        url: 'https://news.openc3.com',
-        params: {version: VERSION, enterprise: ENTERPRISE},
-      )
-      response = conn.get('/news')
-      if response.success?
-        NewsModel.set(response.body)
-      else
-        NewsModel.news_error("Error contacting OpenC3 news feed (status: #{response.status})")
-      end
+      begin
+        conn = Faraday.new(
+          url: 'https://news.openc3.com',
+          params: {version: VERSION, enterprise: ENTERPRISE},
+        )
+        response = conn.get('/news')
+        if response.success?
+          NewsModel.set(response.body)
+        else
+          NewsModel.news_error("Error contacting OpenC3 news feed (status: #{response.status})")
+        end
 
-      # Test code to update the news feed with a dummy message
-      # data = NewsModel.all()
-      # json = JSON.parse(data)
-      # json.unshift( { date: Time.now.utc.iso8601, title: "News at #{Time.now}", body: "The news feed has been updated at #{Time.now}." })
-      # json.pop if json.length > 5
-      # NewsModel.set(json.to_json)
-    rescue Exception => e
-      NewsModel.news_error("Error contacting OpenC3 news feed. #{e.message})")
+        # Test code to update the news feed with a dummy message
+        # data = NewsModel.all()
+        # json = JSON.parse(data)
+        # json.unshift( { date: Time.now.utc.iso8601, title: "News at #{Time.now}", body: "The news feed has been updated at #{Time.now}." })
+        # json.pop if json.length > 5
+        # NewsModel.set(json.to_json)
+      rescue StandardError => e
+        NewsModel.news_error("Error contacting OpenC3 news feed. #{e.message}")
+      end
     end
 
     # Update the local copy of the plugin store data

--- a/openc3/lib/openc3/microservices/periodic_microservice.rb
+++ b/openc3/lib/openc3/microservices/periodic_microservice.rb
@@ -46,8 +46,8 @@ module OpenC3
           NewsModel.news_error("Error contacting OpenC3 news feed (status: #{response.status})")
         end
       end
-    rescue Exception => e
-      NewsModel.news_error("Error contacting OpenC3 news feed. #{e.message})")
+    rescue StandardError => e
+      NewsModel.news_error("Error contacting OpenC3 news feed. #{e.message}")
     end
 
     def run

--- a/openc3/spec/api/settings_api_spec.rb
+++ b/openc3/spec/api/settings_api_spec.rb
@@ -13,6 +13,8 @@
 
 require 'spec_helper'
 require 'openc3/api/settings_api'
+require 'openc3/script/extract'
+require 'openc3/utilities/authorization'
 
 module OpenC3
   describe Api do
@@ -100,6 +102,28 @@ module OpenC3
         @api.set_setting('key2', 2)
         @api.set_setting('key3', 3)
         expect(@api.get_settings('key1','key3')).to eql ["string", 3]
+      end
+    end
+
+    describe "update_news" do
+      it "raises AuthError without writing the news feed" do
+        NewsModel.set('[]')
+        saved = $openc3_authorize
+        $openc3_authorize = true
+        begin
+          expect { @api.update_news(scope: 'DEFAULT', token: nil) }.to raise_error(AuthError, /Token is required/)
+        ensure
+          $openc3_authorize = saved
+        end
+        expect(NewsModel.all()).to eql '[]'
+      end
+
+      it "writes a news error if the feed can't be reached" do
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::ConnectionFailed.new('no route'))
+        @api.update_news(scope: 'DEFAULT')
+        news = JSON.parse(NewsModel.all())
+        expect(news[0]['title']).to eql 'News Error'
+        expect(news[0]['body']).to include 'no route'
       end
     end
   end

--- a/openc3/spec/api/settings_api_spec.rb
+++ b/openc3/spec/api/settings_api_spec.rb
@@ -15,6 +15,7 @@ require 'spec_helper'
 require 'openc3/api/settings_api'
 require 'openc3/script/extract'
 require 'openc3/utilities/authorization'
+require 'openc3/utilities/local_mode'
 
 module OpenC3
   describe Api do

--- a/openc3/spec/api/stash_api_spec.rb
+++ b/openc3/spec/api/stash_api_spec.rb
@@ -13,6 +13,8 @@
 
 require 'spec_helper'
 require 'openc3/api/stash_api'
+require 'openc3/script/extract'
+require 'openc3/utilities/authorization'
 
 module OpenC3
   describe Api do

--- a/openc3/spec/microservices/decom_microservice_spec.rb
+++ b/openc3/spec/microservices/decom_microservice_spec.rb
@@ -17,6 +17,7 @@ require 'openc3/packets/limits_response'
 require 'openc3/models/metric_model'
 require 'openc3/topics/telemetry_topic'
 require 'openc3/topics/limits_event_topic'
+require 'openc3/script/extract'
 
 module OpenC3
   describe DecomMicroservice do


### PR DESCRIPTION
The method-level `rescue Exception` swallowed the AuthError raised by authorize, so unauthenticated JSON-RPC callers got 200 OK and an anonymous write to the openc3_news Redis key. Authorize now runs outside the rescued region and the rescue is narrowed to StandardError.

Also disables the User Menu Refresh button for non-admins, which previously wiped the feed on Enterprise, and adds the missing Extract/Authorization requires to three specs that could not load standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)