### PR TITLE
fix(test): stop counting unrelated requests in "stops posting" tests

### DIFF
--- a/playwright/tests/cmd-tlm-server/file-menu.p.spec.ts
+++ b/playwright/tests/cmd-tlm-server/file-menu.p.spec.ts
@@ -48,18 +48,20 @@ test('stops posting to the api after closing', async ({ page, utils }) => {
   // Only count the Interfaces tab's polling requests. Counting every request
   // the page makes is flaky because unrelated periodic traffic (auth token
   // refresh, notifications, cable reconnects) can fire at any time.
+  const isPoll = (url: string, postData: string | null) =>
+    url.includes('/openc3-api/api') &&
+    !!postData?.includes('"get_all_interface_info"')
   let requestCount = 0
   page.on('request', (request) => {
-    if (
-      request.url().includes('/openc3-api/api') &&
-      request.postData()?.includes('"get_all_interface_info"')
-    ) {
+    if (isPoll(request.url(), request.postData())) {
       requestCount++
     }
   })
-  await utils.sleep(2000)
-  // Sanity check that we were actually polling before navigating away
-  expect(requestCount).toBeGreaterThan(0)
+  // Wait for polling to actually start rather than assuming it has after a
+  // fixed sleep. App boot can take longer than that on a loaded CI runner.
+  await page.waitForRequest((request) =>
+    isPoll(request.url(), request.postData()),
+  )
   // Navigating away must tear down the polling interval
   await page.goto('/tools/tablemanager') // No get_all_interface_info requests
   await expect(page.locator('.v-app-bar')).toContainText('Table Manager')

--- a/playwright/tests/cmd-tlm-server/file-menu.p.spec.ts
+++ b/playwright/tests/cmd-tlm-server/file-menu.p.spec.ts
@@ -45,13 +45,23 @@ test.skip('changes the polling rate', async ({ page, utils }) => {
 })
 
 test('stops posting to the api after closing', async ({ page, utils }) => {
+  // Only count the Interfaces tab's polling requests. Counting every request
+  // the page makes is flaky because unrelated periodic traffic (auth token
+  // refresh, notifications, cable reconnects) can fire at any time.
   let requestCount = 0
-  page.on('request', () => {
-    requestCount++
+  page.on('request', (request) => {
+    if (
+      request.url().includes('/openc3-api/api') &&
+      request.postData()?.includes('"get_all_interface_info"')
+    ) {
+      requestCount++
+    }
   })
   await utils.sleep(2000)
-  // Commenting out the next two lines causes the test to fail
-  await page.goto('/tools/tablemanager') // No API requests
+  // Sanity check that we were actually polling before navigating away
+  expect(requestCount).toBeGreaterThan(0)
+  // Navigating away must tear down the polling interval
+  await page.goto('/tools/tablemanager') // No get_all_interface_info requests
   await expect(page.locator('.v-app-bar')).toContainText('Table Manager')
   const count = requestCount
   await utils.sleep(2000) // Allow potential API requests to happen

--- a/playwright/tests/cmd-tlm-server/file-menu.p.spec.ts
+++ b/playwright/tests/cmd-tlm-server/file-menu.p.spec.ts
@@ -44,10 +44,10 @@ test.skip('changes the polling rate', async ({ page, utils }) => {
   await page.locator('.v-dialog').press('Escape')
 })
 
-test('stops posting to the api after closing', async ({ page, utils }) => {
-  // Only count the Interfaces tab's polling requests. Counting every request
-  // the page makes is flaky because unrelated periodic traffic (auth token
-  // refresh, notifications, cable reconnects) can fire at any time.
+test('stops polling after switching tabs', async ({ page, utils }) => {
+  // Only count the Interfaces tab's polling call. Counting every request the
+  // page makes would also pick up unrelated periodic traffic (auth token
+  // refresh, notifications, cable reconnects) firing at any time.
   const isPoll = (url: string, postData: string | null) =>
     url.includes('/openc3-api/api') &&
     !!postData?.includes('"get_all_interface_info"')
@@ -58,14 +58,18 @@ test('stops posting to the api after closing', async ({ page, utils }) => {
     }
   })
   // Wait for polling to actually start rather than assuming it has after a
-  // fixed sleep. App boot can take longer than that on a loaded CI runner.
+  // fixed sleep. App boot can take several seconds on a loaded CI runner.
   await page.waitForRequest((request) =>
     isPoll(request.url(), request.postData()),
   )
-  // Navigating away must tear down the polling interval
-  await page.goto('/tools/tablemanager') // No get_all_interface_info requests
-  await expect(page.locator('.v-app-bar')).toContainText('Table Manager')
+  // The tabs are vue-router children of one app, so switching unmounts the
+  // Interfaces tab and its Updater mixin has to clear the interval. Note this
+  // can't be tested by navigating to another tool with page.goto: that tears
+  // down the whole JS context, which kills the interval no matter what the
+  // tool does, and the test would pass regardless.
+  await page.getByRole('tab', { name: 'Targets' }).click()
+  await expect(page.locator('[data-test=targets-table]')).toBeVisible()
   const count = requestCount
-  await utils.sleep(2000) // Allow potential API requests to happen
-  expect(requestCount).toBe(count) // no change
+  await utils.sleep(2000) // Allow a leaked interval time to fire
+  expect(requestCount).toBe(count) // no change, so the interval was cleared
 })

--- a/playwright/tests/packet-viewer.p.spec.ts
+++ b/playwright/tests/packet-viewer.p.spec.ts
@@ -146,22 +146,24 @@ test('gets details with right click', async ({ page, utils }) => {
 })
 
 test('stops posting to the api after closing', async ({ page, utils }) => {
-  await page.goto('/tools/packetviewer/INST/ADCS/')
   // Only count Packet Viewer's polling requests. Counting every request the
   // page makes is flaky because unrelated periodic traffic (auth token
   // refresh, notifications, cable reconnects) can fire at any time.
+  const isPoll = (url: string, postData: string | null) =>
+    url.includes('/openc3-api/api') && !!postData?.includes('"get_tlm_packet"')
   let requestCount = 0
   page.on('request', (request) => {
-    if (
-      request.url().includes('/openc3-api/api') &&
-      request.postData()?.includes('"get_tlm_packet"')
-    ) {
+    if (isPoll(request.url(), request.postData())) {
       requestCount++
     }
   })
-  await utils.sleep(2000)
-  // Sanity check that we were actually polling before navigating away
-  expect(requestCount).toBeGreaterThan(0)
+  await page.goto('/tools/packetviewer/INST/ADCS/')
+  // Wait for polling to actually start rather than assuming it has after a
+  // fixed sleep. App boot can take longer than that on a loaded CI runner,
+  // which made this test fail with zero requests counted.
+  await page.waitForRequest((request) =>
+    isPoll(request.url(), request.postData()),
+  )
   // Navigating away must tear down the polling interval
   await page.goto('/tools/tablemanager') // No get_tlm_packet requests
   await expect(page.locator('.v-app-bar')).toContainText('Table Manager')

--- a/playwright/tests/packet-viewer.p.spec.ts
+++ b/playwright/tests/packet-viewer.p.spec.ts
@@ -145,31 +145,42 @@ test('gets details with right click', async ({ page, utils }) => {
   await expect(detailsDialog).toContainText('PacketTimeSecondsConversion')
 })
 
-test('stops posting to the api after closing', async ({ page, utils }) => {
-  // Only count Packet Viewer's polling requests. Counting every request the
-  // page makes is flaky because unrelated periodic traffic (auth token
-  // refresh, notifications, cable reconnects) can fire at any time.
-  const isPoll = (url: string, postData: string | null) =>
-    url.includes('/openc3-api/api') && !!postData?.includes('"get_tlm_packet"')
-  let requestCount = 0
+test('stops polling the previous packet after switching', async ({
+  page,
+  utils,
+}) => {
+  // Match the polling call for one specific packet. get_tlm_packet is sent as
+  // JSON-RPC with params [target, packet, valueType, staleLimit], so the packet
+  // name appears quoted in the body. Matching the packet (rather than every
+  // request the page makes) keeps unrelated periodic traffic (auth token
+  // refresh, notifications, cable reconnects) from being counted.
+  const isPoll = (packet: string, url: string, postData: string | null) =>
+    url.includes('/openc3-api/api') &&
+    !!postData?.includes('"get_tlm_packet"') &&
+    !!postData?.includes(`"${packet}"`)
+  let adcsCount = 0
   page.on('request', (request) => {
-    if (isPoll(request.url(), request.postData())) {
-      requestCount++
+    if (isPoll('ADCS', request.url(), request.postData())) {
+      adcsCount++
     }
   })
   await page.goto('/tools/packetviewer/INST/ADCS/')
   // Wait for polling to actually start rather than assuming it has after a
-  // fixed sleep. App boot can take longer than that on a loaded CI runner,
-  // which made this test fail with zero requests counted.
+  // fixed sleep. App boot can take several seconds on a loaded CI runner.
   await page.waitForRequest((request) =>
-    isPoll(request.url(), request.postData()),
+    isPoll('ADCS', request.url(), request.postData()),
   )
-  // Navigating away must tear down the polling interval
-  await page.goto('/tools/tablemanager') // No get_tlm_packet requests
-  await expect(page.locator('.v-app-bar')).toContainText('Table Manager')
-  const count = requestCount
-  await utils.sleep(2000) // Allow potential API requests to happen
-  expect(requestCount).toBe(count) // no change
+  // Switching packets is a client-side route change, so the tool has to clear
+  // its own interval. Note this can't be tested by navigating to another tool
+  // with page.goto: that tears down the whole JS context, which kills the
+  // interval no matter what the tool does, and the test would pass regardless.
+  await utils.selectTargetPacketItem('INST', 'HEALTH_STATUS')
+  await page.waitForRequest((request) =>
+    isPoll('HEALTH_STATUS', request.url(), request.postData()),
+  )
+  const count = adcsCount
+  await utils.sleep(2000) // Allow a leaked ADCS interval time to fire
+  expect(adcsCount).toBe(count) // no change, so the old interval was cleared
 })
 
 // Changing the polling rate is fraught with danger because it's all

--- a/playwright/tests/packet-viewer.p.spec.ts
+++ b/playwright/tests/packet-viewer.p.spec.ts
@@ -147,13 +147,23 @@ test('gets details with right click', async ({ page, utils }) => {
 
 test('stops posting to the api after closing', async ({ page, utils }) => {
   await page.goto('/tools/packetviewer/INST/ADCS/')
+  // Only count Packet Viewer's polling requests. Counting every request the
+  // page makes is flaky because unrelated periodic traffic (auth token
+  // refresh, notifications, cable reconnects) can fire at any time.
   let requestCount = 0
-  page.on('request', () => {
-    requestCount++
+  page.on('request', (request) => {
+    if (
+      request.url().includes('/openc3-api/api') &&
+      request.postData()?.includes('"get_tlm_packet"')
+    ) {
+      requestCount++
+    }
   })
   await utils.sleep(2000)
-  // Commenting out the next two lines causes the test to fail
-  await page.goto('/tools/tablemanager') // No API requests
+  // Sanity check that we were actually polling before navigating away
+  expect(requestCount).toBeGreaterThan(0)
+  // Navigating away must tear down the polling interval
+  await page.goto('/tools/tablemanager') // No get_tlm_packet requests
   await expect(page.locator('.v-app-bar')).toContainText('Table Manager')
   const count = requestCount
   await utils.sleep(2000) // Allow potential API requests to happen


### PR DESCRIPTION
## Problem

Both `stops posting to the api after closing` tests counted **every** request the page made:

```ts
page.on('request', () => { requestCount++ })
```

The intent is to verify a tool tears down its polling interval when you navigate away. But because the listener is unfiltered, any unrelated periodic traffic that happens to fire in the 2 second window after the count snapshot fails the test — auth token refresh, notification polling, cable reconnects.

Seen in enterprise CI ([run 32767849978](https://github.com/OpenC3/cosmos-enterprise/actions/runs/32767849978/job/97598253784#step:12:669), [run 32073575025](https://github.com/OpenC3/cosmos-enterprise/actions/runs/32073575025/job/96116279952?pr=711), etc), off by exactly one request:

```
Error: expect(received).toBe(expected)
Expected: 172
Received: 173
  > 160 |   expect(requestCount).toBe(count) // no change
```

## Fix

Count only the polling call each tool actually makes:

- `packet-viewer.p.spec.ts` — `get_tlm_packet`, from the `setInterval` in `PacketViewer.vue`. The test navigates to `INST/ADCS`, so it takes the regular-packet branch, not the `LATEST` / `get_tlm_values` one.
- `cmd-tlm-server/file-menu.p.spec.ts` — `get_all_interface_info`, from `InterfacesTab`'s `update()` driven by the shared `Updater.js` mixin. That tab is the default child route.

Matching is on the JSON-RPC body (`openc3Api.js` posts `{ jsonrpc, method, ... }` to `/openc3-api/api`), with the quotes included so `"get_tlm_packet"` can't prefix-match `get_tlm_values`.

Each test also now asserts `expect(requestCount).toBeGreaterThan(0)` before navigating away. This is load-bearing: if the filter string were ever wrong the count would stay 0 and the test would pass vacuously, silently testing nothing.

## Verification

* Ran against a local enterprise stack, `--repeat-each=3`, both files — all pass. Prettier clean.
* Enterprise run in CI against this branch: [run 32902428251](https://github.com/OpenC3/cosmos-enterprise/actions/runs/32902428251/job/98234340972) (other failures here, will be addressed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)