### PR TITLE
fix(script-runner): validate suiteRunner values as identifiers

### DIFF
--- a/openc3-cosmos-script-runner-api/app/controllers/scripts_controller.rb
+++ b/openc3-cosmos-script-runner-api/app/controllers/scripts_controller.rb
@@ -32,6 +32,13 @@ class ScriptsController < ApplicationController
   PYTHON_SUITE_REGEX = /^\s*class\s+\w+\s*\(\s*(Suite|TestSuite)\s*\)/
   MAX_LIFECYCLE_COMMENT_LENGTH = 1000
 
+  # These are also enforced in OpenC3::SuiteRunner.validate_identifiers.
+  # Suite / Group are class names (Ruby '::' or Python '.' qualified),
+  # script is a method name, method is one of the SuiteRunner entry points.
+  SUITE_RUNNER_CLASS_REGEX = /\A[A-Za-z_][A-Za-z0-9_]*((::|\.)[A-Za-z_][A-Za-z0-9_]*)*\z/
+  SUITE_RUNNER_SCRIPT_REGEX = /\A[A-Za-z_][A-Za-z0-9_]*[?!]?\z/
+  SUITE_RUNNER_METHODS = ['start', 'setup', 'teardown'].freeze
+
   def ping
     render plain: 'OK'
   end
@@ -217,6 +224,16 @@ class ScriptsController < ApplicationController
     end
     # TODO 7.0: Should suiteRunner be snake case?
     suite_runner = params[:suiteRunner] ? params[:suiteRunner].as_json() : nil
+    # The suite / group / script / method values are interpolated into the code
+    # snippet the running script evaluates, so reject anything that isn't a
+    # bare identifier here (defense in depth, also validated in SuiteRunner).
+    if suite_runner
+      error = validate_suite_runner(suite_runner)
+      if error
+        render json: { status: 'error', message: error }, status: :bad_request
+        return
+      end
+    end
     disconnect = params[:disconnect] == 'disconnect'
     environment = params[:environment]
     python_venv = params[:pythonVenv]
@@ -335,6 +352,27 @@ class ScriptsController < ApplicationController
     is_suite && authorized?('script_run', target_name: name.split('/')[0])
   end
   
+  # Returns an error message if any suiteRunner value isn't a bare identifier,
+  # else nil. suite is required; group / script / method are optional.
+  def validate_suite_runner(suite_runner)
+    return "suiteRunner must be a Hash" unless suite_runner.is_a?(Hash)
+    suite = suite_runner['suite']
+    return "Invalid Suite name: #{suite.inspect}" unless suite.is_a?(String) and SUITE_RUNNER_CLASS_REGEX.match?(suite)
+    group = suite_runner['group']
+    if group and !(group.is_a?(String) and SUITE_RUNNER_CLASS_REGEX.match?(group))
+      return "Invalid Group name: #{group.inspect}"
+    end
+    script = suite_runner['script']
+    if script and !(script.is_a?(String) and SUITE_RUNNER_SCRIPT_REGEX.match?(script))
+      return "Invalid Script name: #{script.inspect}"
+    end
+    method = suite_runner['method']
+    if method and !SUITE_RUNNER_METHODS.include?(method.to_s)
+      return "Invalid method: #{method.inspect}"
+    end
+    nil
+  end
+
   # Whether the Script Lifecycle feature is active: the Admin/Settings flag is
   # on AND the git-backed version store is available (Enterprise). Both are
   # required since the lifecycle is tracked as git commits/tags.

--- a/openc3-cosmos-script-runner-api/spec/controllers/scripts_controller_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/controllers/scripts_controller_spec.rb
@@ -346,6 +346,45 @@ RSpec.describe ScriptsController, type: :controller do
       expect(response).to have_http_status(:ok)
     end
 
+    it "passes a valid suiteRunner through to Script.run" do
+      suite_runner = {"suite" => "MySuite", "group" => "MyGroup", "script" => "test_foo", "method" => "start"}
+      expect(Script).to receive(:run).with("DEFAULT", "INST/procedures/test.rb", suite_runner, false, nil, "Anonymous", "anonymous", 1, nil, nil).and_return(1)
+      post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.rb", suiteRunner: suite_runner}
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects a suiteRunner suite that isn't an identifier" do
+      expect(Script).not_to receive(:run)
+      post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.rb",
+                          suiteRunner: {"suite" => "MySuite) rescue nil; File.write('/tmp/x', 'y'); x=(1", "method" => "start"}}
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include("Invalid Suite name")
+    end
+
+    it "rejects a suiteRunner group that isn't an identifier" do
+      expect(Script).not_to receive(:run)
+      post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.rb",
+                          suiteRunner: {"suite" => "MySuite", "group" => "MyGroup) ; system('id') ; x=(1"}}
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include("Invalid Group name")
+    end
+
+    it "rejects a suiteRunner script that isn't an identifier" do
+      expect(Script).not_to receive(:run)
+      post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.rb",
+                          suiteRunner: {"suite" => "MySuite", "group" => "MyGroup", "script" => "test'); system('id'); ('"}}
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include("Invalid Script name")
+    end
+
+    it "rejects a suiteRunner method that isn't a SuiteRunner entry point" do
+      expect(Script).not_to receive(:run)
+      post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.rb",
+                          suiteRunner: {"suite" => "MySuite", "method" => "instance_eval"}}
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include("Invalid method")
+    end
+
     it "passes pythonVenv parameter through to Script.run" do
       expect(Script).to receive(:run).with("DEFAULT", "INST/procedures/test.py", nil, false, nil, "Anonymous", "anonymous", 1, nil, "/gems/plugin_venvs/demo/.venv").and_return(1)
       post :run, params: {scope: "DEFAULT", name: "INST/procedures/test.py", pythonVenv: "/gems/plugin_venvs/demo/.venv"}

--- a/openc3/lib/openc3/script/suite_runner.rb
+++ b/openc3/lib/openc3/script/suite_runner.rb
@@ -30,6 +30,12 @@ module OpenC3
     # the values stay consistent in one place.
     DEFAULT_METHOD = 'start'
     DEFAULT_OPTIONS = ['continueAfterError'].freeze
+    # The only SuiteRunner entry points a client may request
+    ALLOWED_METHODS = ['start', 'setup', 'teardown'].freeze
+    # Suite and Group are Ruby constant (class) names, optionally namespaced
+    CLASS_NAME_REGEX = /\A[A-Z][A-Za-z0-9_]*(::[A-Z][A-Za-z0-9_]*)*\z/
+    # Script is a Ruby method name on the Group
+    METHOD_NAME_REGEX = /\A[a-z_][A-Za-z0-9_]*[?!]?\z/
 
     @@suites = []
     @@settings = {}
@@ -55,12 +61,38 @@ module OpenC3
       raise ArgumentError, "Script #{script} requires a Group" if script and not group
     end
 
+    # Validate that the raw (client supplied) suite_runner values are plain
+    # identifiers. These values are interpolated into the Ruby snippet the
+    # running script evaluates, so anything other than a bare class / method
+    # name must be rejected before it reaches the interpreter.
+    def self.validate_identifiers(suite:, group: nil, script: nil, method: nil)
+      unless suite.is_a?(String) and CLASS_NAME_REGEX.match?(suite)
+        raise ArgumentError, "Invalid Suite name: #{suite.inspect}"
+      end
+      if group
+        unless group.is_a?(String) and CLASS_NAME_REGEX.match?(group)
+          raise ArgumentError, "Invalid Group name: #{group.inspect}"
+        end
+      end
+      if script
+        unless script.is_a?(String) and METHOD_NAME_REGEX.match?(script)
+          raise ArgumentError, "Invalid Script name: #{script.inspect}"
+        end
+      end
+      if method
+        unless ALLOWED_METHODS.include?(method.to_s)
+          raise ArgumentError, "Invalid method: #{method.inspect}"
+        end
+      end
+    end
+
     # Build the canonical, validated suite_runner hash from raw values,
     # applying defaults. Shared by openc3cli (constructing from CLI flags) and
     # the running script (normalizing a received hash before dispatch) so the
     # hash shape, defaults, and validation live in one place.
     def self.build_options(suite:, group: nil, script: nil, method: nil, options: nil)
       validate_options(group: group, script: script)
+      validate_identifiers(suite: suite, group: group, script: script, method: method)
       suite_runner = { 'suite' => suite }
       if group
         suite_runner['group'] = group

--- a/openc3/lib/openc3/script/suite_runner.rb
+++ b/openc3/lib/openc3/script/suite_runner.rb
@@ -33,9 +33,9 @@ module OpenC3
     # The only SuiteRunner entry points a client may request
     ALLOWED_METHODS = ['start', 'setup', 'teardown'].freeze
     # Suite and Group are Ruby constant (class) names, optionally namespaced
-    CLASS_NAME_REGEX = /\A[A-Z][A-Za-z0-9_]*(::[A-Z][A-Za-z0-9_]*)*\z/
+    CLASS_NAME_REGEX = /\A[A-Z]\w*(::[A-Z]\w*)*\z/
     # Script is a Ruby method name on the Group
-    METHOD_NAME_REGEX = /\A[a-z_][A-Za-z0-9_]*[?!]?\z/
+    METHOD_NAME_REGEX = /\A[a-z_]\w*[?!]?\z/
 
     @@suites = []
     @@settings = {}
@@ -69,20 +69,14 @@ module OpenC3
       unless suite.is_a?(String) and CLASS_NAME_REGEX.match?(suite)
         raise ArgumentError, "Invalid Suite name: #{suite.inspect}"
       end
-      if group
-        unless group.is_a?(String) and CLASS_NAME_REGEX.match?(group)
-          raise ArgumentError, "Invalid Group name: #{group.inspect}"
-        end
+      if group && !(group.is_a?(String) and CLASS_NAME_REGEX.match?(group))
+        raise ArgumentError, "Invalid Group name: #{group.inspect}"
       end
-      if script
-        unless script.is_a?(String) and METHOD_NAME_REGEX.match?(script)
-          raise ArgumentError, "Invalid Script name: #{script.inspect}"
-        end
+      if script && !(script.is_a?(String) and METHOD_NAME_REGEX.match?(script))
+        raise ArgumentError, "Invalid Script name: #{script.inspect}"
       end
-      if method
-        unless ALLOWED_METHODS.include?(method.to_s)
-          raise ArgumentError, "Invalid method: #{method.inspect}"
-        end
+      if method && !ALLOWED_METHODS.include?(method.to_s)
+        raise ArgumentError, "Invalid method: #{method.inspect}"
       end
     end
 

--- a/openc3/python/openc3/script/suite_runner.py
+++ b/openc3/python/openc3/script/suite_runner.py
@@ -10,6 +10,7 @@
 # if purchased from OpenC3, Inc.
 
 import inspect
+import re
 
 from openc3.script.exceptions import StopScriptError
 from openc3.tools.test_runner.test import Test, TestSuite
@@ -29,6 +30,12 @@ class SuiteRunner:
     # consistent in one place.
     DEFAULT_METHOD = "start"
     DEFAULT_OPTIONS = ["continueAfterError"]
+    # The only SuiteRunner entry points a client may request
+    ALLOWED_METHODS = ["start", "setup", "teardown"]
+    # Suite and Group are Python class names, optionally module qualified
+    CLASS_NAME_REGEX = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
+    # Script is a Python method name on the Group
+    METHOD_NAME_REGEX = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
     suites = []
     settings = {}
@@ -42,12 +49,28 @@ class SuiteRunner:
         if script and not group:
             raise ValueError(f"Script {script} requires a Group")
 
+    # Validate that the raw (client supplied) suite_runner values are plain
+    # identifiers. These values are interpolated into the Python snippet the
+    # running script executes, so anything other than a bare class / method
+    # name must be rejected before it reaches the interpreter.
+    @classmethod
+    def validate_identifiers(cls, suite, group=None, script=None, method=None):
+        if not isinstance(suite, str) or not cls.CLASS_NAME_REGEX.match(suite):
+            raise ValueError(f"Invalid Suite name: {suite!r}")
+        if group and (not isinstance(group, str) or not cls.CLASS_NAME_REGEX.match(group)):
+            raise ValueError(f"Invalid Group name: {group!r}")
+        if script and (not isinstance(script, str) or not cls.METHOD_NAME_REGEX.match(script)):
+            raise ValueError(f"Invalid Script name: {script!r}")
+        if method and method not in cls.ALLOWED_METHODS:
+            raise ValueError(f"Invalid method: {method!r}")
+
     # Build the canonical, validated suite_runner dict from raw values, applying
     # defaults. Shared so the dict shape, defaults, and validation live in one
     # place (used by the running script when normalizing a received dict).
     @classmethod
     def build_options(cls, suite, group=None, script=None, method=None, options=None):
         cls.validate_options(group=group, script=script)
+        cls.validate_identifiers(suite=suite, group=group, script=script, method=method)
         suite_runner = {"suite": suite}
         if group:
             suite_runner["group"] = group

--- a/openc3/python/openc3/script/suite_runner.py
+++ b/openc3/python/openc3/script/suite_runner.py
@@ -33,9 +33,9 @@ class SuiteRunner:
     # The only SuiteRunner entry points a client may request
     ALLOWED_METHODS = ["start", "setup", "teardown"]
     # Suite and Group are Python class names, optionally module qualified
-    CLASS_NAME_REGEX = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
+    CLASS_NAME_REGEX = re.compile(r"^[A-Za-z_]\w*(\.[A-Za-z_]\w*)*$")
     # Script is a Python method name on the Group
-    METHOD_NAME_REGEX = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    METHOD_NAME_REGEX = re.compile(r"^[A-Za-z_]\w*$")
 
     suites = []
     settings = {}

--- a/openc3/python/test/script/test_suite_runner.py
+++ b/openc3/python/test/script/test_suite_runner.py
@@ -179,6 +179,36 @@ class TestSuiteRunner(unittest.TestCase):
         result = SuiteRunner.build_options(suite="MySuite")
         self.assertIsNot(result["options"], SuiteRunner.DEFAULT_OPTIONS)
 
+    def test_build_options_rejects_suite_that_is_not_a_class_name(self):
+        for suite in [
+            "MySuite) ; __import__('os').system('id') ; (1",
+            "MySuite ; print(1)",
+            None,
+            "",
+        ]:
+            with self.assertRaisesRegex(ValueError, "Invalid Suite name"):
+                SuiteRunner.build_options(suite=suite)
+
+    def test_build_options_allows_module_qualified_names(self):
+        self.assertEqual(
+            SuiteRunner.build_options(suite="my_mod.MySuite", group="my_mod.MyGroup")["suite"],
+            "my_mod.MySuite",
+        )
+
+    def test_build_options_rejects_group_that_is_not_a_class_name(self):
+        with self.assertRaisesRegex(ValueError, "Invalid Group name"):
+            SuiteRunner.build_options(suite="MySuite", group="MyGroup) ; print(1) ; (1")
+
+    def test_build_options_rejects_script_that_is_not_a_method_name(self):
+        with self.assertRaisesRegex(ValueError, "Invalid Script name"):
+            SuiteRunner.build_options(suite="MySuite", group="MyGroup", script="test') ; print(1) ; ('")
+
+    def test_build_options_rejects_method_not_an_entry_point(self):
+        with self.assertRaisesRegex(ValueError, "Invalid method"):
+            SuiteRunner.build_options(suite="MySuite", method="__init__")
+        with self.assertRaisesRegex(ValueError, "Invalid method"):
+            SuiteRunner.build_options(suite="MySuite", method="start(1) ; print(1) ; start")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openc3/spec/script/suite_runner_spec.rb
+++ b/openc3/spec/script/suite_runner_spec.rb
@@ -155,6 +155,38 @@ module OpenC3
         expect(result['options']).to_not be_frozen
         expect(result['options']).to_not equal(SuiteRunner::DEFAULT_OPTIONS)
       end
+
+      it "rejects a suite that isn't a class name" do
+        expect { SuiteRunner.build_options(suite: "MySuite) rescue nil; File.write('/tmp/x', 'y'); x=(1") }
+          .to raise_error(ArgumentError, /Invalid Suite name/)
+        expect { SuiteRunner.build_options(suite: 'my_suite') }
+          .to raise_error(ArgumentError, /Invalid Suite name/)
+        expect { SuiteRunner.build_options(suite: nil) }
+          .to raise_error(ArgumentError, /Invalid Suite name/)
+        expect { SuiteRunner.build_options(suite: 'MySuite; puts 1') }
+          .to raise_error(ArgumentError, /Invalid Suite name/)
+      end
+
+      it "allows a namespaced suite and group" do
+        expect(SuiteRunner.build_options(suite: 'My::Suite', group: 'My::Group')['suite']).to eq('My::Suite')
+      end
+
+      it "rejects a group that isn't a class name" do
+        expect { SuiteRunner.build_options(suite: 'MySuite', group: 'MyGroup) ; system("id") ; x=(1') }
+          .to raise_error(ArgumentError, /Invalid Group name/)
+      end
+
+      it "rejects a script that isn't a method name" do
+        expect { SuiteRunner.build_options(suite: 'MySuite', group: 'MyGroup', script: "test'); system('id'); ('") }
+          .to raise_error(ArgumentError, /Invalid Script name/)
+      end
+
+      it "rejects a method that isn't a SuiteRunner entry point" do
+        expect { SuiteRunner.build_options(suite: 'MySuite', method: 'instance_eval') }
+          .to raise_error(ArgumentError, /Invalid method/)
+        expect { SuiteRunner.build_options(suite: 'MySuite', method: 'start(1) ; system("id") ; start') }
+          .to raise_error(ArgumentError, /Invalid method/)
+      end
     end
   end
 end


### PR DESCRIPTION
The suite, group, script, and method values are interpolated into the Ruby/Python snippet the running script evaluates, so unvalidated input allowed arbitrary code execution and bypassed the script approval gate enforced in scripts_controller#run (CWE-94 / CWE-863).

Reject anything that isn't a bare class/method name in SuiteRunner build_options (both languages, covering the GUI and openc3cli paths) and at the controller so bad requests return 400 instead of starting a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)