### PR TITLE
fix(frontend): guard requests on auth and batch settings fetches

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -832,8 +832,8 @@ export default {
         this.keyMap[indexString] = key
         items.push([key, indexString])
       })
-      OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity).then(
-        (refreshed) => {
+      OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity)
+        .then((refreshed) => {
           if (refreshed) {
             OpenC3Auth.setTokens()
           }
@@ -844,8 +844,10 @@ export default {
             start_time: this.startDateTime,
             end_time: this.endDateTime,
           })
-        },
-      )
+        })
+        // A rejection means we have no token and are being redirected to login,
+        // so don't try to subscribe
+        .catch(() => {})
     },
     received: function (data) {
       this.cable.recordPing()

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataextractor/src/tools/DataExtractor/DataExtractor.vue
@@ -306,7 +306,12 @@
 // Putting large data into Vue data section causes lots of overhead
 let dataExtractorRawData = []
 
-import { Api, Cable, OpenC3Api } from '@openc3/js-common/services'
+import {
+  Api,
+  Cable,
+  OpenC3Api,
+  logUnlessAuthRequired,
+} from '@openc3/js-common/services'
 import {
   Config,
   OpenC3TimePicker,
@@ -845,9 +850,10 @@ export default {
             end_time: this.endDateTime,
           })
         })
-        // A rejection means we have no token and are being redirected to login,
-        // so don't try to subscribe
-        .catch(() => {})
+        // An AuthRequiredError means we have no token and are being redirected
+        // to login, so don't try to subscribe. Anything else is unexpected and
+        // still gets logged.
+        .catch(logUnlessAuthRequired)
     },
     received: function (data) {
       this.cable.recordPing()

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/DataViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/DataViewer.vue
@@ -225,7 +225,12 @@
 </template>
 
 <script>
-import { Api, Cable, OpenC3Api } from '@openc3/js-common/services'
+import {
+  Api,
+  Cable,
+  OpenC3Api,
+  logUnlessAuthRequired,
+} from '@openc3/js-common/services'
 import {
   Config,
   OpenC3TimePicker,
@@ -550,9 +555,10 @@ export default {
               ...this.startEndTime,
             })
           })
-          // A rejection means we have no token and are being redirected to
-          // login, so don't try to subscribe
-          .catch(() => {})
+          // An AuthRequiredError means we have no token and are being
+          // redirected to login, so don't try to subscribe. Anything else is
+          // unexpected and still gets logged.
+          .catch(logUnlessAuthRequired)
       }
 
       if (packetBased.length > 0) {
@@ -583,9 +589,10 @@ export default {
               })
             })
           })
-          // A rejection means we have no token and are being redirected to
-          // login, so don't try to subscribe
-          .catch(() => {})
+          // An AuthRequiredError means we have no token and are being
+          // redirected to login, so don't try to subscribe. Anything else is
+          // unexpected and still gets logged.
+          .catch(logUnlessAuthRequired)
       }
     },
     removeFromSubscription: function (packets) {

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/DataViewer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-dataviewer/src/tools/DataViewer/DataViewer.vue
@@ -538,8 +538,8 @@ export default {
 
       if (itemBased.length > 0) {
         // Add the items to the subscription
-        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity).then(
-          (refreshed) => {
+        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity)
+          .then((refreshed) => {
             if (refreshed) {
               OpenC3Auth.setTokens()
             }
@@ -549,8 +549,10 @@ export default {
               items: itemBased.map(this.itemSubscriptionKey),
               ...this.startEndTime,
             })
-          },
-        )
+          })
+          // A rejection means we have no token and are being redirected to
+          // login, so don't try to subscribe
+          .catch(() => {})
       }
 
       if (packetBased.length > 0) {
@@ -567,8 +569,8 @@ export default {
           // This eliminates duplicates by converted to Set and back to Array
           modeGroups[mode] = [...new Set(modeGroups[mode])]
         })
-        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity).then(
-          (refreshed) => {
+        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity)
+          .then((refreshed) => {
             if (refreshed) {
               OpenC3Auth.setTokens()
             }
@@ -580,8 +582,10 @@ export default {
                 ...this.startEndTime,
               })
             })
-          },
-        )
+          })
+          // A rejection means we have no token and are being redirected to
+          // login, so don't try to subscribe
+          .catch(() => {})
       }
     },
     removeFromSubscription: function (packets) {

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/api.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/api.js
@@ -16,6 +16,7 @@
 */
 
 import axios from './axios'
+import { refreshToken } from './authGuard'
 
 const request = async function (
   method,
@@ -31,16 +32,9 @@ const request = async function (
   } = {},
 ) {
   if (!noAuth) {
-    try {
-      let refreshed = await OpenC3Auth.updateToken(
-        OpenC3Auth.defaultMinValidity,
-      )
-      if (refreshed) {
-        OpenC3Auth.setTokens()
-      }
-    } catch (error) {
-      OpenC3Auth.login()
-    }
+    // Throws an AuthRequiredError if we have no token, in which case we're
+    // being redirected to login and must not send the request
+    await refreshToken()
     headers['Authorization'] = localStorage.openc3Token
   }
   // Everything from the front-end is manual by default

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/api.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/api.js
@@ -16,7 +16,7 @@
 */
 
 import axios from './axios'
-import { refreshToken } from './authGuard'
+import { isAuthRequiredError, refreshToken } from './authGuard'
 
 const request = async function (
   method,
@@ -26,16 +26,34 @@ const request = async function (
     params = {},
     headers,
     noAuth = false,
+    optionalAuth = false,
     noScope = false,
     onUploadProgress = false,
     responseType,
   } = {},
 ) {
   if (!noAuth) {
-    // Throws an AuthRequiredError if we have no token, in which case we're
-    // being redirected to login and must not send the request
-    await refreshToken()
-    headers['Authorization'] = localStorage.openc3Token
+    if (optionalAuth) {
+      // Public bootstrap endpoints (e.g. tools/all, which AppNav needs to
+      // render the login page itself) must still be sent with no token.
+      // Refresh if we can and send whatever token we end up with, but never
+      // let a missing one block the request.
+      try {
+        await refreshToken()
+      } catch (error) {
+        if (!isAuthRequiredError(error)) {
+          throw error
+        }
+      }
+      if (localStorage.openc3Token) {
+        headers['Authorization'] = localStorage.openc3Token
+      }
+    } else {
+      // Throws an AuthRequiredError if we have no token, in which case we're
+      // being redirected to login and must not send the request
+      await refreshToken()
+      headers['Authorization'] = localStorage.openc3Token
+    }
   }
   // Everything from the front-end is manual by default
   // The various api methods decide whether to pass the manual
@@ -72,6 +90,7 @@ export default {
       headers = acceptOnlyDefaultHeaders,
       noScope,
       noAuth,
+      optionalAuth,
       onUploadProgress,
       responseType,
     } = {},
@@ -81,6 +100,7 @@ export default {
       headers,
       noScope,
       noAuth,
+      optionalAuth,
       onUploadProgress,
       responseType,
     })

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/authGuard.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/authGuard.js
@@ -50,7 +50,10 @@ export function logUnlessAuthRequired(error) {
   }
 }
 
-export class AuthRequiredError extends Error {
+// NOTE: AuthRequiredError itself is deliberately not exported. It's matched by
+// name, not by identity, so callers use isAuthRequiredError instead - exporting
+// the class would invite instanceof checks that break across editions.
+class AuthRequiredError extends Error {
   constructor(message = 'Authentication required') {
     super(message)
     this.name = 'AuthRequiredError'

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/authGuard.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/authGuard.js
@@ -1,0 +1,112 @@
+/*
+# Copyright 2026, OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+*/
+
+// Whether an error means "there is no usable token, we're going to the login
+// page". OpenC3Auth.updateToken rejects with one of these instead of resolving
+// as if the token were good (see tool-base public/js/auth.js). Matched by name
+// so this works with any Auth implementation, core or enterprise.
+export function isAuthRequiredError(error) {
+  return error?.name === 'AuthRequiredError'
+}
+
+// Whether an error is a request that came back unauthorized. A stale token
+// rejects with the underlying axios error rather than an AuthRequiredError,
+// since the token only turns out to be bad once the server says so.
+// Api (axios) rejections carry the response, so the status is right there.
+// OpenC3Api.exec rejects with a synthetic Error instead, which has no response
+// at all - only a name copied from the JSON-RPC error class - so match on that
+// too or every 401 through OpenC3Api slips past this check. The class comes
+// from Ruby's Exception#as_json, which uses the fully namespaced name.
+const UNAUTHORIZED_ERROR_CLASSES = new Set([
+  'OpenC3::AuthError',
+  'OpenC3::ForbiddenError',
+])
+
+export function isUnauthorizedError(error) {
+  return (
+    error?.response?.status === 401 ||
+    error?.status === 401 ||
+    UNAUTHORIZED_ERROR_CLASSES.has(error?.name)
+  )
+}
+
+// Drop-in replacement for `.catch(console.error)` on requests that fire while
+// the page is still deciding whether it's logged in. Neither a missing token nor
+// a rejected one is an error worth a stack trace - the axios interceptor is
+// already sending us to login - but everything else is.
+export function logUnlessAuthRequired(error) {
+  if (!isAuthRequiredError(error) && !isUnauthorizedError(error)) {
+    console.error(error)
+  }
+}
+
+export class AuthRequiredError extends Error {
+  constructor(message = 'Authentication required') {
+    super(message)
+    this.name = 'AuthRequiredError'
+  }
+}
+
+// Being sent to the login page isn't a bug, it's a navigation. Callers that
+// don't catch it shouldn't fill the console with stack traces on the way out.
+// Lives here rather than in tool-base so both core and enterprise get it, since
+// each edition ships its own tool-base and its own Auth implementation.
+if (!globalThis.__openc3AuthRejectionHandler) {
+  globalThis.__openc3AuthRejectionHandler = true
+  globalThis.addEventListener?.('unhandledrejection', (event) => {
+    if (isAuthRequiredError(event.reason)) {
+      event.preventDefault()
+    }
+  })
+}
+
+// Send the browser to login, at most once per page load. Redirecting is a
+// navigation, so a second call can only mean the first one didn't take us
+// anywhere - an Auth implementation that comes back still holding no usable
+// token would otherwise bounce us through login forever. Keep rejecting so
+// callers still abandon their requests; just stop asking to navigate.
+let redirectingToLogin = false
+function redirectToLogin() {
+  if (redirectingToLogin) return
+  redirectingToLogin = true
+  OpenC3Auth.login()
+}
+
+// Refresh the auth token before making a request. Rejects with an
+// AuthRequiredError - without making the request - when we have no token to
+// send. Every such request is a guaranteed 401, and before this guard existed a
+// single page load with a stale token produced a burst of them: each component
+// fetching its own settings, all logged server side as errors.
+export async function refreshToken() {
+  try {
+    const refreshed = await OpenC3Auth.updateToken(
+      OpenC3Auth.defaultMinValidity,
+    )
+    if (refreshed) {
+      OpenC3Auth.setTokens()
+    }
+  } catch (error) {
+    if (isAuthRequiredError(error)) {
+      throw error
+    }
+    // Any other failure to refresh means we can't authenticate either
+    redirectToLogin()
+    throw new AuthRequiredError(error?.message)
+  }
+  // An Auth implementation may redirect to login without rejecting, so don't
+  // rely solely on the rejection above
+  if (!localStorage.openc3Token) {
+    redirectToLogin()
+    throw new AuthRequiredError()
+  }
+}

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/axios.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/axios.js
@@ -16,6 +16,7 @@
 */
 
 import axios from 'axios'
+import { logUnlessAuthRequired } from './authGuard'
 
 const axiosInstance = axios.create({
   baseURL: location.origin,
@@ -57,7 +58,8 @@ axiosInstance.interceptors.response.use(
               OpenC3Auth.setTokens()
             }
           })
-          .catch(() => {})
+          // Only the redirect is expected here; log anything else
+          .catch(logUnlessAuthRequired)
         return Promise.reject(error)
       }
       // HazardousError (409) and CriticalCmdError (428) are command control

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/axios.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/axios.js
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -27,15 +27,6 @@ axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response) {
-      if (error.response.status === 401) {
-        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity, true).then(
-          function (refreshed) {
-            if (refreshed) {
-              OpenC3Auth.setTokens()
-            }
-          },
-        )
-      }
       // Individual tools can set 'Ignore-Errors' to an error code
       // they potentially expect, e.g. '500', in which case we ignore it
       // For example in CommandSender.vue:
@@ -44,12 +35,29 @@ axiosInstance.interceptors.response.use(
       //     'Ignore-Errors': '404',
       //   },
       // })
+      // NOTE: This must come before the 401 handling below so that callers who
+      // expect a 401 (the login page checking a session token, or checking a
+      // password) opt out of clearing tokens and redirecting to login. Clearing
+      // tokens there would delete the session another tab is still using.
       if (
         error.response.config.headers['Ignore-Errors'] &&
         error.response.config.headers['Ignore-Errors'].includes(
           error.response.status.toString(),
         )
       ) {
+        return Promise.reject(error)
+      }
+      if (error.response.status === 401) {
+        // updateToken rejects with an AuthRequiredError when it gives up and
+        // redirects to login. Nothing to do about it here, and no banner: the
+        // page is on its way to /login.
+        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity, true)
+          .then(function (refreshed) {
+            if (refreshed) {
+              OpenC3Auth.setTokens()
+            }
+          })
+          .catch(() => {})
         return Promise.reject(error)
       }
       // HazardousError (409) and CriticalCmdError (428) are command control

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
@@ -16,6 +16,7 @@
 */
 
 import { createConsumer } from '@anycable/web'
+import { isAuthRequiredError } from './authGuard'
 
 // How long to wait before rebuilding a consumer whose subscribe failed
 // unrecoverably. Long enough to not spin when the backend is unreachable, short
@@ -153,16 +154,23 @@ export default class Cable {
       finalUrl.searchParams.set('scope', subscription._scope)
       this._cable = createConsumer(finalUrl.href)
     }
-    return OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity).then(
-      (refreshed) => {
+    return OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity)
+      .then((refreshed) => {
         if (refreshed) {
           OpenC3Auth.setTokens()
         }
         if (this._cable) {
           subscription._subscribe(this._cable)
         }
-      },
-    )
+      })
+      .catch((error) => {
+        // No token means we're being redirected to login. Resolve without
+        // subscribing rather than rejecting: callers treat a rejected
+        // createSubscription as a tool error, and this isn't one.
+        if (!isAuthRequiredError(error)) {
+          throw error
+        }
+      })
   }
   // Replace the consumer and re-subscribe everything on it. Dropping the old
   // consumer is what clears the leaked pending subscription (see

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/index.js
@@ -12,9 +12,29 @@
 */
 
 import Api from './api'
+// NOTE: AuthRequiredError itself is deliberately not exported. It's matched by
+// name, not by identity, so callers use isAuthRequiredError instead - exporting
+// the class would invite instanceof checks that break across editions.
+import {
+  isAuthRequiredError,
+  isUnauthorizedError,
+  logUnlessAuthRequired,
+  refreshToken,
+} from './authGuard'
 import axios from './axios'
 import Cable from './cable'
 import { ConfigParserError, ConfigParserService } from './configParser'
 import OpenC3Api from './openc3Api'
 
-export { Api, axios, Cable, ConfigParserError, ConfigParserService, OpenC3Api }
+export {
+  Api,
+  axios,
+  Cable,
+  ConfigParserError,
+  ConfigParserService,
+  isAuthRequiredError,
+  isUnauthorizedError,
+  logUnlessAuthRequired,
+  OpenC3Api,
+  refreshToken,
+}

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/index.js
@@ -12,29 +12,16 @@
 */
 
 import Api from './api'
-// NOTE: AuthRequiredError itself is deliberately not exported. It's matched by
-// name, not by identity, so callers use isAuthRequiredError instead - exporting
-// the class would invite instanceof checks that break across editions.
-import {
-  isAuthRequiredError,
-  isUnauthorizedError,
-  logUnlessAuthRequired,
-  refreshToken,
-} from './authGuard'
 import axios from './axios'
 import Cable from './cable'
 import { ConfigParserError, ConfigParserService } from './configParser'
 import OpenC3Api from './openc3Api'
 
 export {
-  Api,
-  axios,
-  Cable,
-  ConfigParserError,
-  ConfigParserService,
   isAuthRequiredError,
   isUnauthorizedError,
   logUnlessAuthRequired,
-  OpenC3Api,
   refreshToken,
-}
+} from './authGuard'
+
+export { Api, axios, Cable, ConfigParserError, ConfigParserService, OpenC3Api }

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/openc3Api.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/openc3Api.js
@@ -19,6 +19,7 @@
 */
 
 import axios from './axios.js'
+import { refreshToken } from './authGuard.js'
 import { parse, stringify, isInteger, isSafeNumber } from 'lossless-json'
 
 // parse huge integer values into a bigint, and use a regular number otherwise
@@ -41,16 +42,9 @@ export default class OpenC3Api {
     headerOptions = {},
     timeout = 60000,
   ) {
-    try {
-      let refreshed = await OpenC3Auth.updateToken(
-        OpenC3Auth.defaultMinValidity,
-      )
-      if (refreshed) {
-        OpenC3Auth.setTokens()
-      }
-    } catch (error) {
-      OpenC3Auth.login()
-    }
+    // Throws an AuthRequiredError if we have no token, in which case we're
+    // being redirected to login and must not send the request
+    await refreshToken()
     this.id = this.id + 1
     try {
       kwparams['scope'] = window.openc3Scope

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/auth.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/auth.js
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2024, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 */
 
@@ -17,11 +17,28 @@ const emptyPromise = function (resolution = null) {
     resolve(resolution)
   })
 }
+// Signals that there is no usable token and the browser is being redirected to
+// the login page. Callers must abandon the request they were about to make:
+// sending it can only 401, which does nothing but log a server side error.
+// Identified by name rather than by class so code shared with enterprise (which
+// has its own Auth implementation) doesn't have to import this file.
+class AuthRequiredError extends Error {
+  constructor(message = 'Authentication required') {
+    super(message)
+    this.name = 'AuthRequiredError'
+  }
+}
+
 class Auth {
+  // @param value [Number] unused in core, minimum token validity in seconds
+  // @param from_401 [Boolean] whether a request just came back unauthorized
+  // @return [Promise<Boolean>] whether the token was refreshed, or a rejection
+  //   with an AuthRequiredError if we're redirecting to login instead
   updateToken(value, from_401 = false) {
     if (!localStorage.openc3Token || from_401) {
       this.clearTokens()
       this.login(location.href)
+      return Promise.reject(new AuthRequiredError())
     }
     return emptyPromise()
   }

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/auth.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/auth.js
@@ -30,10 +30,12 @@ class AuthRequiredError extends Error {
 }
 
 class Auth {
-  // @param value [Number] unused in core, minimum token validity in seconds
-  // @param from_401 [Boolean] whether a request just came back unauthorized
-  // @return [Promise<Boolean>] whether the token was refreshed, or a rejection
-  //   with an AuthRequiredError if we're redirecting to login instead
+  /**
+   * @param value {number} unused in core, minimum token validity in seconds
+   * @param from_401 {boolean} whether a request just came back unauthorized
+   * @return {Promise<boolean>} whether the token was refreshed, or a rejection
+   *   with an AuthRequiredError if we're redirecting to login instead
+   */
   updateToken(value, from_401 = false) {
     if (!localStorage.openc3Token || from_401) {
       this.clearTokens()

--- a/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/auth.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-tool-base/public/js/auth.js
@@ -46,15 +46,23 @@ class Auth {
   clearTokens() {
     delete localStorage.openc3Token
   }
+  // Navigating to login is idempotent: a page load with no token calls
+  // updateToken once per request, and each of those would otherwise schedule
+  // its own redirect. Only the first one that actually navigates counts - the
+  // flag is set inside the branch so an already-on-login call doesn't block a
+  // later user initiated login.
   login(redirect) {
+    if (this.redirectingToLogin) return
     let url = new URL(redirect)
     let result = url.pathname
     if (url.search) {
       result = result + url.search
     }
     // redirect to login if we're not already there
-    if (!/^\/login/.test(location.pathname))
+    if (!/^\/login/.test(location.pathname)) {
+      this.redirectingToLogin = true
       location = `/login?redirect=${encodeURI(result)}`
+    }
   }
   logout() {
     this.clearTokens()

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -1957,8 +1957,8 @@ export default {
       if (this.subscription) {
         this.subscribeTime = performance.now()
         this.emptyDataNotified = false
-        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity).then(
-          (refreshed) => {
+        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity)
+          .then((refreshed) => {
             if (refreshed) {
               OpenC3Auth.setTokens()
             }
@@ -1972,8 +1972,10 @@ export default {
               start_time: theStartTime,
               end_time: this.graphEndDateTime,
             })
-          },
-        )
+          })
+          // A rejection means we have no token and are being redirected to
+          // login, so don't try to subscribe
+          .catch(() => {})
       }
     },
     clearAllData: function () {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -321,7 +321,11 @@ import GraphEditDialog from './GraphEditDialog.vue'
 import GraphEditItemDialog from './GraphEditItemDialog.vue'
 import uPlot from 'uplot'
 import bs from 'binary-search'
-import { OpenC3Api, Cable } from '@openc3/js-common/services'
+import {
+  OpenC3Api,
+  Cable,
+  logUnlessAuthRequired,
+} from '@openc3/js-common/services'
 import { useStore } from '@/plugins/store'
 import { TimeFilters } from '@/util'
 import 'uplot/dist/uPlot.min.css'
@@ -1973,9 +1977,10 @@ export default {
               end_time: this.graphEndDateTime,
             })
           })
-          // A rejection means we have no token and are being redirected to
-          // login, so don't try to subscribe
-          .catch(() => {})
+          // An AuthRequiredError means we have no token and are being
+          // redirected to login, so don't try to subscribe. Anything else is
+          // unexpected and still gets logged.
+          .catch(logUnlessAuthRequired)
       }
     },
     clearAllData: function () {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/ToolsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/ToolsTab.vue
@@ -87,6 +87,17 @@ import Sortable from 'sortablejs'
 import { Api } from '@openc3/js-common/services'
 import { OutputDialog } from '@/components'
 
+// There's no response when the request never made it out, e.g. an
+// AuthRequiredError or the server being unreachable. Rails renders errors as
+// JSON, so response.data may be an object rather than a string.
+const errorMessage = function (error) {
+  const data = error?.response?.data
+  if (typeof data === 'string' && data) {
+    return data
+  }
+  return data?.message || data?.error || error?.message || 'Unknown error'
+}
+
 export default {
   components: { OutputDialog },
   data() {
@@ -159,9 +170,7 @@ export default {
         .catch((error) => {
           window.$cosmosNotify.serious({
             title: `Failed to add tool ${this.name}`,
-            // There's no response when the request never made it out, e.g. an
-            // AuthRequiredError or the server being unreachable
-            message: error?.response?.data || error?.message,
+            message: errorMessage(error),
           })
         })
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/ToolsTab.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/tabs/ToolsTab.vue
@@ -159,7 +159,9 @@ export default {
         .catch((error) => {
           window.$cosmosNotify.serious({
             title: `Failed to add tool ${this.name}`,
-            message: error.response.data,
+            // There's no response when the request never made it out, e.g. an
+            // AuthRequiredError or the server being unreachable
+            message: error?.response?.data || error?.message,
           })
         })
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppFooter.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppFooter.vue
@@ -36,8 +36,9 @@
 </template>
 
 <script>
-import { Api, OpenC3Api } from '@openc3/js-common/services'
+import { Api, logUnlessAuthRequired } from '@openc3/js-common/services'
 import { UpgradeToEnterpriseDialog } from '@/components'
+import { getCachedSetting } from '@/util'
 import ClockFooter from './ClockFooter.vue'
 
 export default {
@@ -83,16 +84,15 @@ export default {
         this.license = response.data.license
         this.version = response.data.version
       })
-      .catch(console.error)
+      .catch(logUnlessAuthRequired)
   },
   methods: {
     getSourceUrl: function () {
-      new OpenC3Api()
-        .get_settings(['source_url'])
-        .then((response) => {
-          this.sourceUrl = response[0]
-        })
-        .catch(console.error)
+      // Fall back to '' rather than undefined so the anchor keeps rendering an
+      // (empty) href instead of dropping the attribute entirely
+      getCachedSetting('source_url', '').then((response) => {
+        this.sourceUrl = response
+      })
     },
     upgrade: function () {
       if (!this.enterprise) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
@@ -250,8 +250,14 @@ export default {
         this.timeZone = response
       }
     })
-    // Tools are global and are always installed into the DEFAULT scope
-    Api.get('/openc3-api/tools/all', { params: { scope: 'DEFAULT' } })
+    // Tools are global and are always installed into the DEFAULT scope.
+    // This endpoint requires no authorization and the nav has to render even
+    // when we have no token (the login page mounts it too), so don't let the
+    // auth guard block the request.
+    Api.get('/openc3-api/tools/all', {
+      params: { scope: 'DEFAULT' },
+      optionalAuth: true,
+    })
       .then((response) => {
         this.appNav = response.data
 
@@ -339,9 +345,10 @@ export default {
                 OpenC3Auth.setTokens()
               }
             })
-            // A rejection means we have no token and are being redirected to
-            // login, so there's nothing to do here
-            .catch(() => {})
+            // An AuthRequiredError means we have no token and are being
+            // redirected to login, so there's nothing to do here. Anything
+            // else (network, unexpected auth failure) still gets logged.
+            .catch(logUnlessAuthRequired)
         }, 60000)
       })
       .catch(logUnlessAuthRequired)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/AppNav.vue
@@ -157,8 +157,9 @@
 
 <script>
 import { navigateToUrl, registerApplication, start } from 'single-spa'
-import { Api, OpenC3Api } from '@openc3/js-common/services'
+import { Api, logUnlessAuthRequired } from '@openc3/js-common/services'
 import { UpgradeToEnterpriseDialog } from '@/components'
+import { getCachedSetting } from '@/util'
 import Notifications from './Notifications.vue'
 import ScopeSelector from './ScopeSelector.vue'
 import UserMenu from './UserMenu.vue'
@@ -180,7 +181,6 @@ export default {
   },
   data() {
     return {
-      api: new OpenC3Api(),
       timeZone: 'local',
       subtitle: null,
       // Update AstroSettings.vue when changing this
@@ -229,8 +229,8 @@ export default {
     const urlParams = new URLSearchParams(window.location.search)
     this.chromeless = urlParams.get('chromeless')
 
-    this.api
-      .get_setting('astro')
+    // These three go out as a single batched get_settings request
+    getCachedSetting('astro')
       .then((response) => {
         if (response) {
           // The response is an object with settings
@@ -238,28 +238,18 @@ export default {
         }
       })
       .catch((error) => {
-        // Do nothing
+        // Do nothing - malformed setting, keep the defaults
       })
-    this.api
-      .get_setting('subtitle')
-      .then((response) => {
-        if (response) {
-          this.subtitle = response
-        }
-      })
-      .catch((error) => {
-        // Do nothing
-      })
-    this.api
-      .get_setting('time_zone')
-      .then((response) => {
-        if (response) {
-          this.timeZone = response
-        }
-      })
-      .catch((error) => {
-        // Do nothing
-      })
+    getCachedSetting('subtitle').then((response) => {
+      if (response) {
+        this.subtitle = response
+      }
+    })
+    getCachedSetting('time_zone').then((response) => {
+      if (response) {
+        this.timeZone = response
+      }
+    })
     // Tools are global and are always installed into the DEFAULT scope
     Api.get('/openc3-api/tools/all', { params: { scope: 'DEFAULT' } })
       .then((response) => {
@@ -343,14 +333,18 @@ export default {
 
         // Check every minute if we need to update our token
         setInterval(() => {
-          OpenC3Auth.updateToken(120).then(function (refreshed) {
-            if (refreshed) {
-              OpenC3Auth.setTokens()
-            }
-          })
+          OpenC3Auth.updateToken(120)
+            .then(function (refreshed) {
+              if (refreshed) {
+                OpenC3Auth.setTokens()
+              }
+            })
+            // A rejection means we have no token and are being redirected to
+            // login, so there's nothing to do here
+            .catch(() => {})
         }, 60000)
       })
-      .catch(console.error)
+      .catch(logUnlessAuthRequired)
   },
   mounted() {
     globalThis.addEventListener(

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ClassificationBanners.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ClassificationBanners.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -16,7 +16,7 @@
 -->
 
 <script>
-import { OpenC3Api } from '@openc3/js-common/services'
+import { getCachedSetting } from '@/util'
 
 export default {
   data: function () {
@@ -45,9 +45,7 @@ export default {
     },
   },
   created: function () {
-    const api = new OpenC3Api()
-    api
-      .get_setting('classification_banner')
+    getCachedSetting('classification_banner')
       .then((response) => {
         if (response) {
           this.classification = JSON.parse(response)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ContextTag.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ContextTag.vue
@@ -25,13 +25,12 @@
 </template>
 
 <script>
-import { OpenC3Api } from '@openc3/js-common/services'
+import { getCachedSetting, invalidateCachedSetting } from '@/util'
 
 export default {
   name: 'ContextTag',
   data() {
     return {
-      api: new OpenC3Api(),
       contextTag: {
         text: null,
         fontColor: null,
@@ -51,24 +50,32 @@ export default {
     this.stopContextTagAutoRefresh()
   },
   methods: {
+    // The first read joins the batched get_settings the rest of the base
+    // components issue on page load. getCachedSetting never rejects - it falls
+    // back on failure - so there's nothing here to catch.
     getContextTagSettings() {
-      return this.api
-        .get_setting('context_tag')
-        .then((response) => {
-          if (response) {
-            const parsed = JSON.parse(response)
-            this.contextTag = {
-              text: parsed.text,
-              fontColor: parsed.fontColor,
-              backgroundColor: parsed.backgroundColor,
-            }
+      return getCachedSetting('context_tag').then((response) => {
+        if (!response) return
+        try {
+          const parsed = JSON.parse(response)
+          this.contextTag = {
+            text: parsed.text,
+            fontColor: parsed.fontColor,
+            backgroundColor: parsed.backgroundColor,
           }
-        })
-        .catch(console.error)
+        } catch (error) {
+          // Malformed setting, keep whatever we're already showing. Still a real
+          // problem worth reporting, unlike the auth errors this used to log.
+          console.error(error)
+        }
+      })
     },
     startContextTagAutoRefresh() {
       this.stopContextTagAutoRefresh()
       this.contextTagRefreshInterval = setInterval(() => {
+        // The cache is write-once per session, so drop our entry first or every
+        // refresh after the first would be served the same stale value
+        invalidateCachedSetting('context_tag')
         this.getContextTagSettings()
       }, 60000)
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Login.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Login.vue
@@ -62,7 +62,7 @@
               size="large"
               color="success"
               :disabled="!formValid"
-              @click.prevent="() => verify()"
+              @click.prevent="verify"
             >
               Login
             </v-btn>
@@ -81,7 +81,7 @@
 </template>
 
 <script>
-import { Api } from '@openc3/js-common/services'
+import { Api, isUnauthorizedError } from '@openc3/js-common/services'
 
 export default {
   data() {
@@ -101,6 +101,19 @@ export default {
       return {
         noAuth: true,
         noScope: true, // lol
+        // 401 and 429 are normal, expected answers on this page: the session
+        // token we are checking may be stale, the password may be wrong, or we
+        // may be rate limited. Every one of them is already reported in the
+        // form's own alert, so opt out of the axios interceptor to avoid a
+        // duplicate error banner. For 401 this also stops the interceptor from
+        // clearing tokens (shared with every other tab on this origin) and
+        // bouncing us through a login redirect while we're already on the login
+        // page.
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'Ignore-Errors': '401,429',
+        },
       }
     },
     rules: function () {
@@ -137,15 +150,49 @@ export default {
   },
   mounted: function () {
     if (localStorage.openc3Token) {
-      this.verify(localStorage.openc3Token, true)
+      this.verifyToken()
     }
   },
   methods: {
     showReset: function () {
       this.reset = true
     },
+    // Skip the login form if the session token we already have is still good.
+    // Note this must not go to /auth/verify: that endpoint only checks
+    // passwords, so a session token always failed there and was recorded as a
+    // bad password attempt against the rate limit.
+    verifyToken: function () {
+      const token = localStorage.openc3Token
+      Api.post('/openc3-api/auth/verify-token', {
+        data: {
+          token,
+        },
+        ...this.options,
+      })
+        .then(() => {
+          this.redirect()
+        })
+        .catch((error) => {
+          // Only a 401 means the token is actually stale. Anything else (server
+          // down, 500) says nothing about the token, and throwing it away would
+          // needlessly force the user to retype their password.
+          if (!isUnauthorizedError(error)) {
+            return
+          }
+          // Stale token - drop it and let the user log in normally. Only if it's
+          // still the token we checked: the user can finish logging in while
+          // this request is in flight, and deleting the new token would send
+          // them straight back to the login form.
+          if (localStorage.openc3Token === token) {
+            delete localStorage.openc3Token
+          }
+        })
+    },
     login: function (response) {
       localStorage.openc3Token = response.data
+      this.redirect()
+    },
+    redirect: function () {
       const redirect = new URLSearchParams(window.location.search).get(
         'redirect',
       )
@@ -156,12 +203,11 @@ export default {
         window.location = '/'
       }
     },
-    verify: function (password, noAlert) {
-      password ||= this.password
+    verify: function () {
       this.showAlert = false
       Api.post('/openc3-api/auth/verify', {
         data: {
-          password,
+          password: this.password,
         },
         ...this.options,
       })
@@ -169,9 +215,9 @@ export default {
           this.login(response)
         })
         .catch((error) => {
-          if (error?.status === 401) {
+          if (isUnauthorizedError(error)) {
             this.alert = 'Incorrect password'
-          } else if (error?.status === 429) {
+          } else if (error?.status === 429 || error?.response?.status === 429) {
             this.alert = 'Please try again later'
           } else if (
             error?.response?.data?.message === 'invalid password hash'
@@ -182,7 +228,7 @@ export default {
             this.alert = error.message || 'Something went wrong...'
           }
           this.alertType = 'warning'
-          this.showAlert = !noAlert
+          this.showAlert = true
         })
     },
     setPassword: function () {
@@ -198,7 +244,11 @@ export default {
           this.login(response)
         })
         .catch((error) => {
-          this.alert = `Invalid password: ${error.response.data.message}`
+          // No response at all means the server is unreachable, not a bad
+          // password, so don't blow up dereferencing it
+          this.alert = `Invalid password: ${
+            error?.response?.data?.message || error?.message || 'unknown error'
+          }`
           this.alertType = 'warning'
           this.showAlert = true
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Login.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Login.vue
@@ -173,17 +173,17 @@ export default {
           this.redirect()
         })
         .catch((error) => {
-          // Only a 401 means the token is actually stale. Anything else (server
-          // down, 500) says nothing about the token, and throwing it away would
-          // needlessly force the user to retype their password.
-          if (!isUnauthorizedError(error)) {
-            return
-          }
-          // Stale token - drop it and let the user log in normally. Only if it's
-          // still the token we checked: the user can finish logging in while
-          // this request is in flight, and deleting the new token would send
-          // them straight back to the login form.
-          if (localStorage.openc3Token === token) {
+          // Only a 401 means the token is actually stale, so drop it and let the
+          // user log in normally. Anything else (server down, 500) says nothing
+          // about the token, and throwing it away would needlessly force the
+          // user to retype their password. Also require that it's still the
+          // token we checked: the user can finish logging in while this request
+          // is in flight, and deleting the new token would send them straight
+          // back to the login form.
+          if (
+            isUnauthorizedError(error) &&
+            localStorage.openc3Token === token
+          ) {
             delete localStorage.openc3Token
           }
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Notifications.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/Notifications.vue
@@ -185,7 +185,7 @@
 
 <script>
 import { formatDistanceToNow } from 'date-fns'
-import { Api, Cable } from '@openc3/js-common/services'
+import { Api, Cable, logUnlessAuthRequired } from '@openc3/js-common/services'
 import { AstroStatusColors, UnknownToAstroStatus } from '@/icons'
 import { AstroStatus } from '@/util'
 
@@ -324,7 +324,7 @@ export default {
       .then((response) => {
         this.numScripts = response.data.total
       })
-      .catch(console.error)
+      .catch(logUnlessAuthRequired)
   },
   unmounted: function () {
     window.removeEventListener('openc3-ack-alert', this.onAckAlert)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ThemeSwitcher.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/ThemeSwitcher.vue
@@ -11,7 +11,7 @@
 -->
 
 <script>
-import { OpenC3Api } from '@openc3/js-common/services'
+import { getCachedSetting } from '@/util'
 
 const VALID_THEMES = new Set([
   'cosmosDark',
@@ -23,9 +23,7 @@ const VALID_THEMES = new Set([
 
 export default {
   created: function () {
-    const api = new OpenC3Api()
-    api
-      .get_setting('theme')
+    getCachedSetting('theme')
       .then((response) => {
         if (!VALID_THEMES.has(response)) return
         switch (response) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/UserMenu.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/UserMenu.vue
@@ -118,9 +118,10 @@
 </template>
 
 <script>
-import { Api } from '@openc3/js-common/services'
+import { Api, logUnlessAuthRequired } from '@openc3/js-common/services'
 import { OpenC3Api } from '@openc3/js-common/services'
 import { UpgradeToEnterpriseDialog } from '@/components'
+import { getCachedSetting } from '@/util'
 import DOMPurify from 'dompurify'
 
 export default {
@@ -176,14 +177,13 @@ export default {
                 this.activeUsers = ['None']
               }
             })
-            .catch(console.error)
+            .catch(logUnlessAuthRequired)
         }
       }
     },
   },
   created: function () {
-    this.api
-      .get_setting('news_feed')
+    getCachedSetting('news_feed')
       .then((response) => {
         if (response) {
           this.newsFeed = response
@@ -230,11 +230,13 @@ export default {
             })
           }
         })
-        .catch(console.error)
+        .catch(logUnlessAuthRequired)
     },
     logout: function () {
       OpenC3Auth.logout()
-      Api.put(`/openc3-api/users/logout/${this.username}`).catch(console.error)
+      Api.put(`/openc3-api/users/logout/${this.username}`).catch(
+        logUnlessAuthRequired,
+      )
     },
     login: function () {
       OpenC3Auth.login(location.href)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/UserMenu.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/UserMenu.vue
@@ -232,11 +232,17 @@ export default {
         })
         .catch(logUnlessAuthRequired)
     },
-    logout: function () {
-      OpenC3Auth.logout()
-      Api.put(`/openc3-api/users/logout/${this.username}`).catch(
-        logUnlessAuthRequired,
-      )
+    logout: async function () {
+      // Terminating the server side session requires the current token, and
+      // OpenC3Auth.logout() clears it (and reloads the page), so this request
+      // has to go out first.
+      try {
+        await Api.put(`/openc3-api/users/logout/${this.username}`)
+      } catch (error) {
+        logUnlessAuthRequired(error)
+      } finally {
+        OpenC3Auth.logout()
+      }
     },
     login: function () {
       OpenC3Auth.login(location.href)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/index.js
@@ -17,6 +17,7 @@ export { default as TimeFilters } from './timeFilters'
 export { default as CmdUtilities } from './cmdUtilities'
 export {
   getCachedSetting,
+  invalidateCachedSetting,
   peekCachedSetting,
   resetSettingsCache,
 } from './settingsCache'

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/settingsCache.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/settingsCache.js
@@ -13,32 +13,78 @@
 
 import { OpenC3Api } from '@openc3/js-common/services'
 
-// Process-wide cache for settings fetched via OpenC3Api.get_setting.
+// Process-wide cache for settings fetched via OpenC3Api.get_settings.
 // Settings change rarely; the admin UI tells users to refresh after edits, so
 // a write-once-per-session cache is the documented contract.
 const cache = new Map()
 const inflight = new Map()
+
+// Requests made in the same tick are coalesced into one get_settings call.
+// Page load mounts a handful of components that each want a different setting
+// (theme, astro, subtitle, time_zone, ...); as separate requests they were a
+// burst of round trips, and a burst of server side auth errors when the token
+// was stale.
+let batch = null
+// Bumped by resetSettingsCache so a batch queued before the reset doesn't write
+// its results into the cache afterwards. It still settles its promises - callers
+// are already awaiting them and must not be left hanging.
+let generation = 0
+
+// cacheable is false when the value is a fallback we made up because the
+// request failed. Caching that would pin every setting in the batch to its
+// default for the rest of the session, so a transient failure (network blip, a
+// 401 while the token is being refreshed) would look permanent. Settle the
+// promise so callers aren't left hanging, but leave the cache empty so the next
+// caller retries.
+function settle(entry, value, batchGeneration, cacheable = true) {
+  if (batchGeneration === generation) {
+    inflight.delete(entry.name)
+    if (cacheable) {
+      cache.set(entry.name, value)
+    }
+  }
+  entry.resolve(value)
+}
+
+// entries is captured by the caller rather than read from `batch`, which the
+// reset can null out before this microtask runs
+function flushBatch(entries, batchGeneration) {
+  if (batch === entries) {
+    batch = null
+  }
+  new OpenC3Api()
+    .get_settings(entries.map((entry) => entry.name))
+    .then((response) => {
+      entries.forEach((entry, index) => {
+        settle(entry, response?.[index] ?? entry.fallback, batchGeneration)
+      })
+    })
+    .catch(() => {
+      entries.forEach((entry) =>
+        settle(entry, entry.fallback, batchGeneration, false),
+      )
+    })
+}
 
 export function getCachedSetting(name, fallback) {
   if (cache.has(name)) {
     return Promise.resolve(cache.get(name))
   }
   if (!inflight.has(name)) {
-    const promise = new OpenC3Api()
-      .get_setting(name)
-      .then((response) => {
-        const value = response ?? fallback
-        cache.set(name, value)
-        return value
-      })
-      .catch(() => {
-        cache.set(name, fallback)
-        return fallback
-      })
-      .finally(() => {
-        inflight.delete(name)
-      })
-    inflight.set(name, promise)
+    let resolve
+    inflight.set(
+      name,
+      new Promise((res) => {
+        resolve = res
+      }),
+    )
+    if (batch === null) {
+      const entries = []
+      const batchGeneration = generation
+      batch = entries
+      queueMicrotask(() => flushBatch(entries, batchGeneration))
+    }
+    batch.push({ name, fallback, resolve })
   }
   return inflight.get(name)
 }
@@ -47,7 +93,16 @@ export function peekCachedSetting(name) {
   return cache.has(name) ? cache.get(name) : undefined
 }
 
+// Drop a single setting so the next getCachedSetting refetches it. For the few
+// components that poll a setting on an interval and would otherwise be served
+// the same cached value forever (see ContextTag).
+export function invalidateCachedSetting(name) {
+  cache.delete(name)
+}
+
 export function resetSettingsCache() {
   cache.clear()
   inflight.clear()
+  batch = null
+  generation += 1
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ArrayplotWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ArrayplotWidget.vue
@@ -225,8 +225,8 @@ export default {
     },
     addItemsToSubscription: function (itemArray = this.items) {
       if (this.subscription) {
-        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity).then(
-          (refreshed) => {
+        OpenC3Auth.updateToken(OpenC3Auth.defaultMinValidity)
+          .then((refreshed) => {
             if (refreshed) {
               OpenC3Auth.setTokens()
             }
@@ -240,8 +240,10 @@ export default {
               start_time: null,
               end_time: null,
             })
-          },
-        )
+          })
+          // A rejection means we have no token and are being redirected to
+          // login, so don't try to subscribe
+          .catch(() => {})
       }
     },
     itemName: function (item) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ArrayplotWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ArrayplotWidget.vue
@@ -18,7 +18,7 @@
 <script>
 import uPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
-import { Cable } from '@openc3/js-common/services'
+import { Cable, logUnlessAuthRequired } from '@openc3/js-common/services'
 import GraphWidget from './GraphWidget'
 
 export default {
@@ -241,9 +241,10 @@ export default {
               end_time: null,
             })
           })
-          // A rejection means we have no token and are being redirected to
-          // login, so don't try to subscribe
-          .catch(() => {})
+          // An AuthRequiredError means we have no token and are being
+          // redirected to login, so don't try to subscribe. Anything else is
+          // unexpected and still gets logged.
+          .catch(logUnlessAuthRequired)
       }
     },
     itemName: function (item) {


### PR DESCRIPTION
Stacked on #3748 — **review/merge that first**; this branch's base is `auth-verify-token-logging`, so the diff shown here is frontend only. `Login.vue` calls the `POST /auth/verify-token` endpoint added in #3748.

## Problem

A page load with a stale or missing token fired one request per component. Each was a guaranteed 401, logged server side as an error, and each rejection was a console stack trace on the way to the login page. The login page itself checked its token via `auth#verify`, where a session token is never a valid password — so the check failed *and* consumed rate limit.

## `services/authGuard.js`

Single place that decides "we have no usable token":

- `refreshToken()` — rejects with an `AuthRequiredError` **before** the request goes out. Also redirects to login at most once per page load: a second redirect can only mean the first didn't navigate, which would otherwise bounce forever.
- `isUnauthorizedError()` — matches axios 401s *and* the synthetic errors `OpenC3Api.exec` builds, which carry no response, only a name copied from the Ruby exception class (`OpenC3::AuthError`, `OpenC3::ForbiddenError`). Without the name check every 401 through `OpenC3Api` slipped past.
- `logUnlessAuthRequired()` — drop-in for `.catch(console.error)` on requests that fire before login is settled.
- An `unhandledrejection` handler swallows `AuthRequiredError` only. Being sent to login is a navigation, not a bug.

Errors are matched **by name, not identity** — `AuthRequiredError` is deliberately not re-exported from `services/index.js`, since `instanceof` breaks across editions (core and enterprise each ship their own tool-base and Auth implementation).

## Batched settings

`getCachedSetting` now queues into one `get_settings` call per tick instead of a round trip per component (theme, astro, subtitle, time_zone, source_url, … all mount together). Details that matter:

- A failed batch settles its callers with fallbacks but **does not cache them**, so a transient 401 during a token refresh doesn't pin every setting to its default for the rest of the session.
- A `generation` counter means a batch queued before `resetSettingsCache()` won't write into the cache afterwards — but still settles its promises, so awaiting callers aren't left hanging.
- `invalidateCachedSetting()` added for components that poll a setting on an interval (`ContextTag`) and would otherwise be served the same cached value forever.

## Test plan

- [x] `pnpm lint --max-warnings 0` clean in `openc3-js-common`, `openc3-vue-common`, `openc3-cosmos-tool-dataextractor`, `openc3-cosmos-tool-dataviewer`
- [x] Manual: load a tool with an expired token in localStorage → single redirect to login, no console stack traces, no 401 burst in cmd-tlm-api logs
- [x] Manual: settings still apply on load (theme, classification banner, subtitle, time zone, context tag)
- [x] Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)