### PR TITLE
Udp interface fixes

### DIFF
--- a/openc3/lib/openc3/interfaces/udp_interface.rb
+++ b/openc3/lib/openc3/interfaces/udp_interface.rb
@@ -23,6 +23,7 @@ module OpenC3
   # Base class for interfaces that send and receive messages over UDP
   class UdpInterface < Interface
     HOST_127_0_0_1 = '127.0.0.1'
+    HOST_0_0_0_0 = '0.0.0.0'
 
     # @param hostname [String] Machine to connect to
     # @param write_dest_port [Integer] Port to write commands to
@@ -77,8 +78,11 @@ module OpenC3
       @read_timeout = ConfigParser.handle_nil(read_timeout)
       @read_timeout = @read_timeout.to_f if @read_timeout
       @bind_address = ConfigParser.handle_nil(bind_address)
-      if @bind_address && @bind_address.casecmp('LOCALHOST').zero?
-        @bind_address = HOST_127_0_0_1
+      if @bind_address
+        @bind_address = HOST_127_0_0_1 if @bind_address.casecmp('LOCALHOST').zero?
+      else
+        # nil means all local addresses which is what 0.0.0.0 means
+        @bind_address = HOST_0_0_0_0
       end
       @write_socket = nil
       @read_socket = nil
@@ -93,7 +97,7 @@ module OpenC3
       result += " #{@write_src_port} (write src port)" if @write_src_port
       result += " #{@bind_address}:#{@read_port} (read)" if @read_port
       result += " #{@interface_address} (interface addr)" if @interface_address
-      result += " #{@bind_address} (bind addr)" if @bind_address != '0.0.0.0'
+      result += " #{@bind_address} (bind addr)" if @bind_address != HOST_0_0_0_0
       return result.strip
     end
 
@@ -102,6 +106,10 @@ module OpenC3
     # the constructor.
     def connect
       if @read_port and @write_dest_port and @write_src_port and (@read_port == @write_src_port)
+        # read_multicast is false because this socket is not connected and thus
+        # doesn't filter by peer address. Joining the multicast group we write to
+        # would deliver our own commands back to us as telemetry (multicast
+        # loopback is enabled by default).
         @read_socket = UdpReadWriteSocket.new(
           @read_port,
           @bind_address,
@@ -109,9 +117,9 @@ module OpenC3
           @hostname,
           @interface_address,
           @ttl,
-          true,
-          true,
-          false
+          false, # read_multicast
+          true,  # write_multicast
+          false  # connect_socket
         )
         @write_socket = @read_socket
       else

--- a/openc3/lib/openc3/interfaces/udp_interface.rb
+++ b/openc3/lib/openc3/interfaces/udp_interface.rb
@@ -91,7 +91,7 @@ module OpenC3
       result = ''
       result += " #{@hostname}:#{@write_dest_port} (write dest port)" if @write_dest_port
       result += " #{@write_src_port} (write src port)" if @write_src_port
-      result += " #{@hostname}:#{@read_port} (read)" if @read_port
+      result += " #{@bind_address}:#{@read_port} (read)" if @read_port
       result += " #{@interface_address} (interface addr)" if @interface_address
       result += " #{@bind_address} (bind addr)" if @bind_address != '0.0.0.0'
       return result.strip
@@ -108,7 +108,10 @@ module OpenC3
           @write_dest_port,
           @hostname,
           @interface_address,
-          @ttl
+          @ttl,
+          true,
+          true,
+          false
         )
         @write_socket = @read_socket
       else

--- a/openc3/lib/openc3/io/udp_sockets.rb
+++ b/openc3/lib/openc3/io/udp_sockets.rb
@@ -27,6 +27,9 @@ module OpenC3
   class UdpReadWriteSocket
     HOST_0_0_0_0 = '0.0.0.0'
 
+    # MSG_DONTWAIT is not defined on Windows where sends are left blocking
+    WRITE_FLAGS = Socket.const_defined?('MSG_DONTWAIT') ? Socket::MSG_DONTWAIT : 0
+
     # @param bind_port [Integer[ Port to write data out from and receive data on (0 = randomly assigned)
     # @param bind_address [String] Local address to bind to (0.0.0.0 = All local addresses)
     # @param external_port [Integer] External port to write to
@@ -36,7 +39,7 @@ module OpenC3
     # @param read_multicast [Boolean] Whether or not to try to read from the external address as multicast
     # @param write_multicast [Boolean] Whether or not to write to the external address as multicast
     # @param connect_socket [Boolean] Whether to connect the socket to the external address. If false,
-    #   writes use sendmsg_nonblock so reads can accept datagrams from any source.
+    #   writes explicitly address each datagram so reads can accept datagrams from any source.
     def initialize(
       bind_port = 0,
       bind_address = HOST_0_0_0_0,
@@ -53,6 +56,15 @@ module OpenC3
       @external_address = external_address
       @external_port = external_port
       @connect_socket = connect_socket
+      # Resolve the destination once at creation time so writes don't pay for a
+      # (potentially blocking) name lookup on every datagram
+      @external_sockaddr = nil
+      if !connect_socket and external_address and external_port
+        # Explicitly resolve IPv4 because UDPSocket is an AF_INET socket and
+        # sockaddr_in would otherwise hand back an IPv6 address for names like localhost
+        ip_address = Socket.getaddrinfo(external_address, nil, Socket::AF_INET, Socket::SOCK_DGRAM)[0][3]
+        @external_sockaddr = Socket.sockaddr_in(external_port, ip_address)
+      end
 
       # Basic setup to reuse address
       @socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, 1)
@@ -96,11 +108,12 @@ module OpenC3
 
       loop do
         begin
-          if @connect_socket
-            bytes_sent = @socket.write_nonblock(data_to_send)
+          if @external_sockaddr
+            # send is used rather than sendmsg_nonblock because sendmsg is not
+            # implemented on Windows
+            bytes_sent = @socket.send(data_to_send, WRITE_FLAGS, @external_sockaddr)
           else
-            destination = Socket.sockaddr_in(@external_port, @external_address)
-            bytes_sent = @socket.sendmsg_nonblock(data_to_send, 0, destination)
+            bytes_sent = @socket.write_nonblock(data_to_send)
           end
         rescue Errno::EAGAIN, Errno::EWOULDBLOCK
           result = IO.fast_select(nil, [@socket], nil, write_timeout)
@@ -140,12 +153,18 @@ module OpenC3
     end
 
     # @param host [String] Machine name or IP address
-    # @param port [String] Port
+    # @param port [String] Port (unused, kept for backwards compatibility)
     # @return [Boolean] Whether the hostname is multicast
     def self.multicast?(host, port = nil)
       return false if host.nil?
 
-      Addrinfo.udp(host, port || 0).ipv4_multicast?
+      begin
+        Addrinfo.udp(host, 0).ipv4_multicast?
+      rescue SocketError, ArgumentError
+        # Hostname isn't resolvable so it can't be a multicast address we handle.
+        # Reads don't need the hostname at all so don't fail creating the socket.
+        false
+      end
     end
   end
 

--- a/openc3/lib/openc3/io/udp_sockets.rb
+++ b/openc3/lib/openc3/io/udp_sockets.rb
@@ -35,6 +35,8 @@ module OpenC3
     # @param ttl [Integer] Time To Live for outgoing multicast packets
     # @param read_multicast [Boolean] Whether or not to try to read from the external address as multicast
     # @param write_multicast [Boolean] Whether or not to write to the external address as multicast
+    # @param connect_socket [Boolean] Whether to connect the socket to the external address. If false,
+    #   writes use sendmsg_nonblock so reads can accept datagrams from any source.
     def initialize(
       bind_port = 0,
       bind_address = HOST_0_0_0_0,
@@ -43,10 +45,14 @@ module OpenC3
       multicast_interface_address = nil,
       ttl = 1,
       read_multicast = true,
-      write_multicast = true
+      write_multicast = true,
+      connect_socket = true
     )
 
       @socket = UDPSocket.new
+      @external_address = external_address
+      @external_port = external_port
+      @connect_socket = connect_socket
 
       # Basic setup to reuse address
       @socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, 1)
@@ -55,10 +61,10 @@ module OpenC3
       @socket.bind(bind_address, bind_port) if bind_address and bind_port
 
       # Default send to the specified address and port
-      @socket.connect(external_address, external_port) if external_address and external_port
+      @socket.connect(external_address, external_port) if connect_socket and external_address and external_port
 
       # Handle multicast
-      if UdpReadWriteSocket.multicast?(external_address, external_port)
+      if UdpReadWriteSocket.multicast?(external_address)
         if write_multicast
           # Basic setup set time to live
           @socket.setsockopt(Socket::IPPROTO_IP, Socket::IP_MULTICAST_TTL, ttl.to_i)
@@ -90,7 +96,12 @@ module OpenC3
 
       loop do
         begin
-          bytes_sent = @socket.write_nonblock(data_to_send)
+          if @connect_socket
+            bytes_sent = @socket.write_nonblock(data_to_send)
+          else
+            destination = Socket.sockaddr_in(@external_port, @external_address)
+            bytes_sent = @socket.sendmsg_nonblock(data_to_send, 0, destination)
+          end
         rescue Errno::EAGAIN, Errno::EWOULDBLOCK
           result = IO.fast_select(nil, [@socket], nil, write_timeout)
           if result
@@ -131,10 +142,10 @@ module OpenC3
     # @param host [String] Machine name or IP address
     # @param port [String] Port
     # @return [Boolean] Whether the hostname is multicast
-    def self.multicast?(host, port)
-      return false if host.nil? || port.nil?
+    def self.multicast?(host, port = nil)
+      return false if host.nil?
 
-      Addrinfo.udp(host, port).ipv4_multicast?
+      Addrinfo.udp(host, port || 0).ipv4_multicast?
     end
   end
 

--- a/openc3/python/openc3/interfaces/udp_interface.py
+++ b/openc3/python/openc3/interfaces/udp_interface.py
@@ -76,8 +76,12 @@ class UdpInterface(Interface):
         if self.read_timeout is not None:
             self.read_timeout = float(read_timeout)
         self.bind_address = ConfigParser.handle_none(bind_address)
-        if self.bind_address and self.bind_address.upper() == "LOCALHOST":
-            self.bind_address = "127.0.0.1"
+        if self.bind_address:
+            if self.bind_address.upper() == "LOCALHOST":
+                self.bind_address = "127.0.0.1"
+        else:
+            # None means all local addresses which is what 0.0.0.0 means
+            self.bind_address = "0.0.0.0"
         self.write_socket = None
         self.read_socket = None
         if self.read_port is None:
@@ -111,6 +115,10 @@ class UdpInterface(Interface):
             and self.write_src_port is not None
             and self.read_port == self.write_src_port
         ):
+            # read_multicast is False because this socket is not connected and thus
+            # doesn't filter by peer address. Joining the multicast group we write to
+            # would deliver our own commands back to us as telemetry (multicast
+            # loopback is enabled by default).
             self.read_socket = UdpReadWriteSocket(
                 bind_port=self.read_port,
                 bind_address=self.bind_address,
@@ -118,6 +126,7 @@ class UdpInterface(Interface):
                 external_address=self.hostname,
                 multicast_interface_address=self.interface_address,
                 ttl=self.ttl,
+                read_multicast=False,
                 connect_socket=False,
             )
             self.write_socket = self.read_socket

--- a/openc3/python/openc3/interfaces/udp_interface.py
+++ b/openc3/python/openc3/interfaces/udp_interface.py
@@ -89,12 +89,12 @@ class UdpInterface(Interface):
 
     def connection_string(self):
         result = ""
-        if self.write_dest_port:
+        if self.write_dest_port is not None:
             result += f" {self.hostname}:{self.write_dest_port} (write dest port)"
-        if self.write_src_port:
+        if self.write_src_port is not None:
             result += f" {self.write_src_port} (write src port)"
-        if self.read_port:
-            result += f" {self.hostname}:{self.read_port} (read)"
+        if self.read_port is not None:
+            result += f" {self.bind_address}:{self.read_port} (read)"
         if self.interface_address:
             result += f" {self.interface_address} (interface addr)"
         if self.bind_address != "0.0.0.0":
@@ -105,25 +105,31 @@ class UdpInterface(Interface):
     # the constructor and a new {UdpReadSocket} if the read_port was given in
     # the constructor.
     def connect(self):
-        if self.read_port and self.write_dest_port and self.write_src_port and (self.read_port == self.write_src_port):
+        if (
+            self.read_port is not None
+            and self.write_dest_port is not None
+            and self.write_src_port is not None
+            and self.read_port == self.write_src_port
+        ):
             self.read_socket = UdpReadWriteSocket(
-                self.read_port,
-                self.bind_address,
-                self.write_dest_port,
-                self.hostname,
-                self.interface_address,
-                self.ttl,
+                bind_port=self.read_port,
+                bind_address=self.bind_address,
+                external_port=self.write_dest_port,
+                external_address=self.hostname,
+                multicast_interface_address=self.interface_address,
+                ttl=self.ttl,
+                connect_socket=False,
             )
             self.write_socket = self.read_socket
         else:
-            if self.read_port:
+            if self.read_port is not None:
                 self.read_socket = UdpReadSocket(
                     self.read_port,
                     self.hostname,
                     self.interface_address,
                     self.bind_address,
                 )
-            if self.write_dest_port:
+            if self.write_dest_port is not None:
                 self.write_socket = UdpWriteSocket(
                     self.hostname,
                     self.write_dest_port,
@@ -159,7 +165,7 @@ class UdpInterface(Interface):
         super().disconnect()
 
     def read(self):
-        if self.read_port:
+        if self.read_port is not None:
             return super().read()
 
         # Write only interface so stop the thread which calls read

--- a/openc3/python/openc3/io/udp_sockets.py
+++ b/openc3/python/openc3/io/udp_sockets.py
@@ -28,7 +28,8 @@ class UdpReadWriteSocket:
     # @param read_multicast [Boolean] Whether or not to try to read from the external address as multicast
     # @param write_multicast [Boolean] Whether or not to write to the external address as multicast
     # @param connect_socket [Boolean] Whether to connect the socket to the external address. If false,
-    #   writes use sendto so reads can accept datagrams from any source.
+    #   writes use sendto so reads can accept datagrams from any source. The destination is resolved
+    #   once at creation time so writes don't pay for a name lookup on every datagram.
     def __init__(
         self,
         bind_port=0,
@@ -46,6 +47,11 @@ class UdpReadWriteSocket:
         self.external_address = external_address
         self.external_port = external_port
         self.connect_socket = connect_socket
+        # Resolve the destination once at creation time so writes don't pay for a
+        # (potentially blocking) name lookup on every datagram
+        self.external_destination = None
+        if not connect_socket and external_address and external_port is not None:
+            self.external_destination = (socket.gethostbyname(external_address), external_port)
 
         # Basic setup to reuse address
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -89,15 +95,19 @@ class UdpReadWriteSocket:
 
         while True:
             try:
-                if self.connect_socket:
-                    bytes_sent = self.socket.send(data_to_send)
+                if self.external_destination:
+                    bytes_sent = self.socket.sendto(data_to_send, self.external_destination)
                 else:
-                    bytes_sent = self.socket.sendto(data_to_send, (self.external_address, self.external_port))
+                    bytes_sent = self.socket.send(data_to_send)
             except OSError as e:
                 if e.args[0] == socket.EAGAIN or e.args[0] == socket.EWOULDBLOCK:
                     result = select.select([], [self.socket], [], write_timeout)
                     if len(result[0]) == 0 and len(result[1]) == 0 and len(result[2]) == 0:
                         raise TimeoutError from e
+                    continue
+                # Anything else (ENETUNREACH, EINVAL, ...) is not retryable. Raise
+                # rather than looping forever on a send that can never succeed.
+                raise
             total_bytes_sent += bytes_sent
             if total_bytes_sent >= num_bytes_to_send:
                 break
@@ -129,13 +139,18 @@ class UdpReadWriteSocket:
         return method
 
     # @param host [String] Machine name or IP address
-    # @param port [String] Port
+    # @param port [String] Port (unused, kept for backwards compatibility)
     # @return [Boolean] Whether the hostname is multicast
     @classmethod
     def multicast(cls, host, port=None):
         if host is None:
             return False
-        host_ip = socket.gethostbyname(host)
+        try:
+            host_ip = socket.gethostbyname(host)
+        except OSError:
+            # Hostname isn't resolvable so it can't be a multicast address we handle.
+            # Reads don't need the hostname at all so don't fail creating the socket.
+            return False
         # "224.0.0.0/4 is the CIDR notation for the range of IPv4 multicast addresses,
         # which includes all addresses from 224.0.0.0 to 239.255.255.255.
         return ipaddress.ip_address(host_ip) in ipaddress.ip_network("224.0.0.0/4")

--- a/openc3/python/openc3/io/udp_sockets.py
+++ b/openc3/python/openc3/io/udp_sockets.py
@@ -27,6 +27,8 @@ class UdpReadWriteSocket:
     # @param ttl [Integer] Time To Live for outgoing multicast packets
     # @param read_multicast [Boolean] Whether or not to try to read from the external address as multicast
     # @param write_multicast [Boolean] Whether or not to write to the external address as multicast
+    # @param connect_socket [Boolean] Whether to connect the socket to the external address. If false,
+    #   writes use sendto so reads can accept datagrams from any source.
     def __init__(
         self,
         bind_port=0,
@@ -37,23 +39,27 @@ class UdpReadWriteSocket:
         ttl=1,
         read_multicast=True,
         write_multicast=True,
+        connect_socket=True,
     ):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.socket.setblocking(False)
+        self.external_address = external_address
+        self.external_port = external_port
+        self.connect_socket = connect_socket
 
         # Basic setup to reuse address
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
         # Bind to local address and port - This sets recv port, write_src port, recv_address, and write_src_address
-        if bind_address and bind_port:
+        if bind_address and bind_port is not None:
             self.socket.bind((bind_address, bind_port))
 
         # Default send to the specified address and port
-        if external_address and external_port:
+        if connect_socket and external_address and external_port is not None:
             self.socket.connect((external_address, external_port))
 
         # Handle multicast
-        if UdpReadWriteSocket.multicast(external_address, external_port):
+        if UdpReadWriteSocket.multicast(external_address):
             if write_multicast:
                 # Basic setup set time to live
                 self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, int(ttl))
@@ -83,7 +89,10 @@ class UdpReadWriteSocket:
 
         while True:
             try:
-                bytes_sent = self.socket.send(data_to_send)
+                if self.connect_socket:
+                    bytes_sent = self.socket.send(data_to_send)
+                else:
+                    bytes_sent = self.socket.sendto(data_to_send, (self.external_address, self.external_port))
             except OSError as e:
                 if e.args[0] == socket.EAGAIN or e.args[0] == socket.EWOULDBLOCK:
                     result = select.select([], [self.socket], [], write_timeout)
@@ -123,8 +132,8 @@ class UdpReadWriteSocket:
     # @param port [String] Port
     # @return [Boolean] Whether the hostname is multicast
     @classmethod
-    def multicast(cls, host, port):
-        if host is None or port is None:
+    def multicast(cls, host, port=None):
+        if host is None:
             return False
         host_ip = socket.gethostbyname(host)
         # "224.0.0.0/4 is the CIDR notation for the range of IPv4 multicast addresses,

--- a/openc3/python/test/interfaces/test_udp_interface.py
+++ b/openc3/python/test/interfaces/test_udp_interface.py
@@ -71,11 +71,11 @@ class TestUdpInterface(unittest.TestCase):
         i = UdpInterface("123.4.5.6", "8888", "8889", "8890", "456.7.8.9", "64", "5", "5", "1.2.3.4")
         self.assertEqual(
             i.connection_string(),
-            "123.4.5.6:8888 (write dest port) 8890 (write src port) 123.4.5.6:8889 (read) 456.7.8.9 (interface addr) 1.2.3.4 (bind addr)",
+            "123.4.5.6:8888 (write dest port) 8890 (write src port) 1.2.3.4:8889 (read) 456.7.8.9 (interface addr) 1.2.3.4 (bind addr)",
         )
 
         i = UdpInterface("localhost", "None", "8889")
-        self.assertEqual(i.connection_string(), "127.0.0.1:8889 (read)")
+        self.assertEqual(i.connection_string(), "0.0.0.0:8889 (read)")
 
         i = UdpInterface("localhost", "8888", "None")
         self.assertEqual(i.connection_string(), "127.0.0.1:8888 (write dest port)")
@@ -128,6 +128,29 @@ class TestUdpInterface(unittest.TestCase):
         self.assertFalse(i.connected())
         self.assertIsNone(i.write_socket)
         self.assertIsNone(i.read_socket)
+
+    def test_shared_socket_receives_from_a_different_source_port(self):
+        destination = UdpReadSocket(4003)
+        sender = UdpWriteSocket("127.0.0.1", 4002, 4004)
+        i = UdpInterface("127.0.0.1", 4003, 4002, 4002)
+        i.connect()
+
+        sender.write(b"telemetry")
+        self.assertEqual(i.read_socket.read(1.0), b"telemetry")
+        i.write_socket.write(b"command")
+        self.assertEqual(destination.read(1.0), b"command")
+        self.assertEqual(i.write_socket.getsockname()[1], 4002)
+
+        i.disconnect()
+        close_socket(sender)
+        close_socket(destination)
+
+    def test_creates_a_read_socket_for_port_zero(self):
+        i = UdpInterface("127.0.0.1", None, 0)
+        i.connect()
+        self.assertIsNotNone(i.read_socket)
+        self.assertGreater(i.read_socket.getsockname()[1], 0)
+        i.disconnect()
 
     @patch("socket.socket")
     def test_stops_the_read_thread_if_there_is_an_ioerror(self, mock_socket):

--- a/openc3/python/test/interfaces/test_udp_interface.py
+++ b/openc3/python/test/interfaces/test_udp_interface.py
@@ -80,6 +80,10 @@ class TestUdpInterface(unittest.TestCase):
         i = UdpInterface("localhost", "8888", "None")
         self.assertEqual(i.connection_string(), "127.0.0.1:8888 (write dest port)")
 
+        # None bind_address means all local addresses
+        i = UdpInterface("localhost", "None", "8889", "None", "None", "64", "5", "5", "None")
+        self.assertEqual(i.connection_string(), "0.0.0.0:8889 (read)")
+
     def test_creates_a_udpwritesocket_and_udpreadsocket_if_both_given(self):
         i = UdpInterface("localhost", "8888", "8889")
         self.assertFalse(i.connected())
@@ -130,27 +134,59 @@ class TestUdpInterface(unittest.TestCase):
         self.assertIsNone(i.read_socket)
 
     def test_shared_socket_receives_from_a_different_source_port(self):
-        destination = UdpReadSocket(4003)
-        sender = UdpWriteSocket("127.0.0.1", 4002, 4004)
-        i = UdpInterface("127.0.0.1", 4003, 4002, 4002)
+        # Bind the receiving sockets first so the ports are known, then let the
+        # sender pick an ephemeral source port
+        destination = UdpReadSocket(0)
+        self.addCleanup(close_socket, destination)
+        dest_port = destination.getsockname()[1]
+        shared_port = UdpReadSocket(0)
+        read_port = shared_port.getsockname()[1]
+        close_socket(shared_port)
+
+        sender = UdpWriteSocket("127.0.0.1", read_port)
+        self.addCleanup(close_socket, sender)
+        i = UdpInterface("127.0.0.1", dest_port, read_port, read_port)
+        self.addCleanup(i.disconnect)
         i.connect()
 
         sender.write(b"telemetry")
         self.assertEqual(i.read_socket.read(1.0), b"telemetry")
         i.write_socket.write(b"command")
         self.assertEqual(destination.read(1.0), b"command")
-        self.assertEqual(i.write_socket.getsockname()[1], 4002)
+        self.assertEqual(i.write_socket.getsockname()[1], read_port)
 
-        i.disconnect()
-        close_socket(sender)
-        close_socket(destination)
+    def test_clamps_a_ttl_below_one(self):
+        i = UdpInterface("localhost", "8888", "None", "None", "None", "0")
+        self.assertEqual(i.ttl, 1)
+
+    def test_defaults_a_none_write_timeout_to_ten_seconds(self):
+        i = UdpInterface("localhost", "8888", "None", "None", "None", "64", "None")
+        self.assertEqual(i.write_timeout, 10.0)
+
+    @patch("socket.socket")
+    def test_does_not_join_the_multicast_group_it_writes_to_on_a_shared_socket(self, mock_socket):
+        i = UdpInterface("224.0.1.1", 8889, 8889, 8889)
+        self.addCleanup(i.disconnect)
+        i.connect()
+        # Joining the group we transmit to would loop our own commands back as telemetry
+        membership = socket.inet_aton("224.0.1.1") + socket.inet_aton("0.0.0.0")
+        for call in mock_socket.return_value.setsockopt.call_args_list:
+            self.assertNotEqual(call.args, (socket.SOL_IP, socket.IP_ADD_MEMBERSHIP, membership))
+        # Multicast writes are still set up
+        mock_socket.return_value.setsockopt.assert_any_call(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 128)
+
+    def test_creates_a_read_only_socket_with_an_unresolvable_hostname(self):
+        i = UdpInterface("this-host-does-not-exist.invalid", None, 0)
+        self.addCleanup(i.disconnect)
+        i.connect()
+        self.assertIsNotNone(i.read_socket)
 
     def test_creates_a_read_socket_for_port_zero(self):
         i = UdpInterface("127.0.0.1", None, 0)
+        self.addCleanup(i.disconnect)
         i.connect()
         self.assertIsNotNone(i.read_socket)
         self.assertGreater(i.read_socket.getsockname()[1], 0)
-        i.disconnect()
 
     @patch("socket.socket")
     def test_stops_the_read_thread_if_there_is_an_ioerror(self, mock_socket):

--- a/openc3/python/test/io/test_udp_sockets.py
+++ b/openc3/python/test/io/test_udp_sockets.py
@@ -51,7 +51,7 @@ class TestUdpWriteSocket(unittest.TestCase):
 
     def test_determines_if_a_host_is_multicast(self):
         self.assertFalse(UdpWriteSocket.multicast(None, 80))
-        self.assertFalse(UdpWriteSocket.multicast("224.0.1.1", None))
+        self.assertTrue(UdpWriteSocket.multicast("224.0.1.1", None))
         self.assertFalse(UdpWriteSocket.multicast("127.0.0.1", 80))
         self.assertTrue(UdpWriteSocket.multicast("224.0.1.1", 80))
 
@@ -65,6 +65,17 @@ class TestUdpReadSocket(unittest.TestCase):
         udp = UdpReadSocket(8888, "224.0.1.1")
         _bytes = struct.pack("<I", udp.getsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF))
         self.assertEqual(socket.inet_ntoa(_bytes), "0.0.0.0")
+        udp.close()
+
+    @patch("socket.socket")
+    def test_joins_the_multicast_group(self, mock_socket):
+        UdpReadSocket(8888, "224.0.1.1", "127.0.0.1")
+        membership = socket.inet_aton("224.0.1.1") + socket.inet_aton("127.0.0.1")
+        mock_socket.return_value.setsockopt.assert_any_call(socket.SOL_IP, socket.IP_ADD_MEMBERSHIP, membership)
+
+    def test_binds_port_zero_to_an_ephemeral_port(self):
+        udp = UdpReadSocket(0)
+        self.assertGreater(udp.getsockname()[1], 0)
         udp.close()
 
     def test_reads_data(self):

--- a/openc3/python/test/io/test_udp_sockets.py
+++ b/openc3/python/test/io/test_udp_sockets.py
@@ -9,10 +9,11 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
+import errno
 import select
 import struct
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from openc3.io.udp_sockets import UdpReadSocket, UdpReadWriteSocket, UdpWriteSocket, socket
 
@@ -49,11 +50,56 @@ class TestUdpWriteSocket(unittest.TestCase):
             udp_write.write(b"\x01\x02", 2.0)
         udp_write.close()
 
+    def test_retries_the_send_after_the_socket_becomes_writable(self):
+        udp_read = UdpReadSocket(8888)
+        self.addCleanup(udp_read.close)
+        udp_write = UdpWriteSocket("127.0.0.1", 8888)
+        self.addCleanup(udp_write.close)
+        real_send = udp_write.socket.send
+        calls = []
+
+        def send(*args):
+            calls.append(args)
+            if len(calls) == 1:
+                raise OSError(errno.EAGAIN, "would block")
+            return real_send(*args)
+
+        with patch.object(udp_write, "socket", wraps=udp_write.socket) as mock:
+            mock.send = send
+            udp_write.write(b"\x01\x02", 2.0)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(udp_read.read(), b"\x01\x02")
+
+    def test_raises_on_a_non_retryable_send_error(self):
+        udp = UdpReadWriteSocket(0, "0.0.0.0", 8888, "127.0.0.1", connect_socket=False)
+        real_socket = udp.socket
+        self.addCleanup(real_socket.close)
+        # Non EAGAIN errors are not retryable and must not spin the write loop
+        udp.socket = Mock()
+        udp.socket.sendto.side_effect = OSError(errno.ENETUNREACH, "unreachable")
+        with self.assertRaises(OSError):
+            udp.write(b"\x01\x02", 2.0)
+
+    def test_writes_to_an_unconnected_socket_using_the_address_resolved_at_creation(self):
+        udp_read = UdpReadSocket(8888)
+        self.addCleanup(udp_read.close)
+        # connect_socket False means every write must explicitly address the datagram
+        udp_write = UdpReadWriteSocket(0, "0.0.0.0", 8888, "localhost", connect_socket=False)
+        self.addCleanup(udp_write.close)
+        self.assertEqual(udp_write.external_destination, ("127.0.0.1", 8888))
+        # The destination is resolved once at creation, not on every write
+        with patch("socket.gethostbyname", side_effect=AssertionError("resolved on write")):
+            udp_write.write(b"\x01\x02", 2.0)
+        self.assertEqual(udp_read.read(), b"\x01\x02")
+
     def test_determines_if_a_host_is_multicast(self):
         self.assertFalse(UdpWriteSocket.multicast(None, 80))
         self.assertTrue(UdpWriteSocket.multicast("224.0.1.1", None))
         self.assertFalse(UdpWriteSocket.multicast("127.0.0.1", 80))
         self.assertTrue(UdpWriteSocket.multicast("224.0.1.1", 80))
+
+    def test_returns_false_for_an_unresolvable_host(self):
+        self.assertFalse(UdpWriteSocket.multicast("this-host-does-not-exist.invalid"))
 
 
 class TestUdpReadSocket(unittest.TestCase):
@@ -75,8 +121,8 @@ class TestUdpReadSocket(unittest.TestCase):
 
     def test_binds_port_zero_to_an_ephemeral_port(self):
         udp = UdpReadSocket(0)
+        self.addCleanup(udp.close)
         self.assertGreater(udp.getsockname()[1], 0)
-        udp.close()
 
     def test_reads_data(self):
         udp_read = UdpReadSocket(8888)

--- a/openc3/spec/interfaces/udp_interface_spec.rb
+++ b/openc3/spec/interfaces/udp_interface_spec.rb
@@ -48,6 +48,11 @@ module OpenC3
         expect(i.write_raw_allowed?).to be true
         expect(i.read_allowed?).to be false
       end
+
+      it "defaults a nil write_timeout to 10 seconds" do
+        i = UdpInterface.new('localhost', '8888', 'nil', 'nil', 'nil', '64', 'nil')
+        expect(i.instance_variable_get(:@write_timeout)).to eql 10.0
+      end
     end
 
     describe "connection_string" do
@@ -60,6 +65,10 @@ module OpenC3
 
         i = UdpInterface.new('localhost', '8888', 'nil')
         expect(i.connection_string).to eql "127.0.0.1:8888 (write dest port)"
+
+        # nil bind_address means all local addresses
+        i = UdpInterface.new('localhost', 'nil', '8889', 'nil', 'nil', '64', '5', '5', 'nil')
+        expect(i.connection_string).to eql "0.0.0.0:8889 (read)"
       end
     end
 
@@ -118,29 +127,74 @@ module OpenC3
       end
 
       it "receives from a different source port on a shared read and write socket" do
-        destination = UdpReadSocket.new(4003)
-        sender = UdpWriteSocket.new('127.0.0.1', 4002, 4004)
-        i = UdpInterface.new('127.0.0.1', 4003, 4002, 4002)
-        i.connect
+        # Bind the receiving sockets first so the ports are known, then let the
+        # sender pick an ephemeral source port
+        destination = UdpReadSocket.new(0)
+        dest_port = destination.local_address.ip_port
+        shared_port = UdpReadSocket.new(0)
+        read_port = shared_port.local_address.ip_port
+        OpenC3.close_socket(shared_port)
 
-        sender.write("telemetry")
-        expect(i.instance_variable_get(:@read_socket).read(1.0)).to eql "telemetry"
-        i.instance_variable_get(:@write_socket).write("command")
-        expect(destination.read(1.0)).to eql "command"
-        expect(i.instance_variable_get(:@write_socket).local_address.ip_port).to eql 4002
+        sender = nil
+        i = nil
+        begin
+          sender = UdpWriteSocket.new('127.0.0.1', read_port)
+          i = UdpInterface.new('127.0.0.1', dest_port, read_port, read_port)
+          i.connect
 
-        i.disconnect
-        OpenC3.close_socket(sender)
-        OpenC3.close_socket(destination)
+          sender.write("telemetry")
+          expect(i.instance_variable_get(:@read_socket).read(1.0)).to eql "telemetry"
+          i.instance_variable_get(:@write_socket).write("command")
+          expect(destination.read(1.0)).to eql "command"
+          expect(i.instance_variable_get(:@write_socket).local_address.ip_port).to eql read_port
+        ensure
+          i.disconnect if i
+          OpenC3.close_socket(sender) if sender
+          OpenC3.close_socket(destination)
+        end
+      end
+
+      it "does not join the multicast group it writes to on a shared socket" do
+        skip "UDP multicast does not work in JRuby" unless RUBY_ENGINE == 'ruby'
+
+        calls = []
+        allow_any_instance_of(UDPSocket).to receive(:setsockopt).and_wrap_original do |method, *args|
+          calls << args
+          method.call(*args)
+        end
+        i = UdpInterface.new('224.0.1.1', 8889, 8889, 8889)
+        begin
+          i.connect
+          # Joining the group we transmit to would loop our own commands back as telemetry
+          membership = IPAddr.new('224.0.1.1').hton + IPAddr.new('0.0.0.0').hton
+          expect(calls).to_not include([Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, membership])
+          # Multicast writes are still set up
+          expect(calls).to include([Socket::IPPROTO_IP, Socket::IP_MULTICAST_TTL, 128])
+        ensure
+          i.disconnect
+        end
+      end
+
+      it "creates a read only socket with an unresolvable hostname" do
+        i = UdpInterface.new('this-host-does-not-exist.invalid', nil, 0)
+        begin
+          i.connect
+          expect(i.instance_variable_get(:@read_socket)).to_not be_nil
+        ensure
+          i.disconnect
+        end
       end
 
       it "creates a read socket for port zero" do
         i = UdpInterface.new('127.0.0.1', nil, 0)
-        i.connect
-        read_socket = i.instance_variable_get(:@read_socket)
-        expect(read_socket).to_not be_nil
-        expect(read_socket.local_address.ip_port).to be > 0
-        i.disconnect
+        begin
+          i.connect
+          read_socket = i.instance_variable_get(:@read_socket)
+          expect(read_socket).to_not be_nil
+          expect(read_socket.local_address.ip_port).to be > 0
+        ensure
+          i.disconnect
+        end
       end
     end
 

--- a/openc3/spec/interfaces/udp_interface_spec.rb
+++ b/openc3/spec/interfaces/udp_interface_spec.rb
@@ -53,10 +53,10 @@ module OpenC3
     describe "connection_string" do
       it "builds a human readable connection string" do
         i = UdpInterface.new('123.4.5.6', '8888', '8889', '8890', '456.7.8.9', '64', '5', '5', '1.2.3.4')
-        expect(i.connection_string).to eql "123.4.5.6:8888 (write dest port) 8890 (write src port) 123.4.5.6:8889 (read) 456.7.8.9 (interface addr) 1.2.3.4 (bind addr)"
+        expect(i.connection_string).to eql "123.4.5.6:8888 (write dest port) 8890 (write src port) 1.2.3.4:8889 (read) 456.7.8.9 (interface addr) 1.2.3.4 (bind addr)"
 
         i = UdpInterface.new('localhost', 'nil', '8889')
-        expect(i.connection_string).to eql "127.0.0.1:8889 (read)"
+        expect(i.connection_string).to eql "0.0.0.0:8889 (read)"
 
         i = UdpInterface.new('localhost', '8888', 'nil')
         expect(i.connection_string).to eql "127.0.0.1:8888 (write dest port)"
@@ -115,6 +115,32 @@ module OpenC3
         expect(i.connected?).to be false
         expect(i.instance_variable_get(:@write_socket)).to be_nil
         expect(i.instance_variable_get(:@read_socket)).to be_nil
+      end
+
+      it "receives from a different source port on a shared read and write socket" do
+        destination = UdpReadSocket.new(4003)
+        sender = UdpWriteSocket.new('127.0.0.1', 4002, 4004)
+        i = UdpInterface.new('127.0.0.1', 4003, 4002, 4002)
+        i.connect
+
+        sender.write("telemetry")
+        expect(i.instance_variable_get(:@read_socket).read(1.0)).to eql "telemetry"
+        i.instance_variable_get(:@write_socket).write("command")
+        expect(destination.read(1.0)).to eql "command"
+        expect(i.instance_variable_get(:@write_socket).local_address.ip_port).to eql 4002
+
+        i.disconnect
+        OpenC3.close_socket(sender)
+        OpenC3.close_socket(destination)
+      end
+
+      it "creates a read socket for port zero" do
+        i = UdpInterface.new('127.0.0.1', nil, 0)
+        i.connect
+        read_socket = i.instance_variable_get(:@read_socket)
+        expect(read_socket).to_not be_nil
+        expect(read_socket.local_address.ip_port).to be > 0
+        i.disconnect
       end
     end
 

--- a/openc3/spec/io/udp_sockets_spec.rb
+++ b/openc3/spec/io/udp_sockets_spec.rb
@@ -54,6 +54,34 @@ module OpenC3
         expect { udp_write.write("\x01\x02", 2.0) }.to raise_error(Timeout::Error)
         udp_write.close
       end
+
+      it "raises on a non retryable send error" do
+        udp = UdpReadWriteSocket.new(0, '0.0.0.0', 8888, '127.0.0.1', nil, 1, false, true, false)
+        begin
+          # Non EAGAIN errors are not retryable and must not spin the write loop
+          expect_any_instance_of(UDPSocket).to receive(:send).once.and_raise(Errno::ENETUNREACH)
+          expect { udp.write("\x01\x02", 2.0) }.to raise_error(Errno::ENETUNREACH)
+        ensure
+          udp.close
+        end
+      end
+
+      it "writes to an unconnected socket using the address resolved at creation" do
+        udp_read = UdpReadSocket.new(8888)
+        # connect_socket false means every write must explicitly address the datagram
+        udp_write = UdpReadWriteSocket.new(0, '0.0.0.0', 8888, 'localhost', nil, 1, false, true, false)
+        begin
+          expect(udp_write.instance_variable_get(:@external_sockaddr)).to \
+            eql Socket.sockaddr_in(8888, '127.0.0.1')
+          # The destination is resolved once at creation, not on every write
+          expect(Socket).to_not receive(:getaddrinfo)
+          udp_write.write("\x01\x02", 2.0)
+          expect(udp_read.read).to eql "\x01\x02"
+        ensure
+          udp_read.close
+          udp_write.close
+        end
+      end
     end
 
     describe "multicast" do
@@ -62,6 +90,10 @@ module OpenC3
         expect(UdpWriteSocket.multicast?('224.0.1.1', nil)).to be true
         expect(UdpWriteSocket.multicast?('127.0.0.1', 80)).to be false
         expect(UdpWriteSocket.multicast?('224.0.1.1', 80)).to be true
+      end
+
+      it "returns false for an unresolvable host" do
+        expect(UdpWriteSocket.multicast?('this-host-does-not-exist.invalid')).to be false
       end
     end
   end
@@ -82,8 +114,11 @@ module OpenC3
 
       it "binds port zero to an ephemeral port" do
         udp = UdpReadSocket.new(0)
-        expect(udp.local_address.ip_port).to be > 0
-        udp.close
+        begin
+          expect(udp.local_address.ip_port).to be > 0
+        ensure
+          udp.close
+        end
       end
 
       it "joins the multicast group" do
@@ -95,9 +130,12 @@ module OpenC3
           method.call(*args)
         end
         udp = UdpReadSocket.new(8888, '224.0.1.1')
-        membership = IPAddr.new('224.0.1.1').hton + IPAddr.new('0.0.0.0').hton
-        expect(calls).to include([Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, membership])
-        udp.close
+        begin
+          membership = IPAddr.new('224.0.1.1').hton + IPAddr.new('0.0.0.0').hton
+          expect(calls).to include([Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, membership])
+        ensure
+          udp.close
+        end
       end
     end
 

--- a/openc3/spec/io/udp_sockets_spec.rb
+++ b/openc3/spec/io/udp_sockets_spec.rb
@@ -59,7 +59,7 @@ module OpenC3
     describe "multicast" do
       it "determines if a host is multicast" do
         expect(UdpWriteSocket.multicast?(nil, 80)).to be false
-        expect(UdpWriteSocket.multicast?('224.0.1.1', nil)).to be false
+        expect(UdpWriteSocket.multicast?('224.0.1.1', nil)).to be true
         expect(UdpWriteSocket.multicast?('127.0.0.1', 80)).to be false
         expect(UdpWriteSocket.multicast?('224.0.1.1', 80)).to be true
       end
@@ -78,6 +78,26 @@ module OpenC3
           expect(IPAddr.new_ntoh(udp.getsockopt(Socket::IPPROTO_IP, Socket::IP_MULTICAST_IF).data).to_s).to eql "0.0.0.0"
           udp.close
         end
+      end
+
+      it "binds port zero to an ephemeral port" do
+        udp = UdpReadSocket.new(0)
+        expect(udp.local_address.ip_port).to be > 0
+        udp.close
+      end
+
+      it "joins the multicast group" do
+        skip "UDP multicast does not work in JRuby" unless RUBY_ENGINE == 'ruby'
+
+        calls = []
+        allow_any_instance_of(UDPSocket).to receive(:setsockopt).and_wrap_original do |method, *args|
+          calls << args
+          method.call(*args)
+        end
+        udp = UdpReadSocket.new(8888, '224.0.1.1')
+        membership = IPAddr.new('224.0.1.1').hton + IPAddr.new('0.0.0.0').hton
+        expect(calls).to include([Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, membership])
+        udp.close
       end
     end
 


### PR DESCRIPTION
### What changed

Fixes discovered issues with the UDP Interface.  Main issue was when setting read_port to write src port, packets where only received from the exact destination write port.

### Testing strategy

Tests updated including the specific ports that were causing me issues (4003, 4002) for Govee lights.

### Review notes

Make sure this does not break any compatibility for users
