### PR TITLE
3780 script runner file save

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/FileOpenSaveDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/FileOpenSaveDialog.vue
@@ -283,7 +283,12 @@ export default {
         this.selectedFile = null
       } else {
         // Search through items to find the item with id
-        this.selectedFile = this.findItem(this.items, file.id)
+        let path = this.findItem(this.items, file.id)
+        if (this.type === 'save' && path) {
+          // Strip the '*' which only indicates the file is modified on the server
+          path = path.replace(/\*$/, '')
+        }
+        this.selectedFile = path
         // Select the Submit button so return opens the file
         setTimeout(() => {
           this.$refs.submitBtn.$el.focus()

--- a/playwright/tests/script-runner/file-menu.p.spec.ts
+++ b/playwright/tests/script-runner/file-menu.p.spec.ts
@@ -210,6 +210,75 @@ test('handles File Save overwrite', async ({ page, utils }) => {
   await page.locator('button:has-text("Delete")').click()
 })
 
+// TargetFile.all marks a file with a trailing '*' when a targets_modified copy
+// exists alongside the plugin's original. The marker is display-only -- the
+// server strips it back off in TargetFile.body -- so it must never reach the
+// Filename field. TargetFile.create does NOT strip it, so a marker that gets
+// submitted writes a literal '*' object into the bucket that body() then
+// resolves to the unmarked file, silently hiding the saved data.
+test('strips the modified marker on Save As', async ({ page, utils }) => {
+  const original = 'INST/procedures/throughput_test.rb'
+
+  // throughput_test.rb is used by no other spec, and deleting it at the end
+  // removes only the targets_modified copy, restoring the plugin's original.
+  await page.goto(`/tools/scriptrunner?file=${original}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  await expect(page.locator('.v-app-bar')).toContainText('Script Runner')
+  await expect(page.locator('#sr-controls')).toContainText(original)
+
+  // Write a comment to mark the file as modified, then save it so the marker appears in the listing.
+  await page.locator('textarea').fill('# comment2')
+  if (process.platform === 'darwin') {
+    await page.locator('textarea').press('Meta+S') // Ctrl-S save
+  } else {
+    await page.locator('textarea').press('Control+S') // Ctrl-S save
+  }
+  // Wait for save to complete before continuing
+  await expect(page.getByText('Saving...')).not.toBeVisible()
+
+  await page.locator('[data-test=script-runner-file]').click()
+  await page.locator('text=Save As...').click()
+  // The dialog builds its tree from the listing on created(), so wait for every
+  // target to finish loading before reading the field or the tree.
+  await expect(page.getByRole('progressbar')).not.toBeVisible()
+  await expect(
+    page.locator('[data-test=file-open-save-filename] input'),
+  ).toHaveValue(original)
+
+  await page
+    .locator('[data-test=file-open-save-search] input')
+    .fill('throughput_test.rb')
+  // Precondition: without the marker actually present in the tree this test
+  // would pass no matter what the dialog does with it.
+  const marked = page.getByText('throughput_test.rb*', { exact: true })
+  await expect(marked).toBeVisible()
+
+  // Selecting the marked file must fill in the clean path. toHaveValue is an
+  // exact match, so a trailing '*' fails here.
+  await marked.click()
+  await expect(
+    page.locator('[data-test=file-open-save-filename] input'),
+  ).toHaveValue(original)
+
+  // And the overwrite confirmation quotes the clean path, not the marked one
+  await page.locator('[data-test=file-open-save-submit-btn]').click()
+  await expect(page.getByText(`overwrite: ${original}`)).toBeVisible()
+  await page.locator('button:has-text("Overwrite")').click()
+
+  await expect(
+    page.getByRole('dialog').filter({ hasText: 'File Save As...' }),
+  ).not.toBeVisible()
+  await expect(page.getByText('Saving...')).not.toBeVisible()
+  await expect(page.locator('#sr-controls')).toContainText(original)
+
+  // Delete the targets_modified copy so the plugin's original is restored
+  await page.locator('[data-test=script-runner-file]').click()
+  await page.locator('text=Delete File').click()
+  await expect(page.locator('text=Permanently delete file')).toBeVisible()
+  await page.locator('button:has-text("Delete")').click()
+})
+
 test('handles Download', async ({ page, utils }) => {
   await page.locator('textarea').fill('download this')
   await page.locator('[data-test=script-runner-file]').click()

--- a/playwright/tests/table-manager.s.spec.ts
+++ b/playwright/tests/table-manager.s.spec.ts
@@ -232,6 +232,58 @@ test('edits a binary file', async ({ page, utils }) => {
   )
 })
 
+// Table Manager is the tool where a leaked modified marker actually corrupts data:
+// saveAsFilename passes the field straight to PUT /openc3-api/tables/.../save-as,
+// and nothing on that path (sanitize_params, Table.save_as, TargetFile.create)
+// strips a trailing '*'. The result is a literal '*' object in the bucket which
+// TargetFile.body then resolves back to the unmarked file, so the saved table is
+// written and immediately unreachable.
+test('strips the modified marker on Save As', async ({ page, utils }) => {
+  const binary = 'INST/tables/bin/ConfigTables.bin'
+
+  await page.locator('[data-test=table-manager-file]').click()
+  await page.locator('text=Open File').click()
+  await openFile(page, utils, 'configtables.bin')
+  // The definition filename only lands once tables/load returns, and Save File
+  // posts it, so wait for it rather than saving an empty definition.
+  await expect(
+    page.locator('[data-test=definition-filename] input'),
+  ).toHaveValue('INST/tables/config/ConfigTables_def.txt')
+
+  // Save so the binary exists in both targets/ and targets_modified/, the only
+  // state that makes the listing append the marker. Done here rather than
+  // relying on the earlier edit test so this test stands on its own.
+  await page.locator('[data-test=table-manager-file]').click()
+  await page.locator('text=Save File').click()
+  await utils.sleep(5000) // Saving takes some time
+
+  await page.locator('[data-test=table-manager-file]').click()
+  await page.locator('text=Save As').click()
+  await expect(page.locator('.v-dialog')).toBeVisible()
+  await expect(page.getByRole('progressbar')).not.toBeVisible()
+  await expect(page.getByText('TEMPLATED')).not.toBeVisible()
+  await page
+    .locator('[data-test=file-open-save-search] input')
+    .fill('configtables.bin')
+
+  // Precondition: without the marker actually present in the tree this test
+  // would pass no matter what the dialog does with it. Only INST is edited by
+  // this spec, so INST2's copy of the same filename stays unmarked.
+  const marked = page.getByText('ConfigTables.bin*', { exact: true })
+  await expect(marked).toBeVisible()
+
+  // toHaveValue is an exact match, so a trailing '*' fails here
+  await marked.click()
+  await expect(
+    page.locator('[data-test=file-open-save-filename] input'),
+  ).toHaveValue(binary)
+
+  await page.locator('[data-test=file-open-save-cancel-btn]').click()
+  await expect(
+    page.getByRole('dialog').filter({ hasText: 'File Save As...' }),
+  ).not.toBeVisible()
+})
+
 test('opens and searches file', async ({ page, utils }) => {
   await page.locator('[data-test=table-manager-file]').click()
   await page.locator('text=Open File').click()


### PR DESCRIPTION
closes https://github.com/OpenC3/cosmos/issues/3780
### What changed

Strips the `*` from the file name when saving a file under a previously modified file

### Why it changed

The `*` should only be a visual indication of the file being modified from the original. Not removing the * from the file name when attempting to "Save As" blocks the user from saving the file. 
https://github.com/OpenC3/cosmos/issues/3780

### Testing strategy

Added playwright tests and confirmed fix manually

### Review notes

Seems like there's a disparate approach to trailing `*` in file names between the ScriptRunner and the TableManager, despite their shared use of `FileOpenSaveDialog.vue`. The `table-manager.s.spec.ts` playwright test helps confirm that this bug fix doesn't change its behavior
