### PR TITLE
fix(test): stop test_get_cmd_time flaking on rounding boundaries

### DIFF
--- a/openc3/python/test/script/test_commands.py
+++ b/openc3/python/test/script/test_commands.py
@@ -220,7 +220,10 @@ class TestCommands(unittest.TestCase):
         cmd_time = get_cmd_time("INST", "CLEAR")
         self.assertEqual(cmd_time[0], "INST")
         self.assertEqual(cmd_time[1], "CLEAR")
-        self.assertEqual(f"{cmd_time[2].timestamp():.3f}", f"{gTime:.3f}")
+        # The mock truncates gTime to whole microseconds and datetime rounds
+        # to the nearest microsecond, so compare with a small tolerance
+        # instead of rounded strings which flake on rounding boundaries
+        self.assertAlmostEqual(cmd_time[2].timestamp(), gTime, delta=1e-5)
 
     def test_handles_obfuscation(self):
         global gArgs


### PR DESCRIPTION
## Problem

`test/script/test_commands.py::TestCommands::test_get_cmd_time` fails intermittently in CI:

```
AssertionError: '1787673189.799' != '1787673189.800'
```

Seen in [this run](https://github.com/OpenC3/cosmos/actions/runs/32868403284/job/97869247464) (Python 3.14 unit tests).

## Cause

Test bug, not a product bug. The `Proxy.get_cmd_time` mock truncates `gTime` to whole microseconds when splitting it into `(seconds, microseconds)`, and `get_cmd_time` rebuilds a `datetime` from those parts. The assertion then compared `f"{...:.3f}"` strings of the reconstructed value and the original full-precision `gTime`.

Losing sub-microsecond precision is harmless everywhere except when `gTime` sits on a millisecond rounding boundary (4th decimal digit `5`), where the truncated and original values round in opposite directions. A 200k-iteration simulation of the arithmetic reproduced 110 failures, matching the observed ~0.05% flake rate.

## Fix

Compare the timestamps with a tolerance instead of rounded strings:

```python
self.assertAlmostEqual(cmd_time[2].timestamp(), gTime, delta=1e-5)
```

`1e-5` covers microsecond truncation (1e-6), `datetime` rounding to the nearest microsecond (5e-7), and float epsilon at a 1.8e9 magnitude timestamp (~2.4e-7), while still being 100x tighter than the previous millisecond comparison. The same simulation reports 0 failures with the new assertion.

## Testing

- `uv run pytest test/script/test_commands.py` — 8 passed
- Audited the rest of the Python tests and Ruby specs for the same truncate-then-compare-rounded pattern; the other `get_cmd_time` tests and time-based assertions already use `assertAlmostEqual(delta=...)` or `be_within`, so no other changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)