### PR TITLE
Make clamav and trivy on demand only

### DIFF
--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -23,7 +23,6 @@ permissions:
 
 jobs:
   openc3-clamav-scan:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -11,14 +11,8 @@
 
 name: ClamAV Scan
 
-# Only run on a push to main to avoid running for all the dependabot PRs
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -11,14 +11,8 @@
 
 name: Trivy Scan
 
-# Only run on a push to main to avoid running for all the dependabot PRs
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - "**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 # Workaround for https://github.com/aquasecurity/trivy-action/issues/389
@@ -25,7 +25,6 @@ env:
 
 jobs:
   openc3-scan:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### What changed

Change clamav and trivy scans to ondemand (workflow_dispatch) vs every PR

### Why it changed

These scans are rarely associated with code changes and should only be run during specific dependency updates