### PR TITLE
Fix table manager test

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
@@ -63,7 +63,7 @@
               dense
               color="primary"
               class="mr-3"
-              :disabled="filename == ''"
+              :disabled="filename == '' || definitionFilename == ''"
               data-test="download-file-binary"
               @click="downloadBinary(null)"
             >
@@ -74,7 +74,7 @@
               dense
               color="primary"
               class="mr-3"
-              :disabled="filename == ''"
+              :disabled="filename == '' || definitionFilename == ''"
               data-test="download-file-definition"
               @click="downloadDefinition(null)"
             >
@@ -84,7 +84,7 @@
             <v-btn
               dense
               color="primary"
-              :disabled="filename == ''"
+              :disabled="filename == '' || definitionFilename == ''"
               data-test="download-file-report"
               @click="downloadReport(null)"
             >
@@ -182,7 +182,7 @@
                   dense
                   color="primary"
                   class="mr-3"
-                  :disabled="filename == ''"
+                  :disabled="filename == '' || definitionFilename == ''"
                   data-test="download-table-binary"
                   @click="downloadBinary(table.name)"
                 >
@@ -193,7 +193,7 @@
                   dense
                   color="primary"
                   class="mr-3"
-                  :disabled="filename == ''"
+                  :disabled="filename == '' || definitionFilename == ''"
                   data-test="download-table-definition"
                   @click="downloadDefinition(table.name)"
                 >
@@ -203,7 +203,7 @@
                 <v-btn
                   dense
                   color="primary"
-                  :disabled="filename == ''"
+                  :disabled="filename == '' || definitionFilename == ''"
                   data-test="download-table-report"
                   @click="downloadReport(table.name)"
                 >

--- a/playwright/tests/table-manager.s.spec.ts
+++ b/playwright/tests/table-manager.s.spec.ts
@@ -256,8 +256,7 @@ test('opens and searches file', async ({ page, utils }) => {
   await expect.poll(() => page.locator('tr').count()).toBe(12)
 })
 
-test('downloads binary, definition, report', async ({ page, utils }) => {
-  test.setTimeout(60 * 1000) // 1 minute
+test('downloads binary and definition and report', async ({ page, utils }) => {
   await page.locator('[data-test=table-manager-file]').click()
   await page.locator('text=Open File').click()
   await openFile(page, utils, 'configtables.bin')

--- a/playwright/tests/table-manager.s.spec.ts
+++ b/playwright/tests/table-manager.s.spec.ts
@@ -12,14 +12,16 @@
 # All Rights Reserved
 */
 
-import { test, expect } from './fixture'
+import type { Page } from '@playwright/test'
+import type { Utilities } from '../utilities'
+import { expect, test } from './fixture'
 
 test.use({
   toolPath: '/tools/tablemanager',
   toolName: 'Table Manager',
 })
 
-async function openFile(page, utils, filename) {
+async function openFile(page: Page, _utils: Utilities, filename: string) {
   await expect(page.locator('.v-dialog')).toBeVisible()
   await expect(page.getByRole('progressbar')).not.toBeVisible()
   await expect(page.getByText('TEMPLATED')).not.toBeVisible()

--- a/playwright/tests/table-manager.s.spec.ts
+++ b/playwright/tests/table-manager.s.spec.ts
@@ -282,7 +282,7 @@ test('downloads binary and definition and report', async ({ page, utils }) => {
     page,
     '[data-test="PPS_SELECTION"] [data-test=download-table-binary]',
     function (contents) {
-      expect(contents.length).toBe(2)
+      expect(contents).toHaveLength(2)
     },
     'binary',
   )

--- a/playwright/tests/table-manager.s.spec.ts
+++ b/playwright/tests/table-manager.s.spec.ts
@@ -262,6 +262,11 @@ test('downloads binary and definition and report', async ({ page, utils }) => {
   await page.locator('[data-test=table-manager-file]').click()
   await page.locator('text=Open File').click()
   await openFile(page, utils, 'configtables.bin')
+  // The definition filename is only populated once the tables/load request
+  // returns. Downloading before then posts an empty definition which errors.
+  await expect(
+    page.locator('[data-test=definition-filename] input'),
+  ).toHaveValue('INST/tables/config/ConfigTables_def.txt')
   await utils.download(page, '[data-test=download-file-binary]')
   await utils.download(
     page,


### PR DESCRIPTION
### What changed

Improvement to test "downloads binary, definition, report" and corresponding `TableManager.vue`

### Why it changed

This test was failing frequently due to buttons in TableManager being enabled before all required values for their click action were populated

### Testing strategy

Playwright test - ran this test 20x locally in Enterprise mode, all passes

### Review notes

Example of a [failing run](https://github.com/OpenC3/cosmos/actions/runs/32585141410)
