### PR TITLE
fix(playwright): stop notoast leaking into shared storage state

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -57,11 +57,8 @@ export default defineConfig({
     actionTimeout: 30 * 1000,
     // Base URL to use in actions like `await page.goto('/')`
     baseURL: 'http://localhost:2900',
-    // Keep the trace of every failed attempt, not just retries: with
-    // 'on-first-retry' a test that fails then passes leaves a trace of the
-    // *passing* run, which is the one that needs no diagnosing.
-    // See https://playwright.dev/docs/trace-viewer
-    trace: process.env.CI ? 'retain-on-failure' : 'on',
+    // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
+    trace: process.env.CI ? 'on-first-retry' : 'on',
     screenshot: 'only-on-failure',
     viewport: { width: 1600, height: 1200 },
   },

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -57,8 +57,11 @@ export default defineConfig({
     actionTimeout: 30 * 1000,
     // Base URL to use in actions like `await page.goto('/')`
     baseURL: 'http://localhost:2900',
-    // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
-    trace: process.env.CI ? 'on-first-retry' : 'on',
+    // Keep the trace of every failed attempt, not just retries: with
+    // 'on-first-retry' a test that fails then passes leaves a trace of the
+    // *passing* run, which is the one that needs no diagnosing.
+    // See https://playwright.dev/docs/trace-viewer
+    trace: process.env.CI ? 'retain-on-failure' : 'on',
     screenshot: 'only-on-failure',
     viewport: { width: 1600, height: 1200 },
   },

--- a/playwright/tests/fixture.ts
+++ b/playwright/tests/fixture.ts
@@ -8,10 +8,12 @@
 # See LICENSE.md for more details.
 */
 
+import { writeFile } from 'node:fs/promises'
 import { expect, test as base } from '@playwright/test'
 import { Utilities } from '../utilities'
 import { CoverageReport } from 'monocart-coverage-reports'
 import coverageOptions from '../coverage.config.mjs'
+import { ADMIN_STORAGE_STATE, STORAGE_STATE } from '../playwright.config'
 
 // V8 coverage is Chromium-only and only collected when COVERAGE=1,
 // so normal runs pay no profiler overhead. Requires bundles built with
@@ -42,6 +44,25 @@ const stopCoverage = async (page: any) => {
   }
 }
 
+// localStorage keys the fixture or a spec injects to drive UI preferences
+// rather than authentication. These must never reach the shared storage state
+// files: every context is created from those files, so a persisted notoast
+// silently disables alert toasts for the whole run (Notifications.vue reads
+// localStorage.notoast on load) and a persisted toastPosition changes where the
+// toaster renders.
+const UI_PREF_KEYS = new Set(['notoast', 'toastPosition'])
+
+// Persist just the signed-in session, dropping the UI preference keys above.
+const saveAuthState = async (context: any, path: string) => {
+  const state = await context.storageState()
+  for (const origin of state.origins || []) {
+    origin.localStorage = (origin.localStorage || []).filter(
+      (item: { name: string }) => !UI_PREF_KEYS.has(item.name),
+    )
+  }
+  await writeFile(path, JSON.stringify(state))
+}
+
 // Extend the page fixture to goto the OpenC3 tool and wait for potential
 // redirect to authentication login (Enterprise only).
 // Login and click the hamburger nav icon to close the navigation drawer.
@@ -68,22 +89,27 @@ export const test = base.extend<{
       // profile those too or their bundles are missing from the report.
       context.on('page', startCoverage)
     }
-    // Disable alert toast popups before the first navigation so the
+    // Set the alert toast preference before the first navigation so the
     // Notifications component reads it on load (localStorage.notoast === 'true'
     // means "don't toast"). Runs on every page in the context, so it survives
-    // reloads too.
-    if (disableToasts) {
-      await context.addInitScript(() => {
-        // Runs in every frame, including sandboxed iframes (e.g. the screen
-        // ButtonWidget command sandbox) whose opaque origin has no localStorage
-        // access - guard so we don't throw a SecurityError there.
-        try {
+    // reloads too. Always write the value rather than only setting it when
+    // disabling: contexts start from storageState.json, which can already carry
+    // a notoast from a previous test, and a spec that opts out (notifications)
+    // needs it actually removed.
+    await context.addInitScript((disable: boolean) => {
+      // Runs in every frame, including sandboxed iframes (e.g. the screen
+      // ButtonWidget command sandbox) whose opaque origin has no localStorage
+      // access - guard so we don't throw a SecurityError there.
+      try {
+        if (disable) {
           window.localStorage.setItem('notoast', 'true')
-        } catch {
-          // Sandboxed/cross-origin frame: nothing to disable here.
+        } else {
+          window.localStorage.removeItem('notoast')
         }
-      })
-    }
+      } catch {
+        // Sandboxed/cross-origin frame: nothing to set here.
+      }
+    }, disableToasts)
     await page.goto(`${baseURL}${toolPath}`, { waitUntil: 'domcontentloaded' })
     let utils = new Utilities(page)
     if (process.env.ENTERPRISE === '1') {
@@ -115,12 +141,10 @@ export const test = base.extend<{
           page.waitForURL(`${baseURL}${toolPath}`),
           page.locator('button:has-text("Sign In")').click(),
         ])
-        await page.context().storageState({
-          path:
-            username === 'admin'
-              ? 'adminStorageState.json'
-              : 'storageState.json',
-        })
+        await saveAuthState(
+          page.context(),
+          username === 'admin' ? ADMIN_STORAGE_STATE : STORAGE_STATE,
+        )
       }
     }
     await expect(page.locator('.v-app-bar')).toContainText(toolName, {

--- a/playwright/tests/fixture.ts
+++ b/playwright/tests/fixture.ts
@@ -44,20 +44,35 @@ const stopCoverage = async (page: any) => {
   }
 }
 
-// localStorage keys the fixture or a spec injects to drive UI preferences
-// rather than authentication. These must never reach the shared storage state
-// files: every context is created from those files, so a persisted notoast
-// silently disables alert toasts for the whole run (Notifications.vue reads
-// localStorage.notoast on load) and a persisted toastPosition changes where the
-// toaster renders.
-const UI_PREF_KEYS = new Set(['notoast', 'toastPosition'])
+// The only localStorage keys worth carrying in the shared storage state files.
+// Allowlisted rather than denylisted: every context is created from those files,
+// so anything else that gets captured silently changes app behavior for the rest
+// of the run - a persisted notoast disables alert toasts (Notifications.vue
+// reads it on load), and notificationStreamOffset / lastReadNotification /
+// ackedAlerts make alerts come back already read. A missing key here breaks
+// every spec loudly, which is the failure mode we want.
+const AUTH_STATE_KEYS = new Set([
+  // Session: openc3Token is core's whole auth story, the rest are Enterprise
+  // (see the two public/js/auth.js copies).
+  'openc3Token',
+  'openc3RefreshToken',
+  'openc3OfflineToken',
+  'openc3LoginMode',
+  // Keycloak client config, written at boot by Enterprise auth.js.
+  'keycloakUrl',
+  'keycloakRealm',
+  'keycloakClientId',
+  // Enterprise tool-base main.js reads this at boot to set window.openc3Scope.
+  'openc3Scope',
+])
 
-// Persist just the signed-in session, dropping the UI preference keys above.
+// Persist just the signed-in session, dropping everything else (UI preferences,
+// notification read state, keycloak kc-callback-* redirect leftovers).
 const saveAuthState = async (context: any, path: string) => {
   const state = await context.storageState()
   for (const origin of state.origins || []) {
     origin.localStorage = (origin.localStorage || []).filter(
-      (item: { name: string }) => !UI_PREF_KEYS.has(item.name),
+      (item: { name: string }) => AUTH_STATE_KEYS.has(item.name),
     )
   }
   await writeFile(path, JSON.stringify(state))

--- a/playwright/tests/notifications.s.spec.ts
+++ b/playwright/tests/notifications.s.spec.ts
@@ -49,12 +49,6 @@ async function setQuiet(browser, baseURL, state) {
     page,
     `cmd("INST QUIET with STATE ${state}")\ncmd("INST2 QUIET with STATE ${state}")`,
   )
-  // // Setting QUIET means show alerts and QUIET false means hide alerts
-  // if (state === 'FALSE') {
-  //   await setSetting(page, 'show-alerts', true)
-  // } else {
-  //   await setSetting(page, 'show-alerts', false)
-  // }
 
   // Wait for the command script to finish so the QUIET cmds are actually sent
   // before tearing down the context.

--- a/playwright/tests/notifications.s.spec.ts
+++ b/playwright/tests/notifications.s.spec.ts
@@ -163,6 +163,18 @@ test('yellow limit changes never toast, only show in the menu', async ({
   await expect(yellowToast).toHaveCount(0)
 })
 
+// Reload and wait for the tool to come back. In Enterprise every page load
+// bounces through Keycloak (redirect, token exchange, full app boot) before the
+// message stream resubscribes and replays history - roughly 4s of the budget
+// before any toast can appear. Waiting for the app bar keeps that cost out of
+// the toast assertions below.
+async function reloadAndWaitForApp(page) {
+  await page.reload()
+  await expect(page.locator('.v-app-bar')).toContainText('Script Runner', {
+    timeout: 30000,
+  })
+}
+
 // A menu row (v-list-item) for the alert carrying the given text.
 function menuRow(page, text) {
   return page.locator('[data-test=notification-list] .v-list-item', {
@@ -284,6 +296,11 @@ test('un-acked alerts survive a page reload (must-ack persists)', async ({
   page,
   utils,
 }) => {
+  // Emit, reload (Keycloak round trip plus app boot) and then wait on a stream
+  // replay: more sequential waiting than the 60s default allows for, and
+  // blowing that cap reports an opaque test timeout instead of naming the
+  // assertion that failed.
+  test.setTimeout(120000)
   const alertText = 'Playwright reload persist test'
   await runLog(
     page,
@@ -297,9 +314,11 @@ test('un-acked alerts survive a page reload (must-ack persists)', async ({
   await page.locator('[data-test=notifications]').click()
   await page.keyboard.press('Escape')
 
-  // After reload the un-acked alert is re-fetched and toasts again.
-  await page.reload()
-  await expect(toast).toBeVisible({ timeout: 20000 })
+  // After reload the un-acked alert is re-fetched and toasts again. This waits
+  // on a stream replay rather than a freshly emitted message, so it gets a
+  // longer timeout than the emit-then-assert cases above.
+  await reloadAndWaitForApp(page)
+  await expect(toast).toBeVisible({ timeout: 30000 })
   await toast.getByRole('button', { name: 'Acknowledge' }).click()
   await expect(toast).toBeHidden()
 })
@@ -308,6 +327,9 @@ test('acked alerts stay acked across a reload (no re-toast)', async ({
   page,
   utils,
 }) => {
+  // Same reload cost as the test above, plus a second emit-and-toast for the
+  // sentinel.
+  test.setTimeout(120000)
   const alertText = 'Playwright reload acked test'
   await runLog(
     page,
@@ -321,7 +343,7 @@ test('acked alerts stay acked across a reload (no re-toast)', async ({
   await toast.getByRole('button', { name: 'Acknowledge' }).click()
   await expect(toast).toBeHidden()
 
-  await page.reload()
+  await reloadAndWaitForApp(page)
 
   // Emit a fresh sentinel alert after the reload. Once its toast appears we
   // know the stream reconnected and replayed history, so the acked alert has


### PR DESCRIPTION
## Problem

Enterprise Playwright CI ([run 32272124083](https://github.com/OpenC3/cosmos-enterprise/actions/runs/32272124083/job/96187600934)) failed 9 tests in `notifications.s.spec.ts` — every assertion waiting on `[data-test=toast]` timed out. The two tests that assert *no* toast passed vacuously.

That run's trace artifact shows the context's `storageState` for `http://localhost:2900` contains:

```
notoast = true
```

`Notifications.vue:316` reads it as `showToast = false`, so the gate at `Notifications.vue:524` never queues a toast. Menu population is outside the gate, which is why the notifications badge still counted the alert.

Why it only happens under Enterprise: `fixture.ts` sets `notoast=true` for every spec (`disableToasts: true`), and — inside the `ENTERPRISE === '1'` branch only — re-saves the whole context to `storageState.json` after a mid-run Keycloak re-login, baking that flag in. Every later context is created from that file, and `notifications.s.spec.ts`'s `disableToasts: false` only *skips* the init script, so it could not clear an inherited value.

Unrelated to the cosmos `web-socket-api-refactor` merge: core CI passes the same spec on the same commit.

## Fix

- The init script always writes the toast preference (`setItem` when disabling, `removeItem` when a spec opts out), so opting out defeats an inherited value.
- `saveAuthState` allowlists what gets written to `storageState.json` / `adminStorageState.json`, keeping only session and scope keys: `openc3Token`, `openc3RefreshToken`, `openc3OfflineToken`, `openc3LoginMode`, `keycloakUrl`, `keycloakRealm`, `keycloakClientId`, `openc3Scope`. Everything else is dropped — UI preferences (`notoast`, `toastPosition`), notification read state (`notificationStreamOffset`, `lastReadNotification`, `ackedAlerts`), `kc-callback-*` redirect leftovers.

  Allowlist rather than denylist because the leak is the bug: any test-injected key that reaches that file silently changes behavior for the rest of the run, and the notification read-state keys would do it in the same way `notoast` did. A key missing from the allowlist fails every spec loudly instead, which is the better failure mode — but it does mean the list needs updating if auth-relevant keys are added.
- Removed a dead commented-out `setSetting(..., 'show-alerts', ...)` block in the spec.
- Hardened the two reload tests, which flaked once the toasts started working: in Enterprise every page load bounces through Keycloak, so `page.reload()` spends ~4s on redirect, token exchange and app boot before the message stream resubscribes and replays — all of it previously inside the 20s toast assertion. They now wait for the app bar after reloading, give the replay assertion 30s, and raise their own timeout past the 60s default so an overrun still names the failing assertion.
- `trace: 'retain-on-failure'` in CI. With `on-first-retry`, a test that fails then passes leaves a trace of the passing run — the one that needs no diagnosing.

## Verification

Enterprise run [32395585458](https://github.com/OpenC3/cosmos-enterprise/actions/runs/32395585458/job/96651713395), which did check out this branch: the 9 toast failures are gone (serial batch 47 passed). Two remaining issues, both now understood:

- `un-acked alerts survive a page reload` flaked — the reload/replay timing above, addressed by the last commit and not yet re-run in CI.
- `table-manager.s.spec.ts:259 downloads binary, definition, report` failed on a download timeout. Pre-existing and unrelated; it was already flaky before this branch.

Locally, against an Enterprise stack with a deliberately poisoned `storageState.json` (live operator session plus `notoast` and `notificationStreamOffset`):

- opt-out clears the inherited flag and the default still sets it — passes with the fix, fails with the fixture reverted
- forcing the re-login branch writes back exactly the allowlisted keys, and re-running against that file authenticates without another login, so the allowlist isn't too narrow
- `pnpm lint --max-warnings 0` clean

## Follow-ups (not in this PR)

- `setQuiet` in `notifications.s.spec.ts` builds a raw context from `storageState.json` and cannot log in. Global setup saves the operator session then logs out of it to log in as admin, so that file only works because the fixture refreshes it mid-run — the same write that was poisoning it.
- Enterprise emits its own must-ack ALERTs (`metrics_helper.rb:187`) and `Toast.vue` shows 3 toasts at a time with `duration: Infinity`, so stuck system-health alerts could still starve a spec's toast on a loaded runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
