### PR TITLE
Improve scriptRunner performance for lines and output, and add batching to events

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1940,7 +1940,7 @@ export default {
         this.subscription = null
       }
       this.receivedEvents.length = 0 // Clear any unprocessed events
-      this.clearReceivedOutputEvents()
+      this.discardPendingOutput()
     },
     showMetadata() {
       Api.get('/openc3-api/metadata')
@@ -1979,30 +1979,42 @@ export default {
     fileNameChanged(filename) {
       // Split off the '*' which indicates modified
       filename = filename.split('*')[0]
-      this.editor.setValue(this.files[filename].content)
+      this.setEditorContent(this.files[filename].content)
       this.restoreBreakpoints(filename)
-      this.editor.clearSelection()
       this.markLine(this.files[filename].lineNo, this.state)
+    },
+    // Install new editor content. setValue resets the scroll and invalidates
+    // any existing execution marker, so drop the markLine cache to force the
+    // next markLine to repaint and rescroll.
+    setEditorContent(content) {
+      this.editor.setValue(content)
+      this.editor.clearSelection()
+      this.highlightedLine = null
+      this.highlightedState = null
+      this.highlightedFilename = null
     },
     // Replace all fullLine markers with a single `${clazz}Marker` on lineNo
     // (1-based) and scroll to it
     markLine(lineNo, clazz) {
+      // Only the marker work is cached. gotoLine always runs: markLine is also
+      // how the editor scrolls to the current line, so a cache hit right after
+      // a setValue (which resets the scroll to the top) would leave the user
+      // staring at line 1 of a script stopped far below.
       if (
-        lineNo === this.highlightedLine &&
-        clazz === this.highlightedState &&
-        this.currentFilename === this.highlightedFilename
+        lineNo !== this.highlightedLine ||
+        clazz !== this.highlightedState ||
+        this.currentFilename !== this.highlightedFilename
       ) {
-        return
+        this.removeAllMarkers()
+        this.editor.session.addMarker(
+          new this.Range(lineNo - 1, 0, lineNo - 1, 1),
+          `${clazz}Marker`,
+          'fullLine',
+        )
+        this.highlightedLine = lineNo
+        this.highlightedState = clazz
+        this.highlightedFilename = this.currentFilename
       }
-      this.removeAllMarkers()
-      this.editor.session.addMarker(
-        new this.Range(lineNo - 1, 0, lineNo - 1, 1),
-        `${clazz}Marker`,
-        'fullLine',
-      )
-      this.highlightedLine = lineNo
-      this.highlightedState = clazz
-      this.highlightedFilename = this.currentFilename
       this.editor.gotoLine(lineNo)
     },
     tryLoadRunningScript: function (id) {
@@ -2298,7 +2310,7 @@ export default {
         return
       }
       this.receivedEvents.length = 0 // Drop any events not yet processed
-      this.clearReceivedOutputEvents()
+      this.discardPendingOutput()
       // Reset prompt tracking so the first prompt re-published on this fresh
       // subscription is always processed and displayed. Without this, attaching
       // to a running script (which reuses the component) could carry over a
@@ -2394,7 +2406,7 @@ export default {
         this.subscription = null
       }
       this.receivedEvents.length = 0 // Clear any unprocessed events
-      this.clearReceivedOutputEvents()
+      this.discardPendingOutput()
       // Close any prompt dialogs a killed/stopped script left open;
       // answering them would POST to a script that no longer exists
       this.closePromptDialogs()
@@ -2547,10 +2559,21 @@ export default {
     // visible). State handling always runs.
     processLine(data, display = true) {
       if (data.filename && data.filename !== this.currentFilename) {
-        if (!this.files[data.filename]) {
+        const cached = this.files[data.filename]
+        if (cached && !cached.pending) {
+          this.currentFilename = data.filename
+          this.setEditorContent(cached.content)
+          this.restoreBreakpoints(data.filename)
+        } else if (!cached) {
           // We don't have the contents of the running file (probably because connected to running script)
-          // Set the contents initially to an empty string so we don't start slamming the API
-          this.files[data.filename] = { content: '', lineNo: 0 }
+          // Set the contents initially to an empty string so we don't start slamming the API.
+          // pending distinguishes this placeholder from real content: attaching
+          // twice (Connect to Running Script re-enters scriptStart, which is
+          // expected) would otherwise let the second attach take the branch
+          // above, install '' in the editor and set currentFilename -- after
+          // which every later event skips the content load and the script stays
+          // blank forever.
+          this.files[data.filename] = { content: '', lineNo: 0, pending: true }
 
           // Request the script we need
           const epoch = this.sessionEpoch
@@ -2559,7 +2582,12 @@ export default {
               if (epoch !== this.sessionEpoch) {
                 // A newer file source took over while this fetch was in
                 // flight (script completed / new file loaded) - drop it
-                // rather than clobber the current breakpoints and content
+                // rather than clobber the current breakpoints and content.
+                // Clear the pending placeholder as the catch below does:
+                // nothing else will land, so leaving it in place would make
+                // every later event wait on a fetch that never completes
+                // instead of retrying it.
+                this.files[data.filename] = null
                 return
               }
               // Success - Save the script text and mark the currentFilename as null
@@ -2579,12 +2607,11 @@ export default {
               // Error - Restore the file contents to null so we'll try the API again on the next line
               this.files[data.filename] = null
             })
-        } else {
-          this.currentFilename = data.filename
-          this.editor.setValue(this.files[data.filename].content)
-          this.restoreBreakpoints(data.filename)
-          this.editor.clearSelection()
         }
+        // else: a fetch is already in flight for this file. Leave the editor and
+        // currentFilename alone so a later event installs the content once it
+        // lands, or retries if the fetch is dropped or fails -- both clear the
+        // cache entry.
       }
       this.state = data.state
       switch (this.state) {
@@ -2690,94 +2717,114 @@ export default {
           break
         }
       }
+      let terminated = false
       for (let i = 0; i < events.length; i++) {
         const data = events[i]
         // console.log(data) // Uncomment for debugging
-        switch (data.type) {
-          case 'file':
-            this.files[data.filename] = { content: data.text, lineNo: 0 }
-            this.breakpoints[data.filename] = data.breakpoints
-            if (this.currentFilename === data.filename) {
-              this.restoreBreakpoints(data.filename)
-            }
-            break
-          case 'line':
-            // Every 'line' event runs the state machine (buttons, phase,
-            // lineNo bookkeeping), but only the newest event in the entire
-            // drain does Ace marker/scroll work. Intermediate states still
-            // matter, but their highlights could never become visible.
-            this.processLine(data, i === lastLineIndex)
-            break
-          case 'script':
-            this.handleScript(data)
-            break
-          // DEPRECATED because the 'complete' message now includes the report
-          case 'report':
-            this.results.text = data.report
-            this.results.show = true
-            break
-          case 'complete':
-            // Do not leave the tail of the log waiting for the output throttle
-            // when the script has already completed.
-            this.flushOutputLines(true)
-            if (data.report) {
+        try {
+          switch (data.type) {
+            case 'file':
+              this.files[data.filename] = { content: data.text, lineNo: 0 }
+              this.breakpoints[data.filename] = data.breakpoints
+              if (this.currentFilename === data.filename) {
+                this.restoreBreakpoints(data.filename)
+              }
+              break
+            case 'line':
+              // Every 'line' event runs the state machine (buttons, phase,
+              // lineNo bookkeeping), but only the newest event in the entire
+              // drain does Ace marker/scroll work. Intermediate states still
+              // matter, but their highlights could never become visible.
+              this.processLine(data, i === lastLineIndex)
+              break
+            case 'script':
+              this.handleScript(data)
+              break
+            // DEPRECATED because the 'complete' message now includes the report
+            case 'report':
               this.results.text = data.report
               this.results.show = true
+              break
+            case 'complete':
+              // Do not leave the tail of the log waiting for the output throttle
+              // when the script has already completed.
+              this.flushOutputLines(true)
+              if (data.report) {
+                this.results.text = data.report
+                this.results.show = true
+              }
+              // Set before the teardown below: 'complete' is terminal even if
+              // scriptComplete() throws, and the catch would otherwise let the
+              // loop run on against a half-torn-down session.
+              terminated = true
+              this.removeAllMarkers()
+              this.scriptComplete()
+              break
+            case 'step':
+              this.showDebug = true
+              break
+            case 'screen': {
+              const screenIndex = this.screens.findIndex(
+                (s) =>
+                  s.target == data.target_name && s.screen == data.screen_name,
+              )
+              const definition =
+                screenIndex === -1 ? {} : this.screens[screenIndex]
+              definition.target = data.target_name
+              definition.screen = data.screen_name
+              definition.definition = data.definition
+              definition.left = data.x || 0
+              definition.top = data.y || 0
+              definition.count = this.updateCounter++
+              if (screenIndex === -1) {
+                definition.id = this.idCounter++
+                this.screens.push(definition)
+              } else {
+                this.screens[screenIndex] = definition
+              }
+              break
             }
-            this.removeAllMarkers()
-            this.scriptComplete()
-            break
-          case 'step':
-            this.showDebug = true
-            break
-          case 'screen': {
-            const screenIndex = this.screens.findIndex(
-              (s) =>
-                s.target == data.target_name && s.screen == data.screen_name,
-            )
-            const definition =
-              screenIndex === -1 ? {} : this.screens[screenIndex]
-            definition.target = data.target_name
-            definition.screen = data.screen_name
-            definition.definition = data.definition
-            definition.left = data.x || 0
-            definition.top = data.y || 0
-            definition.count = this.updateCounter++
-            if (screenIndex === -1) {
-              definition.id = this.idCounter++
-              this.screens.push(definition)
-            } else {
-              this.screens[screenIndex] = definition
+            case 'clearscreen': {
+              const screenIndex = this.screens.findIndex(
+                (s) =>
+                  s.target == data.target_name && s.screen == data.screen_name,
+              )
+              if (screenIndex !== -1) {
+                this.screens.splice(screenIndex, 1)
+              }
+              break
             }
-            break
+            case 'clearallscreens':
+              this.screens = []
+              break
+            case 'downloadfile':
+              // Make a link and then 'click' on it to start the download
+              const link = document.createElement('a')
+              link.href = window.location.origin + data.url
+              link.setAttribute('download', data.filename)
+              link.click()
+              break
+            case 'opentab':
+              window.open(data.url, '_blank')
+              break
+            default:
+              // console.log('Unexpected ActionCable message')
+              // console.log(data)
+              break
           }
-          case 'clearscreen': {
-            const screenIndex = this.screens.findIndex(
-              (s) =>
-                s.target == data.target_name && s.screen == data.screen_name,
-            )
-            if (screenIndex !== -1) {
-              this.screens.splice(screenIndex, 1)
-            }
-            break
-          }
-          case 'clearallscreens':
-            this.screens = []
-            break
-          case 'downloadfile':
-            // Make a link and then 'click' on it to start the download
-            const link = document.createElement('a')
-            link.href = window.location.origin + data.url
-            link.setAttribute('download', data.filename)
-            link.click()
-            break
-          case 'opentab':
-            window.open(data.url, '_blank')
-            break
-          default:
-            // console.log('Unexpected ActionCable message')
-            // console.log(data)
-            break
+        } catch (error) {
+          // Isolate each event: the batch was detached from receivedEvents
+          // above, so throwing out of this loop would permanently drop every
+          // event after this one -- the receive interval has nothing left to
+          // retry. Log and keep draining instead.
+          console.error('ScriptRunner failed to process event', data, error)
+        }
+        // 'complete' is terminal and scriptComplete() tore the session down.
+        // Anything after it in this batch would be processed against a dead
+        // session -- a duplicate 'complete' reloading the file again, or a
+        // replayed 'line' pushing state back to running.
+        if (terminated) {
+          break
         }
       }
 
@@ -2802,7 +2849,10 @@ export default {
         // Walk backward without split(), which avoids allocating an array for
         // a very large multi-line output event when only its tail is visible.
         let end = text.length
-        while (end >= 0 && newestFirst.length < this.maxArrayLength) {
+        // end > 0, not end >= 0: lastIndexOf clamps a negative fromIndex to 0,
+        // so text starting with '\n' would return 0 rather than -1 and spin
+        // here forever. Nothing is left to collect at end === 0 anyway.
+        while (end > 0 && newestFirst.length < this.maxArrayLength) {
           const newline = text.lastIndexOf('\n', end - 1)
           const line = text.slice(newline + 1, end)
           if (line) {
@@ -2838,6 +2888,15 @@ export default {
       this.receivedOutputEvents.fill(undefined)
       this.receivedOutputEventCount = 0
       this.receivedOutputEventIndex = 0
+    },
+    // Drop every output event and line that has not been rendered yet. Unlike
+    // clearReceivedOutputEvents (which queueReceivedOutputLines uses to rotate
+    // the ring buffer) this also drops lines already waiting on the flush
+    // throttle, so a restart inside the throttle window cannot spill the old
+    // run's output into the new run's log.
+    discardPendingOutput() {
+      this.clearReceivedOutputEvents()
+      this.pendingOutputLines = []
     },
     queueOutputLines(lines) {
       if (lines.length > 0) {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -794,6 +794,10 @@ const START = 'Start'
 const GO = 'Go'
 const PAUSE = 'Pause'
 const RETRY = 'Retry'
+// State/control events remain responsive at the 100 ms receive interval, but
+// rebuilding a 200-row Vuetify table that often adds no visible value at that
+// rate is expensive during output-heavy scripts.
+const OUTPUT_FLUSH_INTERVAL_MS = 500
 // Matches is_complete in script_status_model
 const TERMINAL_STATES = new Set([
   'completed',
@@ -1608,6 +1612,20 @@ export default {
     // Deliberately NOT in data(): nothing renders from it, and reactive
     // proxying would tax the hottest data path (per line event)
     this.receivedEvents = []
+    // Output does not need strict ordering with control events and is capped in
+    // the UI. Keep it out of the unbounded control queue so a print-heavy loop
+    // cannot delay prompts, state changes, or completion processing.
+    this.receivedOutputEvents = new Array(this.maxArrayLength)
+    this.receivedOutputEventCount = 0
+    this.receivedOutputEventIndex = 0
+    this.pendingOutputLines = []
+    this.lastOutputFlush = 0
+    // Track the execution marker outside Vue reactivity. Tight loops often
+    // report the same handful of lines repeatedly; repainting an unchanged
+    // marker still makes Ace scan markers, render, and scroll the editor.
+    this.highlightedLine = null
+    this.highlightedState = null
+    this.highlightedFilename = null
     // Ensure Offline Access Is Setup For the Current User
     this.api = new OpenC3Api()
     this.api.ensure_offline_access()
@@ -1922,6 +1940,7 @@ export default {
         this.subscription = null
       }
       this.receivedEvents.length = 0 // Clear any unprocessed events
+      this.clearReceivedOutputEvents()
     },
     showMetadata() {
       Api.get('/openc3-api/metadata')
@@ -1968,12 +1987,22 @@ export default {
     // Replace all fullLine markers with a single `${clazz}Marker` on lineNo
     // (1-based) and scroll to it
     markLine(lineNo, clazz) {
+      if (
+        lineNo === this.highlightedLine &&
+        clazz === this.highlightedState &&
+        this.currentFilename === this.highlightedFilename
+      ) {
+        return
+      }
       this.removeAllMarkers()
       this.editor.session.addMarker(
         new this.Range(lineNo - 1, 0, lineNo - 1, 1),
         `${clazz}Marker`,
         'fullLine',
       )
+      this.highlightedLine = lineNo
+      this.highlightedState = clazz
+      this.highlightedFilename = this.currentFilename
       this.editor.gotoLine(lineNo)
     },
     tryLoadRunningScript: function (id) {
@@ -2269,6 +2298,7 @@ export default {
         return
       }
       this.receivedEvents.length = 0 // Drop any events not yet processed
+      this.clearReceivedOutputEvents()
       // Reset prompt tracking so the first prompt re-published on this fresh
       // subscription is always processed and displayed. Without this, attaching
       // to a running script (which reuses the component) could carry over a
@@ -2349,6 +2379,10 @@ export default {
       }
     },
     async scriptComplete() {
+      // Completion can also be reached through status refreshes or failed run
+      // requests rather than a queued 'complete' event.
+      this.queueReceivedOutputLines()
+      this.flushOutputLines(true)
       // Supersede any scriptStart still awaiting its subscription. Must
       // happen before our unsubscribe below: a start resolving mid-complete
       // would otherwise install a fresh subscription after we tore ours
@@ -2360,6 +2394,7 @@ export default {
         this.subscription = null
       }
       this.receivedEvents.length = 0 // Clear any unprocessed events
+      this.clearReceivedOutputEvents()
       // Close any prompt dialogs a killed/stopped script left open;
       // answering them would POST to a script that no longer exists
       this.closePromptDialogs()
@@ -2626,15 +2661,37 @@ export default {
       }
     },
     processReceived() {
-      if (this.receivedEvents.length === 0) {
+      if (
+        this.receivedEvents.length === 0 &&
+        this.receivedOutputEventCount === 0
+      ) {
+        // Output is rendered less frequently than control events. Keep polling
+        // so the final partial batch is displayed even after output goes quiet.
+        this.flushOutputLines()
         return
       }
-      let count = 0
-      const outputLines = []
+      // Detach the current batch instead of splicing a potentially large hot
+      // queue after processing it. Events received during a future turn go
+      // into the new array and are handled by the next interval.
       const events = this.receivedEvents
+      this.receivedEvents = []
+      // Only the newest maxArrayLength messages can survive the UI cap. Scan
+      // backward so older output events and lines are never converted into
+      // short-lived objects merely to be discarded below.
+      this.queueReceivedOutputLines()
+      // Highlight only the newest line in the whole batch. Looking only at
+      // consecutive line events is insufficient because script output is
+      // commonly interleaved between them, causing every line in a tight loop
+      // to remove/add an Ace marker before the browser can paint any of them.
+      let lastLineIndex = -1
+      for (let i = events.length - 1; i >= 0; i--) {
+        if (events[i].type === 'line') {
+          lastLineIndex = i
+          break
+        }
+      }
       for (let i = 0; i < events.length; i++) {
         const data = events[i]
-        count += 1
         // console.log(data) // Uncomment for debugging
         switch (data.type) {
           case 'file':
@@ -2646,34 +2703,10 @@ export default {
             break
           case 'line':
             // Every 'line' event runs the state machine (buttons, phase,
-            // lineNo bookkeeping), but the Ace marker/scroll work is only
-            // done for the last consecutive 'line' event in this drain --
-            // intermediate ones would be overdrawn before the next paint.
-            // (We can't skip events entirely: the final batch of a script
-            // ends with a line_number 0 stopped event, and dropping the
-            // preceding events would lose the final-line highlight.)
-            this.processLine(data, events[i + 1]?.type !== 'line')
-            break
-          case 'output':
-            // data.line can consist of multiple lines split by newlines,
-            // thus we split and only output if the content is not empty.
-            // We also need to ensure it's properly serialized as a string.
-            let dataLine = data.line
-            if (dataLine === null || dataLine === undefined) {
-              dataLine = ''
-            } else if (typeof dataLine === 'object') {
-              dataLine = JSON.stringify(dataLine)
-            } else {
-              dataLine = String(dataLine)
-            }
-            // Accumulate and apply once after the loop: per-line reactive
-            // unshift/pop through a 200-element array is O(lines * 200)
-            // and triggers watchers per line instead of once per batch
-            for (const line of dataLine.split('\n')) {
-              if (line) {
-                outputLines.push({ message: line })
-              }
-            }
+            // lineNo bookkeeping), but only the newest event in the entire
+            // drain does Ace marker/scroll work. Intermediate states still
+            // matter, but their highlights could never become visible.
+            this.processLine(data, i === lastLineIndex)
             break
           case 'script':
             this.handleScript(data)
@@ -2684,6 +2717,9 @@ export default {
             this.results.show = true
             break
           case 'complete':
+            // Do not leave the tail of the log waiting for the output throttle
+            // when the script has already completed.
+            this.flushOutputLines(true)
             if (data.report) {
               this.results.text = data.report
               this.results.show = true
@@ -2745,24 +2781,114 @@ export default {
         }
       }
 
-      if (outputLines.length > 0) {
-        if (this.messagesNewestOnTop) {
-          this.messages = outputLines
-            .reverse()
-            .concat(this.messages)
-            .slice(0, this.maxArrayLength)
+      this.flushOutputLines()
+    },
+    collectRecentOutputLines(outputEvents) {
+      const newestFirst = []
+      for (
+        let i = outputEvents.length - 1;
+        i >= 0 && newestFirst.length < this.maxArrayLength;
+        i--
+      ) {
+        let text = outputEvents[i]
+        if (text === null || text === undefined) {
+          continue
+        } else if (typeof text === 'object') {
+          text = JSON.stringify(text)
         } else {
-          this.messages = this.messages
-            .concat(outputLines)
-            .slice(0, this.maxArrayLength)
+          text = String(text)
+        }
+
+        // Walk backward without split(), which avoids allocating an array for
+        // a very large multi-line output event when only its tail is visible.
+        let end = text.length
+        while (end >= 0 && newestFirst.length < this.maxArrayLength) {
+          const newline = text.lastIndexOf('\n', end - 1)
+          const line = text.slice(newline + 1, end)
+          if (line) {
+            newestFirst.push({ message: line })
+          }
+          if (newline === -1) {
+            break
+          }
+          end = newline
         }
       }
-      // Remove all the events we processed
-      this.receivedEvents.splice(0, count)
+      return newestFirst.reverse()
+    },
+    queueReceivedOutputLines() {
+      if (this.receivedOutputEventCount === 0) {
+        return
+      }
+      const outputEvents = []
+      const start =
+        (this.receivedOutputEventIndex -
+          this.receivedOutputEventCount +
+          this.maxArrayLength) %
+        this.maxArrayLength
+      for (let i = 0; i < this.receivedOutputEventCount; i++) {
+        outputEvents.push(
+          this.receivedOutputEvents[(start + i) % this.maxArrayLength],
+        )
+      }
+      this.clearReceivedOutputEvents()
+      this.queueOutputLines(this.collectRecentOutputLines(outputEvents))
+    },
+    clearReceivedOutputEvents() {
+      this.receivedOutputEvents.fill(undefined)
+      this.receivedOutputEventCount = 0
+      this.receivedOutputEventIndex = 0
+    },
+    queueOutputLines(lines) {
+      if (lines.length > 0) {
+        this.pendingOutputLines = this.pendingOutputLines
+          .concat(lines)
+          .slice(-this.maxArrayLength)
+      }
+    },
+    flushOutputLines(force = false) {
+      if (this.pendingOutputLines.length === 0) {
+        return
+      }
+      const now = Date.now()
+      if (!force && now - this.lastOutputFlush < OUTPUT_FLUSH_INTERVAL_MS) {
+        return
+      }
+
+      const outputLines = this.pendingOutputLines
+      this.pendingOutputLines = []
+      this.lastOutputFlush = now
+      if (this.messagesNewestOnTop) {
+        this.messages = outputLines
+          .slice()
+          .reverse()
+          .concat(this.messages)
+          .slice(0, this.maxArrayLength)
+      } else {
+        this.messages = this.messages
+          .concat(outputLines)
+          .slice(-this.maxArrayLength)
+      }
     },
     received(data) {
       this.cable.recordPing()
-      this.receivedEvents.push(data)
+      // RunningScriptChannel sends bounded arrays to avoid one ActionCable
+      // frame per script event. Also accept an individual event so the UI can
+      // connect to an older backend during a rolling upgrade.
+      const events = Array.isArray(data) ? data : [data]
+      for (const event of events) {
+        if (event.type === 'output') {
+          this.receivedOutputEvents[this.receivedOutputEventIndex] = event.line
+          this.receivedOutputEventIndex =
+            (this.receivedOutputEventIndex + 1) % this.maxArrayLength
+          this.receivedOutputEventCount = Math.min(
+            this.receivedOutputEventCount + 1,
+            this.maxArrayLength,
+          )
+        } else {
+          this.receivedEvents.push(event)
+        }
+      }
     },
     // All prompt responses share the running-script prompt endpoint and
     // the active prompt id; payload carries the method-specific fields
@@ -3509,6 +3635,9 @@ export default {
       Object.keys(allMarkers)
         .filter((key) => allMarkers[key].type === 'fullLine')
         .forEach((marker) => this.editor.session.removeMarker(marker))
+      this.highlightedLine = null
+      this.highlightedState = null
+      this.highlightedFilename = null
     },
     confirmLocalUnlock: function () {
       this.$dialog

--- a/openc3-cosmos-script-runner-api/app/channels/running_script_channel.rb
+++ b/openc3-cosmos-script-runner-api/app/channels/running_script_channel.rb
@@ -69,10 +69,18 @@ class RunningScriptChannel < ApplicationCable::Channel
         end
         complete = true if event['type'] == 'complete'
       end
-      transmit(events) unless events.empty?
     rescue StandardError => e
       # Best-effort: a replay failure must not break the subscription.
       OpenC3::Logger.warn("running_script replay backlog failed: #{e.message}") rescue nil
+    ensure
+      # Flush in ensure: because events are batched, a single corrupt entry
+      # partway through would otherwise discard every event parsed before it,
+      # leaving the client with no state for a script that already ran.
+      begin
+        transmit(events) unless events.empty?
+      rescue StandardError
+        # Nothing better to do than the warn above
+      end
     end
     # Script already finished -- the backlog held the terminal 'complete', so
     # there is nothing left to stream.

--- a/openc3-cosmos-script-runner-api/app/channels/running_script_channel.rb
+++ b/openc3-cosmos-script-runner-api/app/channels/running_script_channel.rb
@@ -30,6 +30,7 @@ class RunningScriptChannel < ApplicationCable::Channel
   def subscribed
     # Defensive: if the auth before_subscribe callback rejected us, skip work.
     return if subscription_rejected?
+
     # The running script mirrors its per-script events into a short-lived Redis
     # stream so a client that subscribes after the script has already produced
     # output/state still receives what it missed (the raw anycable broadcast is
@@ -53,15 +54,22 @@ class RunningScriptChannel < ApplicationCable::Channel
     topic = "running-script-channel:#{params[:id]}:replay"
     last_offset = '0-0'
     complete = false
+    events = []
     begin
       OpenC3::Topic.xrange(topic, '-', '+').each do |msg_id, msg_hash|
         last_offset = msg_id
         data = msg_hash['data']
         next unless data
+
         event = JSON.parse(data)
-        transmit(event)
+        events << event
+        if events.length >= RunningScriptReplayThread::MAX_BATCH_SIZE
+          transmit(events)
+          events = []
+        end
         complete = true if event['type'] == 'complete'
       end
+      transmit(events) unless events.empty?
     rescue StandardError => e
       # Best-effort: a replay failure must not break the subscription.
       OpenC3::Logger.warn("running_script replay backlog failed: #{e.message}") rescue nil

--- a/openc3-cosmos-script-runner-api/app/models/running_script_replay_thread.rb
+++ b/openc3-cosmos-script-runner-api/app/models/running_script_replay_thread.rb
@@ -13,8 +13,8 @@
 
 require 'openc3'
 
-# Streams a running script's replay stream and re-broadcasts each new event to a
-# single ActionCable subscription. The running script (running_script.rb /
+# Streams a running script's replay stream and re-broadcasts new events in
+# bounded batches to a single ActionCable subscription. The running script (running_script.rb /
 # running_script.py) mirrors every per-script frontend event into the stream
 # "running-script-channel:<id>:replay" (capped + short TTL).
 #
@@ -32,6 +32,8 @@ require 'openc3'
 # @start_offset and starts us there, so there is no gap and no duplicate
 # delivery. Modeled on MessagesThread/TopicsThread in cmd-tlm-api.
 class RunningScriptReplayThread
+  MAX_BATCH_SIZE = 100
+
   def initialize(subscription_key, id, start_offset = '0-0', arm_delay: 0.0)
     @subscription_key = subscription_key
     @topic = "running-script-channel:#{id}:replay"
@@ -66,6 +68,7 @@ class RunningScriptReplayThread
         end
       end
       while !@cancel_thread
+        events = []
         # read_topics blocks up to ~1s for new entries then returns, so the loop
         # both drains the backlog (offset starts at '0-0') and streams live.
         OpenC3::Topic.read_topics([@topic], @offsets) do |_topic, msg_id, msg_hash, _redis|
@@ -73,7 +76,8 @@ class RunningScriptReplayThread
           data = msg_hash['data']
           if data
             event = JSON.parse(data)
-            ActionCable.server.broadcast(@subscription_key, event)
+            events << event
+            transmit_events(events) if events.length >= MAX_BATCH_SIZE
             # 'complete' is the script's terminal event: nothing is written to
             # the stream after it. End the thread so it self-cleans without
             # needing to be recycled, even if the client disconnects abruptly
@@ -84,6 +88,11 @@ class RunningScriptReplayThread
           end
           break if @cancel_thread
         end
+        # read_topics commonly yields many entries from one Redis XREAD. Send
+        # them in one ActionCable frame rather than paying the websocket and
+        # client dispatch cost once per script event. Also flushes 'complete'
+        # immediately instead of leaving a partial terminal batch pending.
+        transmit_events(events)
       end
     rescue => e
       OpenC3::Logger.error("RunningScriptReplayThread died: #{e.formatted}") rescue nil
@@ -92,5 +101,14 @@ class RunningScriptReplayThread
 
   def stop
     @cancel_thread = true
+  end
+
+  private
+
+  def transmit_events(events)
+    return if events.empty?
+
+    ActionCable.server.broadcast(@subscription_key, events.dup)
+    events.clear
   end
 end

--- a/openc3-cosmos-script-runner-api/app/models/running_script_replay_thread.rb
+++ b/openc3-cosmos-script-runner-api/app/models/running_script_replay_thread.rb
@@ -69,30 +69,37 @@ class RunningScriptReplayThread
       end
       while !@cancel_thread
         events = []
-        # read_topics blocks up to ~1s for new entries then returns, so the loop
-        # both drains the backlog (offset starts at '0-0') and streams live.
-        OpenC3::Topic.read_topics([@topic], @offsets) do |_topic, msg_id, msg_hash, _redis|
-          @offsets[0] = msg_id
-          data = msg_hash['data']
-          if data
-            event = JSON.parse(data)
-            events << event
-            transmit_events(events) if events.length >= MAX_BATCH_SIZE
-            # 'complete' is the script's terminal event: nothing is written to
-            # the stream after it. End the thread so it self-cleans without
-            # needing to be recycled, even if the client disconnects abruptly
-            # (and unsubscribed never fires). A client that subscribes after the
-            # script finished still gets the full backlog (replayed from '0-0',
-            # including complete) via its own fresh thread, which then ends too.
-            @cancel_thread = true if event['type'] == 'complete'
+        begin
+          # read_topics blocks up to ~1s for new entries then returns, so the
+          # loop both drains the backlog (offset starts at '0-0') and streams
+          # live.
+          OpenC3::Topic.read_topics([@topic], @offsets) do |_topic, msg_id, msg_hash, _redis|
+            @offsets[0] = msg_id
+            data = msg_hash['data']
+            if data
+              event = JSON.parse(data)
+              events << event
+              transmit_events(events) if events.length >= MAX_BATCH_SIZE
+              # 'complete' is the script's terminal event: nothing is written to
+              # the stream after it. End the thread so it self-cleans without
+              # needing to be recycled, even if the client disconnects abruptly
+              # (and unsubscribed never fires). A client that subscribes after
+              # the script finished still gets the full backlog (replayed from
+              # '0-0', including complete) via its own fresh thread, which then
+              # ends too.
+              @cancel_thread = true if event['type'] == 'complete'
+            end
+            break if @cancel_thread
           end
-          break if @cancel_thread
+        ensure
+          # read_topics commonly yields many entries from one Redis XREAD. Send
+          # them in one ActionCable frame rather than paying the websocket and
+          # client dispatch cost once per script event. Also flushes 'complete'
+          # immediately instead of leaving a partial terminal batch pending, and
+          # flushes on an exception so one bad entry cannot take the batch
+          # parsed before it down with the thread.
+          transmit_events(events)
         end
-        # read_topics commonly yields many entries from one Redis XREAD. Send
-        # them in one ActionCable frame rather than paying the websocket and
-        # client dispatch cost once per script event. Also flushes 'complete'
-        # immediately instead of leaving a partial terminal batch pending.
-        transmit_events(events)
       end
     rescue => e
       OpenC3::Logger.error("RunningScriptReplayThread died: #{e.formatted}") rescue nil

--- a/openc3-cosmos-script-runner-api/spec/channels/running_script_channel_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/channels/running_script_channel_spec.rb
@@ -84,6 +84,18 @@ RSpec.describe RunningScriptChannel, type: :channel do
       expect(transmissions.flatten).to eq(events)
     end
 
+    it 'transmits the batch parsed before a bad backlog entry rather than losing it' do
+      backlog({ 'type' => 'line', 'line_no' => 1 })
+      OpenC3::Topic.write_topic("running-script-channel:42:replay", { 'data' => 'not json' }, '102-0')
+
+      subscribe id: '42'
+
+      # Batching must not let one corrupt entry discard the whole preceding
+      # backlog and leave the client with no state for a script that already ran
+      expect(subscription).to be_confirmed
+      expect(transmissions).to eq([[{ 'type' => 'line', 'line_no' => 1 }]])
+    end
+
     it 'stops a leftover broadcaster for the same connection before starting a new one' do
       old_broadcaster = instance_double(RunningScriptReplayThread, stop: nil)
       RunningScriptChannel.class_variable_set(:@@broadcasters, { subscription_key => old_broadcaster })

--- a/openc3-cosmos-script-runner-api/spec/channels/running_script_channel_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/channels/running_script_channel_spec.rb
@@ -46,10 +46,11 @@ RSpec.describe RunningScriptChannel, type: :channel do
       backlog({ 'type' => 'line', 'line_no' => 1 }, { 'type' => 'output', 'line' => 'hi' })
       subscribe id: '42'
       expect(subscription).to be_confirmed
-      expect(transmissions).to eq([
+      expected = [
         { 'type' => 'line', 'line_no' => 1 },
         { 'type' => 'output', 'line' => 'hi' },
-      ])
+      ]
+      expect(transmissions).to eq([expected])
       # Streaming must start strictly after the transmitted backlog (no gap, no
       # duplicates) and stay unarmed for up to ARM_TIMEOUT unless the
       # client performs 'ready'
@@ -63,8 +64,24 @@ RSpec.describe RunningScriptChannel, type: :channel do
       backlog({ 'type' => 'line', 'line_no' => 1 }, { 'type' => 'complete' })
       subscribe id: '42'
       expect(subscription).to be_confirmed
-      expect(transmissions.last).to eq({ 'type' => 'complete' })
+      expected = [
+        { 'type' => 'line', 'line_no' => 1 },
+        { 'type' => 'complete' },
+      ]
+      expect(transmissions.last).to eq(expected)
       expect(RunningScriptReplayThread).not_to have_received(:new)
+    end
+
+    it 'transmits a large backlog in bounded, ordered batches' do
+      events = (1..(RunningScriptReplayThread::MAX_BATCH_SIZE + 1)).map do |line_no|
+        { 'type' => 'line', 'line_no' => line_no }
+      end
+      backlog(*events)
+
+      subscribe id: '42'
+
+      expect(transmissions.map(&:length)).to eq([RunningScriptReplayThread::MAX_BATCH_SIZE, 1])
+      expect(transmissions.flatten).to eq(events)
     end
 
     it 'stops a leftover broadcaster for the same connection before starting a new one' do

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_replay_thread_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_replay_thread_spec.rb
@@ -157,5 +157,22 @@ RSpec.describe RunningScriptReplayThread, type: :model do
       expect(broadcasts.map(&:length)).to eq([RunningScriptReplayThread::MAX_BATCH_SIZE, 1])
       expect(broadcasts.flatten).to eq(events)
     end
+
+    it 'broadcasts the batch parsed before a bad entry rather than losing it' do
+      broadcasts = []
+      allow(ActionCable.server).to receive(:broadcast) { |_key, events| broadcasts << events }
+      event = { 'type' => 'line', 'line_no' => 1 }
+      allow(OpenC3::Topic).to receive(:read_topics) do |_topics, _offsets, &block|
+        block.call(topic, '101-0', { 'data' => event.to_json }, nil)
+        block.call(topic, '102-0', { 'data' => 'not json' }, nil)
+      end
+
+      # The bad entry still kills the thread, but the events it already parsed
+      # must reach the client -- batching must not turn one corrupt entry into
+      # a lost batch.
+      thread = start_thread
+      expect(thread.instance_variable_get(:@thread).join(2)).not_to be_nil
+      expect(broadcasts).to eq([[event]])
+    end
   end
 end

--- a/openc3-cosmos-script-runner-api/spec/models/running_script_replay_thread_spec.rb
+++ b/openc3-cosmos-script-runner-api/spec/models/running_script_replay_thread_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe RunningScriptReplayThread, type: :model do
   end
 
   describe '#start' do
-    it 'streams from the given offset and broadcasts each event to the subscription' do
+    it 'streams from the given offset and broadcasts events together to the subscription' do
       broadcasts = []
       allow(ActionCable.server).to receive(:broadcast) { |key, event| broadcasts << [key, event] }
       line_event = { 'type' => 'line', 'line_no' => 1 }
@@ -121,10 +121,8 @@ RSpec.describe RunningScriptReplayThread, type: :model do
       # even when the client disconnects abruptly and unsubscribed never fires)
       expect(thread.instance_variable_get(:@thread).join(2)).not_to be_nil
       expect(offsets_seen).to eq(['100-0'])
-      expect(broadcasts).to eq([
-        [subscription_key, line_event],
-        [subscription_key, complete_event],
-      ])
+      expected = [subscription_key, [line_event, complete_event]]
+      expect(broadcasts).to eq([expected])
     end
 
     it 'skips entries with no data and keeps streaming' do
@@ -138,7 +136,26 @@ RSpec.describe RunningScriptReplayThread, type: :model do
 
       thread = start_thread
       expect(thread.instance_variable_get(:@thread).join(2)).not_to be_nil
-      expect(broadcasts).to eq([[subscription_key, event]])
+      expect(broadcasts).to eq([[subscription_key, [event]]])
+    end
+
+    it 'caps batches and flushes the terminal partial batch in order' do
+      broadcasts = []
+      allow(ActionCable.server).to receive(:broadcast) { |_key, events| broadcasts << events }
+      events = (1..RunningScriptReplayThread::MAX_BATCH_SIZE).map do |line_no|
+        { 'type' => 'line', 'line_no' => line_no }
+      end
+      events << { 'type' => 'complete' }
+      allow(OpenC3::Topic).to receive(:read_topics) do |_topics, _offsets, &block|
+        events.each_with_index do |event, index|
+          block.call(topic, "#{index + 1}-0", { 'data' => event.to_json }, nil)
+        end
+      end
+
+      thread = start_thread
+      expect(thread.instance_variable_get(:@thread).join(2)).not_to be_nil
+      expect(broadcasts.map(&:length)).to eq([RunningScriptReplayThread::MAX_BATCH_SIZE, 1])
+      expect(broadcasts.flatten).to eq(events)
     end
   end
 end

--- a/openc3/lib/openc3/script/web_socket_api.rb
+++ b/openc3/lib/openc3/script/web_socket_api.rb
@@ -307,6 +307,7 @@ module OpenC3
   # Running Script WebSocket
   class RunningScriptWebSocketApi < ScriptWebSocketApi
     def initialize(id:, **options)
+      @pending_events = []
       @identifier = {
         channel: "RunningScriptChannel",
         id: id
@@ -324,6 +325,36 @@ module OpenC3
       was_subscribed = @subscribed
       super
       write_action({ 'action' => 'ready' }) unless was_subscribed
+    end
+
+    # RunningScriptChannel batches events to reduce ActionCable frame and
+    # client-dispatch overhead. Preserve the public API's historical contract:
+    # callers still receive one script event from each read.
+    def read(ignore_protocol_messages: true, timeout: nil)
+      return @pending_events.shift unless @pending_events.empty?
+
+      loop do
+        message = super
+        return message unless message.is_a?(Array)
+
+        @pending_events.concat(message)
+        return @pending_events.shift unless @pending_events.empty?
+      end
+    end
+
+    def connect
+      @pending_events.clear
+      super
+    end
+
+    def unsubscribe
+      @pending_events.clear
+      super
+    end
+
+    def disconnect
+      @pending_events.clear
+      super
     end
   end
 

--- a/openc3/python/openc3/script/web_socket_api.py
+++ b/openc3/python/openc3/script/web_socket_api.py
@@ -14,6 +14,7 @@ import json
 import os
 import sys
 import time
+from collections import deque
 from datetime import datetime
 
 from openc3.environment import OPENC3_SCOPE
@@ -332,6 +333,7 @@ class RunningScriptWebSocketApi(ScriptWebSocketApi):
     """Running Script WebSocket"""
 
     def __init__(self, id, **options):
+        self.pending_events = deque()
         self.identifier = {"channel": "RunningScriptChannel", "id": id}
         super().__init__(**options)
 
@@ -347,6 +349,31 @@ class RunningScriptWebSocketApi(ScriptWebSocketApi):
         super().subscribe()
         if not was_subscribed:
             self.write_action({"action": "ready"})
+
+    def read(self, ignore_protocol_messages=True, timeout=None):
+        """Return one event at a time while accepting channel event batches."""
+        if self.pending_events:
+            return self.pending_events.popleft()
+
+        while True:
+            message = super().read(ignore_protocol_messages=ignore_protocol_messages, timeout=timeout)
+            if not isinstance(message, list):
+                return message
+            self.pending_events.extend(message)
+            if self.pending_events:
+                return self.pending_events.popleft()
+
+    def connect(self):
+        self.pending_events.clear()
+        return super().connect()
+
+    def unsubscribe(self):
+        self.pending_events.clear()
+        return super().unsubscribe()
+
+    def disconnect(self):
+        self.pending_events.clear()
+        return super().disconnect()
 
 
 class AllScriptsWebSocketApi(ScriptWebSocketApi):

--- a/openc3/python/test/script/test_web_socket_api.py
+++ b/openc3/python/test/script/test_web_socket_api.py
@@ -319,6 +319,33 @@ class TestRunningScriptWebSocketApiReady(unittest.TestCase):
         )
         self.assertEqual(json.loads(frames[-1]["data"]), {"action": "ready"})
 
+    def test_read_returns_batched_events_one_at_a_time(self):
+        api = RunningScriptWebSocketApi(
+            id="spec-script-1",
+            url="ws://test.com/script-api/cable",
+            authentication=mock_auth(),
+        )
+        api.stream = FakeWebSocketStream()
+        api.subscribed = True
+        api.stream.queue_read(
+            '{"message":[{"type":"line","line_no":1},{"type":"output","line":"hi"}]}'
+        )
+
+        self.assertEqual(api.read(), {"type": "line", "line_no": 1})
+        self.assertEqual(api.read(), {"type": "output", "line": "hi"})
+
+    def test_read_accepts_an_individual_event_from_an_older_backend(self):
+        api = RunningScriptWebSocketApi(
+            id="spec-script-1",
+            url="ws://test.com/script-api/cable",
+            authentication=mock_auth(),
+        )
+        api.stream = FakeWebSocketStream()
+        api.subscribed = True
+        api.stream.queue_read('{"message":{"type":"complete"}}')
+
+        self.assertEqual(api.read(), {"type": "complete"})
+
 
 class TestWebSocketApiInit(unittest.TestCase):
     def test_stores_the_timeouts_for_the_stream(self):

--- a/openc3/spec/script/web_socket_api_spec.rb
+++ b/openc3/spec/script/web_socket_api_spec.rb
@@ -591,6 +591,36 @@ module OpenC3
         end
       end
     end
+
+    describe "#read" do
+      let(:api) do
+        RunningScriptWebSocketApi.new(
+          id: "spec-script-1",
+          url: "ws://test.com/script-api/cable",
+          authentication: double("auth", token: "test_token")
+        )
+      end
+      let(:stream) { FakeWebSocketStream.new }
+
+      before do
+        api.instance_variable_set(:@stream, stream)
+        api.instance_variable_set(:@subscribed, true)
+      end
+
+      it "returns batched channel events one at a time without another socket read" do
+        stream.queue_read(
+          '{"message":[{"type":"line","line_no":1},{"type":"output","line":"hi"}]}'
+        )
+
+        expect(api.read).to eq({ "type" => "line", "line_no" => 1 })
+        expect(api.read).to eq({ "type" => "output", "line" => "hi" })
+      end
+
+      it "continues to accept an individual event from an older backend" do
+        stream.queue_read('{"message":{"type":"complete"}}')
+        expect(api.read).to eq({ "type" => "complete" })
+      end
+    end
   end
 
   describe RunningScriptWebSocketApi do

--- a/playwright/tests/script-runner/script-menu.p.spec.ts
+++ b/playwright/tests/script-runner/script-menu.p.spec.ts
@@ -12,6 +12,7 @@
 # All Rights Reserved
 */
 
+import type { Route } from '@playwright/test'
 import { test, expect } from './../fixture'
 import { format } from 'date-fns'
 
@@ -278,6 +279,65 @@ test('view instrumented script', async ({ page, utils }) => {
   await page.locator('text=Instrumented Script').click()
   await expect(page.locator('.v-dialog')).toContainText('binding')
   await page.locator('button:has-text("Ok")').click()
+})
+
+test('loads the script contents when connecting to a running script', async ({
+  page,
+  utils,
+  context,
+}) => {
+  // Park the script in 'waiting' so it stays connectable. The state it
+  // republishes about once a second is what drives the attach path under test.
+  await page
+    .locator('textarea')
+    .fill(`puts "CONNECT_MARKER"\nwait\nputs "done"`)
+  await page.locator('[data-test=start-button]').click()
+  await expect(page.locator('[data-test=state] input')).toHaveValue(
+    /waiting \d+s/,
+    { timeout: 20000 },
+  )
+  const filename = await page.locator('[data-test=filename] input').inputValue()
+
+  // Attach from a second page: it has never loaded this file, so connecting has
+  // to fetch the contents. That is the case where processLine caches an empty
+  // placeholder (so it doesn't slam the API) while the fetch is in flight.
+  const attachPage = await context.newPage()
+  // Go to a non-existent script first to prevent reloading the script cache
+  await attachPage.goto('/tools/scriptrunner/999')
+  await expect(attachPage.locator('.v-app-bar')).toContainText(
+    'Script Runner',
+    {
+      timeout: 20000,
+    },
+  )
+  const toast = attachPage.locator('[data-test=toast]', {
+    hasText: 'Running Script 999 not found',
+  })
+  await expect(toast).toBeVisible()
+  await toast.locator('button:has-text("Dismiss")').click()
+  // This automatically brings up the Running Scripts sheet, so we can connect to the running script
+  await attachPage.getByText('Running Scripts').click()
+  await attachPage.locator('[data-test=running-search] input').fill(filename)
+  await attachPage
+    .locator('[data-test=running-scripts]')
+    .getByRole('button', { name: 'Connect' })
+    .first()
+    .click()
+  await expect(attachPage.locator('[data-test=filename] input')).toHaveValue(
+    filename,
+  )
+
+  // The point of the test: the editor shows the running script, not an empty
+  // buffer.
+  await expect(attachPage.locator('.ace_content')).toContainText(
+    'CONNECT_MARKER',
+    { timeout: 25000 },
+  )
+  await attachPage.close()
+
+  // Don't leave the script running for the rest of the suite
+  await page.locator('[data-test=go-button]').click()
+  await expect(page.locator('[data-test=state] input')).toHaveValue('completed')
 })
 
 // Remaining menu items tested in other cosmos-script-runner tests


### PR DESCRIPTION
### What changed

Improves handling of scriptrunner events such that tight loops are handled better in scriptrunner

### Why it changed

70Hz loop with commanding (output) was causing scriptrunner to fall behind.

### Testing strategy

Tests updated, and ScriptRunner still works.  Will test with the specific rover control script at Smallsat tomorrow.

### Review notes

Look for anything that will break in ScriptRunner