### PR TITLE
test(playwright): absorb the Keycloak reload bounce in notification specs

### DIFF
--- a/playwright/tests/notifications.s.spec.ts
+++ b/playwright/tests/notifications.s.spec.ts
@@ -163,15 +163,18 @@ test('yellow limit changes never toast, only show in the menu', async ({
   await expect(yellowToast).toHaveCount(0)
 })
 
-// Reload and wait for the tool to come back. In Enterprise every page load
-// bounces through Keycloak (redirect, token exchange, full app boot) before the
-// message stream resubscribes and replays history - roughly 4s of the budget
-// before any toast can appear. Waiting for the app bar keeps that cost out of
-// the toast assertions below.
+// Reload and wait for the tool to come back before asserting on anything the
+// reloaded app produces. In Enterprise a reload bounces through Keycloak
+// (redirect, token exchange, full app boot) and only then does the message
+// stream resubscribe and replay history. reload() resolves on the load event of
+// the pre-redirect document, so the Keycloak round trip runs *after* it - on a
+// loaded CI runner that round trip alone has taken 20s+ (a locator waiting
+// through it reports "waiting for navigation to finish" and then dies with the
+// element never found). Absorbing it here keeps it out of the toast timeouts.
 async function reloadAndWaitForApp(page) {
-  await page.reload()
+  await page.reload({ waitUntil: 'domcontentloaded' })
   await expect(page.locator('.v-app-bar')).toContainText('Script Runner', {
-    timeout: 30000,
+    timeout: 60000,
   })
 }
 
@@ -299,8 +302,9 @@ test('un-acked alerts survive a page reload (must-ack persists)', async ({
   // Emit, reload (Keycloak round trip plus app boot) and then wait on a stream
   // replay: more sequential waiting than the 60s default allows for, and
   // blowing that cap reports an opaque test timeout instead of naming the
-  // assertion that failed.
-  test.setTimeout(120000)
+  // assertion that failed. Budgeted for the worst case each step is allowed:
+  // 20s emit + 60s reload + 30s replay.
+  test.setTimeout(180000)
   const alertText = 'Playwright reload persist test'
   await runLog(
     page,
@@ -313,6 +317,16 @@ test('un-acked alerts survive a page reload (must-ack persists)', async ({
   // offset past the un-acked alert, otherwise the reload below would drop it.
   await page.locator('[data-test=notifications]').click()
   await page.keyboard.press('Escape')
+
+  // The re-toast only happens if the un-acked alert lowered the persisted
+  // reconnect offset (Notifications.vue persistStreamOffset), so the reloaded
+  // app resubscribes from before it. Check that here: otherwise a regression
+  // in the offset bookkeeping - or a malformed "<ms>-<seq>" id, which makes the
+  // server-side XREAD fail and the stream deliver nothing at all - surfaces
+  // only as a missing toast 30s after the reload.
+  await expect
+    .poll(() => page.evaluate(() => localStorage.notificationStreamOffset))
+    .toMatch(/^\d+-\d+$/)
 
   // After reload the un-acked alert is re-fetched and toasts again. This waits
   // on a stream replay rather than a freshly emitted message, so it gets a
@@ -329,7 +343,7 @@ test('acked alerts stay acked across a reload (no re-toast)', async ({
 }) => {
   // Same reload cost as the test above, plus a second emit-and-toast for the
   // sentinel.
-  test.setTimeout(120000)
+  test.setTimeout(180000)
   const alertText = 'Playwright reload acked test'
   await runLog(
     page,

--- a/playwright/tests/notifications.s.spec.ts
+++ b/playwright/tests/notifications.s.spec.ts
@@ -8,8 +8,9 @@
 # See LICENSE.md for more details.
 */
 
-import { test, expect } from './fixture'
+import type { Browser, Page } from '@playwright/test'
 import { STORAGE_STATE } from './../playwright.config'
+import { expect, test } from './fixture'
 
 // Run inside Script Runner so we can emit log messages from a script. The
 // Notifications toolbar (which shows the toast) is present in every tool.
@@ -22,7 +23,7 @@ test.use({
 })
 
 // Emit a single log message from a running script.
-async function runLog(page, ruby) {
+async function runLog(page: Page, ruby: string) {
   await page.locator('[data-test=script-runner-file]').click()
   await page.locator('text=New File').click()
   // Wait for the Ace editor to mount before filling so its async init doesn't
@@ -36,7 +37,7 @@ async function runLog(page, ruby) {
 // own out-of-limits telemetry (which would raise unrelated limit alerts and
 // pollute the toasts these tests assert on). Runs in its own authenticated
 // context since before/afterAll have no test-scoped page.
-async function setQuiet(browser, baseURL, state) {
+async function setQuiet(browser: Browser, baseURL: string | undefined, state: string) {
   const context = await browser.newContext({ storageState: STORAGE_STATE })
   const page = await context.newPage()
   await page.goto(`${baseURL}/tools/scriptrunner`, {
@@ -69,7 +70,7 @@ test.afterAll(async ({ browser, baseURL }) => {
 
 // Open Notification settings and set a switch to the desired state (only
 // clicking if it isn't already there), then close the dialog.
-async function setSetting(page, dataTest, enable) {
+async function setSetting(page: Page, dataTest: string, enable: boolean) {
   await page.locator('[data-test=notifications]').click()
   await page.locator('[data-test=notification-settings]').click()
   const input = page.locator(`[data-test=${dataTest}] input`)
@@ -87,7 +88,7 @@ async function setSetting(page, dataTest, enable) {
 
 // Open Notification settings and choose the alert popup position ('top' or
 // 'bottom') via its radio group, then close the dialog.
-async function setToastPosition(page, position) {
+async function setToastPosition(page: Page, position: 'top' | 'bottom') {
   await page.locator('[data-test=notifications]').click()
   await page.locator('[data-test=notification-settings]').click()
   const label = position === 'bottom' ? 'Bottom' : 'Top'
@@ -171,7 +172,7 @@ test('yellow limit changes never toast, only show in the menu', async ({
 // loaded CI runner that round trip alone has taken 20s+ (a locator waiting
 // through it reports "waiting for navigation to finish" and then dies with the
 // element never found). Absorbing it here keeps it out of the toast timeouts.
-async function reloadAndWaitForApp(page) {
+async function reloadAndWaitForApp(page: Page) {
   await page.reload({ waitUntil: 'domcontentloaded' })
   await expect(page.locator('.v-app-bar')).toContainText('Script Runner', {
     timeout: 60000,
@@ -179,7 +180,7 @@ async function reloadAndWaitForApp(page) {
 }
 
 // A menu row (v-list-item) for the alert carrying the given text.
-function menuRow(page, text) {
+function menuRow(page: Page, text: string) {
   return page.locator('[data-test=notification-list] .v-list-item', {
     hasText: text,
   })


### PR DESCRIPTION
## Problem

`notifications.s.spec.ts` › `un-acked alerts survive a page reload (must-ack persists)` is flaky on Enterprise CI. Seen in [cosmos-enterprise run 32395585458 (attempt 2)](https://github.com/OpenC3/cosmos-enterprise/actions/runs/32395585458) — it failed, retried, and passed, so the run reported `1 flaky`.

```
Locator: locator('[data-test=toast]').filter({ hasText: 'Playwright reload persist test' })
Expected: visible
Timeout: 20000ms
Error: element(s) not found

Call log:
  - waiting for locator('[data-test=toast]')...
    - waiting for ".../tools/scriptrunner?file=__TEMP__/..." navigation to finish...
    - navigated to ".../tools/scriptrunner?file=...#state=330de028-...&session_state=...&iss=http%3A%2F%2Floca…"
```

## Root cause

Not a product bug, and not slowness in the message-stream replay.

`page.reload()` resolves on the **load event of the pre-redirect document**. In Enterprise, `OpenC3Auth.init()` then kicks off the Keycloak redirect round trip, so that bounce happens *after* `reload()` returns and lands inside whatever assertion comes next. The call log above shows the entire 20s budget spent in "waiting for navigation to finish", with the OIDC callback URL (`#state=…&session_state=…`) arriving at the moment of timeout — leaving zero budget for app boot, cable resubscribe, and stream replay.

The trace from the passing retry confirms the normal path: reload at t=27.6s, toast visible at t=34.9s, i.e. ~7s is needed *after* the bounce completes. The failing screenshot shows the app booted with an empty notification badge — the replay simply hadn't arrived yet.

## Changes

- `reloadAndWaitForApp` reloads with `waitUntil: 'domcontentloaded'` and waits **60s** (was 30s) for the app bar, so the Keycloak bounce is absorbed there instead of eating the toast timeout. The old comment estimated the bounce at "roughly 4s"; the observed CI worst case is 20s+.
- `test.setTimeout` 120000 → 180000 on both reload tests, so the worst case each step is now allowed (20s emit + 60s reload + 30s replay) can't overflow into an opaque test timeout.
- Assert `localStorage.notificationStreamOffset` matches `/^\d+-\d+$/` before the reload. The re-toast depends entirely on that offset having been lowered below the un-acked alert; checking it turns an offset-bookkeeping regression — or a malformed `<ms>-<seq>` id, which makes the server-side `XREAD` fail and deliver nothing at all — into a named failure instead of a missing toast 30s later.

Test-only change; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
