### PR TITLE
fix(cmd-tlm-api): scope auth rate limit counters per client

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/controllers/auth_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/auth_controller.rb
@@ -22,8 +22,10 @@ class AuthController < ApplicationController
   MAX_BAD_ATTEMPTS = ENV.fetch('OPENC3_AUTH_RATE_LIMIT_TO', '10').to_i
   BAD_ATTEMPTS_WINDOW = ENV.fetch('OPENC3_AUTH_RATE_LIMIT_WITHIN', '120').to_i
 
-  USER_BAD_ATTEMPTS_KEY = 'openc3__auth_bad_attempts__user'
-  SERVICE_BAD_ATTEMPTS_KEY = 'openc3__auth_bad_attempts__service'
+  # Bad attempt counters are scoped per requesting client (see client_id) so a
+  # malicious client can only lock itself out rather than every operator.
+  USER_BAD_ATTEMPTS_KEY_PREFIX = 'openc3__auth_bad_attempts__user'
+  SERVICE_BAD_ATTEMPTS_KEY_PREFIX = 'openc3__auth_bad_attempts__service'
 
   def token_exists
     result = OpenC3::AuthModel.set?
@@ -40,6 +42,7 @@ class AuthController < ApplicationController
 
     begin
       if OpenC3::AuthModel.verify_no_service(params[:password], mode: :password)
+        clear_user_bad_attempts
         render :plain => OpenC3::AuthModel.generate_session()
       else
         record_user_bad_attempt
@@ -59,6 +62,7 @@ class AuthController < ApplicationController
 
     begin
       if OpenC3::AuthModel.verify(params[:password], service_only: true)
+        clear_service_bad_attempts
         render :plain => OpenC3::AuthModel.generate_session()
       else
         record_service_bad_attempt
@@ -85,6 +89,7 @@ class AuthController < ApplicationController
     begin
       # Set throws an exception if it fails for any reason
       OpenC3::AuthModel.set(params[:password], params[:old_password])
+      clear_user_bad_attempts
       OpenC3::Logger.info("Password changed", user: username())
       render :plain => OpenC3::AuthModel.generate_session()
     rescue StandardError => e
@@ -98,45 +103,95 @@ class AuthController < ApplicationController
 
   private
 
-  # Checks to see if the user password has been rate limited due to bad attempts
+  # Identifies the client making the request so that bad attempt counters are
+  # scoped per client instead of globally. A global counter allows any
+  # unauthenticated client to lock out every operator by sending
+  # MAX_BAD_ATTEMPTS bad passwords, so everything that counts bad attempts must
+  # be namespaced by this value.
+  #
+  # This uses Rails request.remote_ip which honors X-Forwarded-For. COSMOS runs
+  # behind traefik, which discards any client supplied X-Forwarded-* headers and
+  # sets them from the real connection, so a client can't choose its own bucket.
+  # See the forwardedHeaders comments in openc3-traefik/traefik.yaml: if traefik
+  # is configured to trust a proxy that doesn't set X-Forwarded-For, every
+  # client collapses into that proxy's bucket.
+  def client_id
+    ip = begin
+      request.remote_ip
+    rescue StandardError
+      nil
+    end
+    ip ||= request.remote_addr
+    # Only allow ip address characters in the key and bound the length so the
+    # attacker controlled header can't be used to build arbitrary Redis keys
+    ip = ip.to_s.gsub(/[^0-9a-fA-F:.]/, '')[0, 45]
+    return ip.empty? ? 'unknown' : ip
+  end
+
+  def user_bad_attempts_key
+    "#{USER_BAD_ATTEMPTS_KEY_PREFIX}__#{client_id}"
+  end
+
+  def service_bad_attempts_key
+    "#{SERVICE_BAD_ATTEMPTS_KEY_PREFIX}__#{client_id}"
+  end
+
+  # Checks to see if this client has been rate limited due to bad user password attempts
   def user_rate_limited?
-    begin
-      count = OpenC3::EphemeralStore.get(USER_BAD_ATTEMPTS_KEY)
-      return count.to_i >= MAX_BAD_ATTEMPTS
-    rescue StandardError => error
-      OpenC3::Logger.error("Redis error checking user rate limit: #{error.message}")
-      return false
-    end
+    rate_limited?(user_bad_attempts_key, 'user')
   end
-  
-  # Initializes or increments the bad attempt counter for the user password
+
+  # Initializes or increments this client's bad attempt counter for the user password
   def record_user_bad_attempt
-    begin
-      count = OpenC3::EphemeralStore.incr(USER_BAD_ATTEMPTS_KEY)
-      OpenC3::EphemeralStore.expire(USER_BAD_ATTEMPTS_KEY, BAD_ATTEMPTS_WINDOW) if count == 1
-    rescue StandardError => error
-      OpenC3::Logger.error("Redis error recording user bad attempt: #{error.message}")
-    end
+    record_bad_attempt(user_bad_attempts_key, 'user')
   end
-  
-  # Checks to see if the service password has been rate limited due to bad attempts
+
+  # Clears this client's bad attempt counter after a successful user authentication
+  def clear_user_bad_attempts
+    clear_bad_attempts(user_bad_attempts_key, 'user')
+  end
+
+  # Checks to see if this client has been rate limited due to bad service password attempts
   def service_rate_limited?
+    rate_limited?(service_bad_attempts_key, 'service')
+  end
+
+  # Initializes or increments this client's bad attempt counter for the service password
+  def record_service_bad_attempt
+    record_bad_attempt(service_bad_attempts_key, 'service')
+  end
+
+  # Clears this client's bad attempt counter after a successful service authentication
+  def clear_service_bad_attempts
+    clear_bad_attempts(service_bad_attempts_key, 'service')
+  end
+
+  def rate_limited?(key, type)
     begin
-      count = OpenC3::EphemeralStore.get(SERVICE_BAD_ATTEMPTS_KEY)
+      count = OpenC3::EphemeralStore.get(key)
       return count.to_i >= MAX_BAD_ATTEMPTS
     rescue StandardError => error
-      OpenC3::Logger.error("Redis error checking service rate limit: #{error.message}")
+      OpenC3::Logger.error("Redis error checking #{type} rate limit: #{error.message}")
       return false
     end
   end
-  
-  # Initializes or increments the bad attempt counter for the service password
-  def record_service_bad_attempt
+
+  def record_bad_attempt(key, type)
     begin
-      count = OpenC3::EphemeralStore.incr(SERVICE_BAD_ATTEMPTS_KEY)
-      OpenC3::EphemeralStore.expire(SERVICE_BAD_ATTEMPTS_KEY, BAD_ATTEMPTS_WINDOW) if count == 1
+      OpenC3::EphemeralStore.incr(key)
+      # Refresh the TTL on every bad attempt so the window slides. This only
+      # extends the lockout of the client making the bad attempts.
+      OpenC3::EphemeralStore.expire(key, BAD_ATTEMPTS_WINDOW)
     rescue StandardError => error
-      OpenC3::Logger.error("Redis error recording service bad attempt: #{error.message}")
+      OpenC3::Logger.error("Redis error recording #{type} bad attempt: #{error.message}")
+    end
+  end
+
+  def clear_bad_attempts(key, type)
+    begin
+      OpenC3::EphemeralStore.del(key)
+    rescue StandardError => error
+      OpenC3::Logger.error("Redis error clearing #{type} bad attempts: #{error.message}")
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/app/controllers/auth_controller.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/controllers/auth_controller.rb
@@ -22,8 +22,10 @@ class AuthController < ApplicationController
   MAX_BAD_ATTEMPTS = ENV.fetch('OPENC3_AUTH_RATE_LIMIT_TO', '10').to_i
   BAD_ATTEMPTS_WINDOW = ENV.fetch('OPENC3_AUTH_RATE_LIMIT_WITHIN', '120').to_i
 
-  USER_BAD_ATTEMPTS_KEY = 'openc3__auth_bad_attempts__user'
-  SERVICE_BAD_ATTEMPTS_KEY = 'openc3__auth_bad_attempts__service'
+  # Bad attempt counters are scoped per requesting client (see client_id) so a
+  # malicious client can only lock itself out rather than every operator.
+  USER_BAD_ATTEMPTS_KEY_PREFIX = 'openc3__auth_bad_attempts__user'
+  SERVICE_BAD_ATTEMPTS_KEY_PREFIX = 'openc3__auth_bad_attempts__service'
 
   def token_exists
     result = OpenC3::AuthModel.set?
@@ -40,6 +42,7 @@ class AuthController < ApplicationController
 
     begin
       if OpenC3::AuthModel.verify_no_service(params[:password], mode: :password)
+        clear_user_bad_attempts
         render :plain => OpenC3::AuthModel.generate_session()
       else
         record_user_bad_attempt
@@ -59,6 +62,7 @@ class AuthController < ApplicationController
 
     begin
       if OpenC3::AuthModel.verify(params[:password], service_only: true)
+        clear_service_bad_attempts
         render :plain => OpenC3::AuthModel.generate_session()
       else
         record_service_bad_attempt
@@ -85,6 +89,7 @@ class AuthController < ApplicationController
     begin
       # Set throws an exception if it fails for any reason
       OpenC3::AuthModel.set(params[:password], params[:old_password])
+      clear_user_bad_attempts
       OpenC3::Logger.info("Password changed", user: username())
       render :plain => OpenC3::AuthModel.generate_session()
     rescue StandardError => e
@@ -98,45 +103,105 @@ class AuthController < ApplicationController
 
   private
 
-  # Checks to see if the user password has been rate limited due to bad attempts
+  # Identifies the client making the request so that bad attempt counters are
+  # scoped per client instead of globally. A global counter allows any
+  # unauthenticated client to lock out every operator by sending
+  # MAX_BAD_ATTEMPTS bad passwords, so everything that counts bad attempts must
+  # be namespaced by this value.
+  #
+  # This uses Rails request.remote_ip which honors X-Forwarded-For. COSMOS runs
+  # behind traefik, which discards any client supplied X-Forwarded-* headers and
+  # sets them from the real connection, so a client can't choose its own bucket.
+  # See the forwardedHeaders comments in openc3-traefik/traefik.yaml: if traefik
+  # is configured to trust a proxy that doesn't set X-Forwarded-For, every
+  # client collapses into that proxy's bucket.
+  def client_id
+    ip = begin
+      request.remote_ip
+    rescue StandardError
+      nil
+    end
+    ip ||= request.remote_addr
+    # Only allow ip address characters in the key and bound the length so the
+    # attacker controlled header can't be used to build arbitrary Redis keys
+    ip = ip.to_s.gsub(/[^0-9a-fA-F:.]/, '')[0, 45]
+    return ip.empty? ? 'unknown' : ip
+  end
+
+  def user_bad_attempts_key
+    "#{USER_BAD_ATTEMPTS_KEY_PREFIX}__#{client_id}"
+  end
+
+  def service_bad_attempts_key
+    "#{SERVICE_BAD_ATTEMPTS_KEY_PREFIX}__#{client_id}"
+  end
+
+  # Checks to see if this client has been rate limited due to bad user password attempts
   def user_rate_limited?
-    begin
-      count = OpenC3::EphemeralStore.get(USER_BAD_ATTEMPTS_KEY)
-      return count.to_i >= MAX_BAD_ATTEMPTS
-    rescue StandardError => error
-      OpenC3::Logger.error("Redis error checking user rate limit: #{error.message}")
-      return false
-    end
+    rate_limited?(user_bad_attempts_key, 'user')
   end
-  
-  # Initializes or increments the bad attempt counter for the user password
+
+  # Initializes or increments this client's bad attempt counter for the user password
   def record_user_bad_attempt
-    begin
-      count = OpenC3::EphemeralStore.incr(USER_BAD_ATTEMPTS_KEY)
-      OpenC3::EphemeralStore.expire(USER_BAD_ATTEMPTS_KEY, BAD_ATTEMPTS_WINDOW) if count == 1
-    rescue StandardError => error
-      OpenC3::Logger.error("Redis error recording user bad attempt: #{error.message}")
-    end
+    record_bad_attempt(user_bad_attempts_key, 'user')
   end
-  
-  # Checks to see if the service password has been rate limited due to bad attempts
+
+  # Clears this client's bad attempt counter after a successful user authentication
+  def clear_user_bad_attempts
+    clear_bad_attempts(user_bad_attempts_key, 'user')
+  end
+
+  # Checks to see if this client has been rate limited due to bad service password attempts
   def service_rate_limited?
+    rate_limited?(service_bad_attempts_key, 'service')
+  end
+
+  # Initializes or increments this client's bad attempt counter for the service password
+  def record_service_bad_attempt
+    record_bad_attempt(service_bad_attempts_key, 'service')
+  end
+
+  # Clears this client's bad attempt counter after a successful service authentication
+  def clear_service_bad_attempts
+    clear_bad_attempts(service_bad_attempts_key, 'service')
+  end
+
+  def rate_limited?(key, type)
     begin
-      count = OpenC3::EphemeralStore.get(SERVICE_BAD_ATTEMPTS_KEY)
-      return count.to_i >= MAX_BAD_ATTEMPTS
+      count = OpenC3::EphemeralStore.get(key)
+      limited = count.to_i >= MAX_BAD_ATTEMPTS
+      # A limited client returns before recording another bad attempt, so if the
+      # counter somehow has no TTL (incr succeeded but expire didn't) nothing
+      # would ever set one and the client would be locked out forever
+      if limited and OpenC3::EphemeralStore.ttl(key) < 0
+        OpenC3::EphemeralStore.expire(key, BAD_ATTEMPTS_WINDOW)
+      end
+      return limited
     rescue StandardError => error
-      OpenC3::Logger.error("Redis error checking service rate limit: #{error.message}")
+      OpenC3::Logger.error("Redis error checking #{type} rate limit: #{error.message}")
       return false
     end
   end
-  
-  # Initializes or increments the bad attempt counter for the service password
-  def record_service_bad_attempt
+
+  def record_bad_attempt(key, type)
     begin
-      count = OpenC3::EphemeralStore.incr(SERVICE_BAD_ATTEMPTS_KEY)
-      OpenC3::EphemeralStore.expire(SERVICE_BAD_ATTEMPTS_KEY, BAD_ATTEMPTS_WINDOW) if count == 1
+      OpenC3::EphemeralStore.incr(key)
+      # Refresh the TTL on every bad attempt so the window is measured from the
+      # last bad attempt rather than the first. Note a client that is already
+      # limited returns before getting here, so it can't extend its own lockout:
+      # the lockout always ends BAD_ATTEMPTS_WINDOW after the attempt that
+      # tripped it.
+      OpenC3::EphemeralStore.expire(key, BAD_ATTEMPTS_WINDOW)
     rescue StandardError => error
-      OpenC3::Logger.error("Redis error recording service bad attempt: #{error.message}")
+      OpenC3::Logger.error("Redis error recording #{type} bad attempt: #{error.message}")
+    end
+  end
+
+  def clear_bad_attempts(key, type)
+    begin
+      OpenC3::EphemeralStore.del(key)
+    rescue StandardError => error
+      OpenC3::Logger.error("Redis error clearing #{type} bad attempts: #{error.message}")
     end
   end
 end

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/auth_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/auth_controller_spec.rb
@@ -106,10 +106,122 @@ RSpec.describe AuthController, :type => :controller do
   end
 
   describe "rate limiting" do
-    # Actually testing that rate limiting is enforced is done in Playwright
-    # because the bad attempt counters in the controller are shared across
-    # all requests/tests. But we can ensure that the config is read and that
-    # successful attempts don't get rate limited.
+    # Sets the client ip for the next request. remote_ip memoizes so clear it.
+    def set_client_ip(ip)
+      request.remote_addr = ip
+      request.env.delete('action_dispatch.remote_ip')
+      request.instance_variable_set(:@remote_ip, nil)
+    end
+
+    it "rate limits bad password attempts from the same client" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      set_client_ip('1.2.3.4')
+      10.times do
+        post :verify, params: { password: 'BAD' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+      post :verify, params: { password: 'BAD' }
+      expect(response).to have_http_status(:too_many_requests)
+      # Even the correct password is rejected for this client
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "does not rate limit other clients when one client sends bad passwords" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      set_client_ip('1.2.3.4')
+      20.times do
+        post :verify, params: { password: 'BAD' }
+      end
+      expect(response).to have_http_status(:too_many_requests)
+
+      # A different client can still log in with the correct password
+      set_client_ip('5.6.7.8')
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rate limits based on X-Forwarded-For when behind a proxy" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      # Simulate traefik forwarding two different browsers from the same proxy
+      request.remote_addr = '10.0.0.1'
+      request.headers['X-Forwarded-For'] = '1.2.3.4'
+      request.instance_variable_set(:@remote_ip, nil)
+      20.times do
+        post :verify, params: { password: 'BAD' }
+      end
+      expect(response).to have_http_status(:too_many_requests)
+
+      request.headers['X-Forwarded-For'] = '5.6.7.8'
+      request.instance_variable_set(:@remote_ip, nil)
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "clears the bad attempt counter after a successful attempt" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      set_client_ip('1.2.3.4')
+      9.times do
+        post :verify, params: { password: 'BAD' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      # Counter was reset so 9 more bad attempts don't trip the limit
+      9.times do
+        post :verify, params: { password: 'BAD' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "refreshes the window on each bad attempt" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      set_client_ip('1.2.3.4')
+      key = "openc3__auth_bad_attempts__user__1.2.3.4"
+      post :verify, params: { password: 'BAD' }
+      OpenC3::EphemeralStore.expire(key, 5)
+      post :verify, params: { password: 'BAD' }
+      expect(OpenC3::EphemeralStore.ttl(key)).to be > 5
+    end
+
+    it "gives the counter a window if it somehow has no expiration" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      # Simulate incr succeeding but expire failing, which would otherwise lock
+      # this client out forever
+      key = "openc3__auth_bad_attempts__user__1.2.3.4"
+      OpenC3::EphemeralStore.set(key, 100)
+      set_client_ip('1.2.3.4')
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:too_many_requests)
+      expect(OpenC3::EphemeralStore.ttl(key)).to be_between(1, 120)
+    end
+
+    it "rate limits bad service password attempts per client" do
+      set_client_ip('1.2.3.4')
+      20.times do
+        post :verify_service, params: { password: 'BAD' }
+      end
+      expect(response).to have_http_status(:too_many_requests)
+
+      set_client_ip('5.6.7.8')
+      post :verify_service, params: { password: 'openc3service' }
+      expect(response).to have_http_status(:ok)
+    end
 
     it "uses default rate limit values from environment" do
       expect(ENV['OPENC3_AUTH_RATE_LIMIT_TO']).to eq('10')

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/auth_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/auth_controller_spec.rb
@@ -106,10 +106,96 @@ RSpec.describe AuthController, :type => :controller do
   end
 
   describe "rate limiting" do
-    # Actually testing that rate limiting is enforced is done in Playwright
-    # because the bad attempt counters in the controller are shared across
-    # all requests/tests. But we can ensure that the config is read and that
-    # successful attempts don't get rate limited.
+    # Sets the client ip for the next request. remote_ip memoizes so clear it.
+    def set_client_ip(ip)
+      request.remote_addr = ip
+      request.env.delete('action_dispatch.remote_ip')
+      request.instance_variable_set(:@remote_ip, nil)
+    end
+
+    it "rate limits bad password attempts from the same client" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      set_client_ip('1.2.3.4')
+      10.times do
+        post :verify, params: { password: 'BAD' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+      post :verify, params: { password: 'BAD' }
+      expect(response).to have_http_status(:too_many_requests)
+      # Even the correct password is rejected for this client
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "does not rate limit other clients when one client sends bad passwords" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      set_client_ip('1.2.3.4')
+      20.times do
+        post :verify, params: { password: 'BAD' }
+      end
+      expect(response).to have_http_status(:too_many_requests)
+
+      # A different client can still log in with the correct password
+      set_client_ip('5.6.7.8')
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rate limits based on X-Forwarded-For when behind a proxy" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      # Simulate traefik forwarding two different browsers from the same proxy
+      request.remote_addr = '10.0.0.1'
+      request.headers['X-Forwarded-For'] = '1.2.3.4'
+      request.instance_variable_set(:@remote_ip, nil)
+      20.times do
+        post :verify, params: { password: 'BAD' }
+      end
+      expect(response).to have_http_status(:too_many_requests)
+
+      request.headers['X-Forwarded-For'] = '5.6.7.8'
+      request.instance_variable_set(:@remote_ip, nil)
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "clears the bad attempt counter after a successful attempt" do
+      post :set, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      set_client_ip('1.2.3.4')
+      9.times do
+        post :verify, params: { password: 'BAD' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+
+      # Counter was reset so 9 more bad attempts don't trip the limit
+      9.times do
+        post :verify, params: { password: 'BAD' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+      post :verify, params: { password: 'PASSWORD' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rate limits bad service password attempts per client" do
+      set_client_ip('1.2.3.4')
+      20.times do
+        post :verify_service, params: { password: 'BAD' }
+      end
+      expect(response).to have_http_status(:too_many_requests)
+
+      set_client_ip('5.6.7.8')
+      post :verify_service, params: { password: 'openc3service' }
+      expect(response).to have_http_status(:ok)
+    end
 
     it "uses default rate limit values from environment" do
       expect(ENV['OPENC3_AUTH_RATE_LIMIT_TO']).to eq('10')

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/auth_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/auth_controller_spec.rb
@@ -106,9 +106,15 @@ RSpec.describe AuthController, :type => :controller do
   end
 
   describe "rate limiting" do
-    # Sets the client ip for the next request. remote_ip memoizes so clear it.
-    def set_client_ip(ip)
-      request.remote_addr = ip
+    # Sets the client ip for the next request, either as the connecting address
+    # or as the address a proxy forwarded. remote_ip memoizes in both the request
+    # instance and the rack env so clear both or later requests keep the old ip.
+    def set_client_ip(ip, forwarded: false)
+      if forwarded
+        request.headers['X-Forwarded-For'] = ip
+      else
+        request.remote_addr = ip
+      end
       request.env.delete('action_dispatch.remote_ip')
       request.instance_variable_set(:@remote_ip, nil)
     end
@@ -151,15 +157,13 @@ RSpec.describe AuthController, :type => :controller do
 
       # Simulate traefik forwarding two different browsers from the same proxy
       request.remote_addr = '10.0.0.1'
-      request.headers['X-Forwarded-For'] = '1.2.3.4'
-      request.instance_variable_set(:@remote_ip, nil)
+      set_client_ip('1.2.3.4', forwarded: true)
       20.times do
         post :verify, params: { password: 'BAD' }
       end
       expect(response).to have_http_status(:too_many_requests)
 
-      request.headers['X-Forwarded-For'] = '5.6.7.8'
-      request.instance_variable_set(:@remote_ip, nil)
+      set_client_ip('5.6.7.8', forwarded: true)
       post :verify, params: { password: 'PASSWORD' }
       expect(response).to have_http_status(:ok)
     end

--- a/openc3-traefik/traefik.yaml
+++ b/openc3-traefik/traefik.yaml
@@ -14,6 +14,17 @@
 entrypoints:
   web:
     address: ":2900"
+    # Login rate limiting in the cmd-tlm-api is scoped by client ip, which comes
+    # from X-Forwarded-For. Leaving forwardedHeaders unset is what makes that
+    # safe: traefik then discards any client supplied X-Forwarded-* headers and
+    # sets them from the real connection, so a client can't choose which rate
+    # limit bucket it lands in. Never set forwardedHeaders.insecure here.
+    # If you run your own proxy or load balancer in front of traefik, list its
+    # addresses in trustedIPs so the client ip it forwards is preserved,
+    # otherwise every client shares the proxy's bucket.
+    # forwardedHeaders:
+    #   trustedIPs:
+    #     - "10.0.0.1/32" # address of the proxy in front of traefik
     http:
       encodedCharacters:
         # Allow encoded slashes (%2F) in URL paths

--- a/playwright/tests/auth.p.spec.ts
+++ b/playwright/tests/auth.p.spec.ts
@@ -19,6 +19,10 @@ test.describe('Auth API', () => {
 
     const maxRequests = Number.parseInt(process.env.OPENC3_AUTH_RATE_LIMIT_TO || '10')
 
+    // Note: rate limiting is scoped per client ip, and traefik discards client
+    // supplied X-Forwarded-For, so this test can only exercise its own bucket.
+    // That a client can't lock out other clients is covered by the cmd-tlm-api
+    // auth_controller_spec.
     let gotRateLimited = false
     for (let i = 0; i <= maxRequests; i++) {
       const response = await request.post('/openc3-api/auth/verify', {


### PR DESCRIPTION
The failed login counters were single global Redis keys, so bad passwords from any one client rate limited every other client, including requests carrying the correct password. Key the counters by client ip instead so a client can only rate limit itself.

Also refresh the counter TTL on every bad attempt and clear the counter after a successful authentication.

Note: This is Core only and does not affect Enterprise which authenticates through Keycloak

🤖 Generated with [Claude Code](https://claude.com/claude-code)