### PR TITLE
Bump setup-uv to 9.0.0

### DIFF
--- a/.github/workflows/api_tests.yml
+++ b/.github/workflows/api_tests.yml
@@ -155,9 +155,10 @@ jobs:
         # with:
         #   fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          enable-cache: true
+          version: "0.11.33" # Matches UV_VERSION in openc3-ruby/Dockerfile
+          enable-cache: auto
           cache-suffix: ${{ matrix.python-version }}
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/api_tests.yml
+++ b/.github/workflows/api_tests.yml
@@ -155,7 +155,7 @@ jobs:
         # with:
         #   fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
           cache-suffix: ${{ matrix.python-version }}

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
           working-directory: openc3/python

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -45,9 +45,10 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          enable-cache: true
+          version: "0.11.33" # Matches UV_VERSION in openc3-ruby/Dockerfile
+          enable-cache: auto
           working-directory: openc3/python
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -49,10 +49,10 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.10.4"
-          enable-cache: true
+          version: "0.11.33" # Matches UV_VERSION in openc3-ruby/Dockerfile
+          enable-cache: auto
           cache-suffix: ${{ matrix.python-version }}
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.10.4"
           enable-cache: true

--- a/.github/workflows/tsdb_integration_tests.yml
+++ b/.github/workflows/tsdb_integration_tests.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/tsdb_integration_tests.yml
+++ b/.github/workflows/tsdb_integration_tests.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          enable-cache: true
+          version: "0.11.33" # Matches UV_VERSION in openc3-ruby/Dockerfile
+          enable-cache: auto
 
       - name: Set up Python
         run: uv python install

--- a/openc3-ruby/Dockerfile
+++ b/openc3-ruby/Dockerfile
@@ -15,6 +15,7 @@ ARG APT_URL=http://deb.debian.org
 ARG PYTHON_VERSION=3.13
 ARG RUBYGEMS_URL
 ARG PYPI_URL=https://pypi.org
+# Update Dockerfile-ubi and the python .github/workflow actions to match this version
 ARG UV_VERSION=0.11.33
 
 ENV APT_URL=${APT_URL}

--- a/openc3-ruby/Dockerfile-ubi
+++ b/openc3-ruby/Dockerfile-ubi
@@ -11,6 +11,7 @@ USER root
 ARG RUBYGEMS_URL=https://rubygems.org
 ENV RUBYGEMS_URL=${RUBYGEMS_URL}
 ARG PYPI_URL=https://pypi.org
+# Update Dockerfile and the python .github/workflow actions to match this version
 ARG UV_VERSION=0.11.33
 ENV PYPI_URL=${PYPI_URL}
 ENV UV_VERSION=${UV_VERSION}


### PR DESCRIPTION
### What changed

Bump setup-uv github action to latest

### Why it changed

[v9.0.0 Release Notes](https://github.com/astral-sh/setup-uv/releases/tag/v9.0.0)

### Testing strategy

CI