### PR TITLE
Improve interface details

### DIFF
--- a/docs.openc3.com/docs/configuration/interfaces.md
+++ b/docs.openc3.com/docs/configuration/interfaces.md
@@ -808,11 +808,12 @@ Interfaces also have the following methods that exist and have default implement
 1. **read** - Read the next packet from the interface. COSMOS implements this method to allow the Protocol system to operate on the data and the packet before it is returned.
 1. **write** - Send a packet to the interface. COSMOS implements this method to allow the Protocol system to operate on the packet and the data before it is sent.
 1. **write_raw** - Send a raw binary string of data to the target. COSMOS implements this method by basically calling write_interface with the raw data.
+1. **details** - Return a hash of interface information displayed by the Interfaces tool details dialog. COSMOS implements this method to return the built-in interface state (target names, connection options, counters, raw data, etc). Override it and merge additional keys into super() to display interface specific values.
 
 :::info[Stored Telemetry]
 Custom interfaces that read non-realtime data (e.g. recorded files, back-orbit data, or store-and-forward playback) should set `packet.stored = true` on telemetry packets before returning them. Stored packets are fully processed through the COSMOS pipeline (identification, decommutation, logging) but do **not** update the Current Value Table (CVT). This prevents historical data from overwriting real-time values in displays like Packet Viewer and Telemetry Viewer. See the [File Interface](#file-interface) for a built-in example of this behavior. Also see [Stored Packets](../guides/packet-types#stored-packets) for more details.
 :::
 
 :::warning[Naming Conventions]
-When creating your own interfaces, in most cases they will be subclasses of one of the built-in interfaces described below. It is important to know that both the filename and class name of the interface files must match with correct capitalization or you will receive "class not found" errors when trying to load your new interface. For example, an interface file called labview_interface.rb must contain the class LabviewInterface. If the class was named, LabVIEWInterface, for example, COSMOS would not be able to find the class because of the unexpected capitalization.
+When creating your own interfaces, in most cases they will be subclasses of one of the built-in interfaces described above. It is important to know that both the filename and class name of the interface files must match with correct capitalization or you will receive "class not found" errors when trying to load your new interface. For example, an interface file called labview_interface.rb must contain the class LabviewInterface. If the class was named, LabVIEWInterface, for example, COSMOS would not be able to find the class because of the unexpected capitalization.
 :::

--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -6380,7 +6380,7 @@ interface_target_disable("INST_INT", "INST", tlm_only: true)
 
 <span class="badge badge--secondary since-heading">Since 6.9.0</span>
 
-Get details on the interface and its protocols.
+Get details on the interface and its protocols. Unlike [get_interface](#get_interface), which returns the stored interface model, `interface_details` queries the running interface microservice and returns its live runtime state, including the most recent raw data read and written and the state of every read and write protocol.
 
 <Tabs groupId="script-language">
 <TabItem value="python" label="Python Syntax">
@@ -6408,7 +6408,24 @@ interface_details("<Interface Name>")
 <TabItem value="python" label="Python Example">
 
 ```python
-interface_details("INST_INT")
+details = interface_details("INST_INT")
+print(details["state"])
+# CONNECTED
+print(details["cmd_target_enabled"])
+# {'INST': True}
+print(details["hostname"], details["write_port"], details["read_port"])
+# host.docker.internal 8080 8081
+print([protocol["name"] for protocol in details["read_protocols"]])
+# ['BurstProtocol']
+print(details["read_protocols"][0]["discard_leading_bytes"])
+# 0
+
+# Raw data arrives as a json_class dict when it is not printable text
+raw = details["read_raw_data"]
+if isinstance(raw, dict):
+    raw = bytes(raw["raw"])
+print(raw)
+# b'\x00\x01\x02\x03'
 ```
 
 </TabItem>
@@ -6416,11 +6433,222 @@ interface_details("INST_INT")
 <TabItem value="ruby" label="Ruby Example">
 
 ```ruby
-interface_details("INST_INT")
+details = interface_details("INST_INT")
+puts details['state']
+# CONNECTED
+puts details['cmd_target_enabled']
+# {"INST"=>true}
+puts "#{details['hostname']} #{details['write_port']} #{details['read_port']}"
+# host.docker.internal 8080 8081
+puts details['read_protocols'].map { |protocol| protocol['name'] }
+# BurstProtocol
+puts details['read_protocols'][0]['discard_leading_bytes']
+# 0
+puts details['read_raw_data'].formatted
+# 00000000: 00 01 02 03
 ```
 
 </TabItem>
 </Tabs>
+
+**Return Value**
+
+Returns a hash / dict of the interface state. The following keys are always present for every interface type.
+
+<Tabs groupId="common">
+<TabItem value="Status">
+| Key     | Type    | Description                                                       |
+| ------- | ------- | ----------------------------------------------------------------- |
+| name    | String  | Interface name, e.g. "INST_INT"                                   |
+| state   | String  | "CONNECTED", "ATTEMPTING", or "DISCONNECTED"                      |
+| clients | Integer | Number of connected clients (server interfaces only, otherwise 0) |
+| txsize  | Integer | Number of packets currently queued to be written                  |
+| rxsize  | Integer | Number of packets currently queued to be read                     |
+| txbytes | Integer | Running total of bytes written to the interface                   |
+| rxbytes | Integer | Running total of bytes read from the interface                    |
+| txcnt   | Integer | Running total of packets written to the interface                 |
+| rxcnt   | Integer | Running total of packets read from the interface                  |
+</TabItem>
+<TabItem value="Configuration">
+| Key                | Type    | Description                                                                     |
+| ------------------ | ------- | ------------------------------------------------------------------------------- |
+| cmd_target_names   | Array   | Names of the targets mapped to this interface for commanding                    |
+| tlm_target_names   | Array   | Names of the targets mapped to this interface for telemetry                     |
+| cmd_target_enabled | Hash    | Target name to boolean, see [interface_target_enable](#interface_target_enable) |
+| tlm_target_enabled | Hash    | Target name to boolean, see [interface_target_enable](#interface_target_enable) |
+| connect_on_startup | Boolean | Whether the interface connects when the microservice starts                     |
+| auto_reconnect     | Boolean | Whether the interface reconnects after a disconnect                             |
+| reconnect_delay    | Float   | Seconds to wait between reconnect attempts                                      |
+| disable_disconnect | Boolean | Whether the Disconnect button is disabled in CmdTlmServer                       |
+| read_allowed       | Boolean | Whether reading telemetry is allowed                                            |
+| write_allowed      | Boolean | Whether writing commands is allowed                                             |
+| write_raw_allowed  | Boolean | Whether writing raw data is allowed                                             |
+| options            | Hash    | Uppercased option name to option values, as set by the OPTION keyword           |
+| stream_log         | Boolean | Whether stream (raw) logging is currently enabled                               |
+</TabItem>
+<TabItem value="Raw data">
+| Key                   | Type          | Description                                                         |
+| --------------------- | ------------- | ------------------------------------------------------------------- |
+| read_raw_data         | String        | Most recent data read from the interface                            |
+| read_raw_data_time    | String or nil | Timestamp of the most recent read, nil if nothing has been read     |
+| written_raw_data      | String        | Most recent data written to the interface                           |
+| written_raw_data_time | String or nil | Timestamp of the most recent write, nil if nothing has been written |
+</TabItem>
+<TabItem value="Protocol">
+| Key             | Type  | Description                                                              |
+| --------------- | ----- | ------------------------------------------------------------------------ |
+| read_protocols  | Array | One hash / dict per read protocol, in the order data flows through them  |
+| write_protocols | Array | One hash / dict per write protocol, in the order data flows through them |
+
+
+Every entry in `read_protocols` and `write_protocols` contains the protocol class name plus the data flowing into and out of that protocol. Entries in `read_protocols` use the `read_` prefixed keys, entries in `write_protocols` use the `write_` prefixed keys.
+
+| Key                    | Type          | Description                               |
+| ---------------------- | ------------- | ----------------------------------------- |
+| name                   | String        | Protocol class name, e.g. "BurstProtocol" |
+| read_data_input        | String        | Data passed into the read protocol        |
+| read_data_input_time   | String or nil | Timestamp the read input was captured     |
+| read_data_output       | String        | Data returned by the read protocol        |
+| read_data_output_time  | String or nil | Timestamp the read output was captured    |
+| write_data_input       | String        | Data passed into the write protocol       |
+| write_data_input_time  | String or nil | Timestamp the write input was captured    |
+| write_data_output      | String        | Data returned by the write protocol       |
+| write_data_output_time | String or nil | Timestamp the write output was captured   |
+
+Each protocol also adds keys for its own configuration. Protocols inherit their parent protocol's keys, so for example a `LengthProtocol` entry contains the `BurstProtocol` keys as well.
+
+| Protocol              | Inherits   | Additional read keys                                                                                                                                                                           | Additional write keys                                                                                                                                                                          |
+| --------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BurstProtocol         | —          | discard_leading_bytes, sync_pattern, fill_fields                                                                                                                                               | discard_leading_bytes, sync_pattern, fill_fields                                                                                                                                               |
+| CrcProtocol           | —          | strip_crc, bad_strategy, endianness, bit_offset, bit_size                                                                                                                                      | write_item_name, endianness, bit_offset, bit_size                                                                                                                                              |
+| CmdResponseProtocol   | —          | response_packet, response_timeout, response_polling_period, raise_exceptions                                                                                                                   | response_packet, response_timeout, response_polling_period, raise_exceptions                                                                                                                   |
+| IgnorePacketProtocol  | —          | target_name, packet_name                                                                                                                                                                       | target_name, packet_name                                                                                                                                                                       |
+| FixedProtocol         | Burst      | min_id_size, telemetry, unknown_raise                                                                                                                                                          | min_id_size, telemetry, unknown_raise                                                                                                                                                          |
+| LengthProtocol        | Burst      | length_bit_offset, length_bit_size, length_value_offset, length_bytes_per_count, length_endianness, length_bytes_needed, max_length                                                            | length_bit_offset, length_bit_size, length_value_offset, length_bytes_per_count, length_endianness, length_bytes_needed, max_length                                                            |
+| PreidentifiedProtocol | Burst      | max_length, reduction_state                                                                                                                                                                    | max_length                                                                                                                                                                                     |
+| TerminatedProtocol    | Burst      | read_termination_characters, strip_read_termination                                                                                                                                            | write_termination_characters                                                                                                                                                                   |
+| SlipProtocol          | Terminated | start_char, end_char, esc_char, esc_end_char, esc_esc_char, read_strip_characters, read_enable_escaping                                                                                        | start_char, end_char, esc_char, esc_end_char, esc_esc_char, write_enable_escaping                                                                                                              |
+| TemplateProtocol      | Terminated | response_template, response_packet, response_target_name, response_lines, response_timeout, response_polling_period, ignore_lines, initial_read_delay, connect_complete_time, raise_exceptions | response_template, response_packet, response_target_name, response_lines, response_timeout, response_polling_period, ignore_lines, initial_read_delay, connect_complete_time, raise_exceptions |
+</TabItem>
+</Tabs>
+
+Each interface type adds its own keys on top of the common keys above. The values mirror the interface's configuration parameters documented in the [Interfaces](/docs/configuration/interfaces.md) guide.
+
+<Tabs groupId="interfaces">
+<TabItem value="TcpipClientInterface">
+| Key           | Type    | Description                                    |
+| ------------- | ------- | ---------------------------------------------- |
+| hostname      | String  | Host the interface connects to                 |
+| write_port    | Integer | Port used to write commands                    |
+| read_port     | Integer | Port used to read telemetry                    |
+| write_timeout | Float   | Seconds to wait for a write                    |
+| read_timeout  | Float   | Seconds to wait for a read, nil for no timeout |
+</TabItem>
+<TabItem value="TcpipServerInterface">
+| Key            | Type    | Description                                    |
+| -------------- | ------- | ---------------------------------------------- |
+| write_port     | Integer | Port clients connect to for commands           |
+| read_port      | Integer | Port clients connect to for telemetry          |
+| write_timeout  | Float   | Seconds to wait for a write                    |
+| read_timeout   | Float   | Seconds to wait for a read, nil for no timeout |
+| listen_address | String  | Address the server binds to                    |
+</TabItem>
+<TabItem value="UdpInterface">
+| Key               | Type    | Description                                    |
+| ----------------- | ------- | ---------------------------------------------- |
+| hostname          | String  | Host to write to                               |
+| write_dest_port   | Integer | Destination port for writes                    |
+| read_port         | Integer | Port to read from                              |
+| write_src_port    | Integer | Source port for writes                         |
+| interface_address | String  | Multicast interface address                    |
+| ttl               | Integer | Time to live for multicast writes              |
+| write_timeout     | Float   | Seconds to wait for a write                    |
+| read_timeout      | Float   | Seconds to wait for a read, nil for no timeout |
+| bind_address      | String  | Address to bind the read socket to             |
+</TabItem>
+<TabItem value="SerialInterface">
+| Key             | Type    | Description                                    |
+| --------------- | ------- | ---------------------------------------------- |
+| write_port_name | String  | Serial port used to write, nil if write only   |
+| read_port_name  | String  | Serial port used to read, nil if read only     |
+| baud_rate       | Integer | Baud rate                                      |
+| parity          | String  | "NONE", "EVEN", or "ODD"                       |
+| stop_bits       | Integer | Number of stop bits                            |
+| data_bits       | Integer | Number of data bits                            |
+| flow_control    | String  | "NONE" or "RTSCTS"                             |
+| write_timeout   | Float   | Seconds to wait for a write                    |
+| read_timeout    | Float   | Seconds to wait for a read, nil for no timeout |
+</TabItem>
+<TabItem value="FileInterface">
+| Key                       | Type    | Description                                             |
+| ------------------------- | ------- | ------------------------------------------------------- |
+| command_write_folder      | String  | Folder commands are written to                          |
+| telemetry_read_folder     | String  | Folder telemetry files are read from                    |
+| telemetry_archive_folder  | String  | Folder read files are moved to, "DELETE" to delete them |
+| file_read_size            | Integer | Bytes read from the file at a time                      |
+| stored                    | Boolean | Whether packets are marked as stored                    |
+| filename                  | String  | File currently being read, empty if none                |
+| extension                 | String  | Extension of files to read                              |
+| label                     | String  | Label prefix applied to written command files           |
+| queue_length              | Integer | Number of files queued to be read                       |
+| polling                   | Boolean | Whether the folder is polled instead of watched         |
+| recursive                 | Boolean | Whether the read folder is searched recursively         |
+| throttle                  | Integer | Bytes per second read throttle, nil for unthrottled     |
+| discard_file_header_bytes | Integer | Bytes discarded from the front of each file             |
+</TabItem>
+<TabItem value="MqttInterface">
+| Key                   | Type    | Description                                                   |
+| --------------------- | ------- | ------------------------------------------------------------- |
+| hostname              | String  | MQTT broker host                                              |
+| port                  | Integer | MQTT broker port                                              |
+| ssl                   | Boolean | Whether TLS is used                                           |
+| ack_timeout           | Float   | Seconds to wait for a broker acknowledgement                  |
+| username              | String  | Username, nil if unauthenticated                              |
+| password              | String  | "Set" if a password is configured, otherwise absent           |
+| cert                  | String  | "Set" if a client certificate is configured, otherwise absent |
+| key                   | String  | "Set" if a client key is configured, otherwise absent         |
+| ca_file               | String  | "Set" if a CA file is configured, otherwise absent            |
+| read_packets_by_topic | Hash    | MQTT topic to the target and packet name it maps to           |
+</TabItem>
+<TabItem value="MqttStreamInterface">
+Same as MqttInterface except `read_packets_by_topic` is replaced by:
+
+| Key         | Type   | Description                     |
+| ----------- | ------ | ------------------------------- |
+| write_topic | String | Topic commands are published to |
+| read_topic  | String | Topic telemetry is read from    |
+</TabItem>
+<TabItem value="HttpClientInterface">
+| Key                         | Type    | Description                                            |
+| --------------------------- | ------- | ------------------------------------------------------ |
+| url                         | String  | Base URL requests are sent to                          |
+| write_timeout               | Float   | Seconds to wait for a write                            |
+| read_timeout                | Float   | Seconds to wait for a read, nil for no timeout         |
+| connect_timeout             | Float   | Seconds to wait for the connection                     |
+| include_request_in_response | Boolean | Whether the request is included in the response packet |
+| response_queue_length       | Integer | Number of responses queued to be read                  |
+</TabItem>
+<TabItem value="HttpServerInterface">
+| Key                  | Type    | Description                          |
+| -------------------- | ------- | ------------------------------------ |
+| listen_address       | String  | Address the server binds to          |
+| port                 | Integer | Port the server listens on           |
+| request_queue_length | Integer | Number of requests queued to be read |
+</TabItem>
+</Tabs>
+
+
+:::note[Timestamp Formats]
+All timestamp strings are ISO 8601 in UTC with microsecond precision, e.g. `2026-08-26T16:15:30.123456Z`. The format is the same whether the interface is implemented in Ruby or Python.
+:::
+
+:::note[Binary Data]
+The raw data and protocol data values hold the actual bytes that crossed the interface. Data which is not printable text is encoded on the wire as `{"json_class": "String", "raw": [<byte values>]}`. Ruby scripts receive this decoded back into a binary String. Python scripts receive the dict as-is, so convert it with `bytes(value["raw"])` before using it.
+:::
+
+:::note[Disconnect Mode]
+`interface_details` is not on the read-only allowlist used by [disconnect_script](#disconnect_script), so it returns `None` (Python) or `nil` (Ruby) when running in disconnect mode.
+:::
 
 ## Routers
 

--- a/openc3/lib/openc3/interfaces/interface.rb
+++ b/openc3/lib/openc3/interfaces/interface.rb
@@ -677,12 +677,12 @@ module OpenC3
       result['read_raw_data'] = @read_raw_data
       result['written_raw_data'] = @written_raw_data
       if @read_raw_data_time
-        result['read_raw_data_time'] = @read_raw_data_time.iso8601
+        result['read_raw_data_time'] = @read_raw_data_time.getutc.iso8601(6)
       else
         result['read_raw_data_time'] = nil
       end
       if @written_raw_data_time
-        result['written_raw_data_time'] = @written_raw_data_time.iso8601
+        result['written_raw_data_time'] = @written_raw_data_time.getutc.iso8601(6)
       else
         result['written_raw_data_time'] = nil
       end

--- a/openc3/lib/openc3/interfaces/protocols/protocol.rb
+++ b/openc3/lib/openc3/interfaces/protocols/protocol.rb
@@ -131,13 +131,13 @@ module OpenC3
     def write_details
       result = {'name' => self.class.name.to_s.split("::")[-1]}
       if @write_data_input_time
-        result['write_data_input_time'] = @write_data_input_time.iso8601
+        result['write_data_input_time'] = @write_data_input_time.getutc.iso8601(6)
       else
         result['write_data_input_time'] = nil
       end
       result['write_data_input'] = @write_data_input
       if @write_data_output_time
-        result['write_data_output_time'] = @write_data_output_time.iso8601
+        result['write_data_output_time'] = @write_data_output_time.getutc.iso8601(6)
       else
         result['write_data_output_time'] = nil
       end
@@ -148,13 +148,13 @@ module OpenC3
     def read_details
       result = {'name' => self.class.name.to_s.split("::")[-1]}
       if @read_data_input_time
-        result['read_data_input_time'] = @read_data_input_time.iso8601
+        result['read_data_input_time'] = @read_data_input_time.getutc.iso8601(6)
       else
         result['read_data_input_time'] = nil
       end
       result['read_data_input'] = @read_data_input
       if @read_data_output_time
-        result['read_data_output_time'] = @read_data_output_time.iso8601
+        result['read_data_output_time'] = @read_data_output_time.getutc.iso8601(6)
       else
         result['read_data_output_time'] = nil
       end

--- a/openc3/lib/openc3/interfaces/protocols/template_protocol.rb
+++ b/openc3/lib/openc3/interfaces/protocols/template_protocol.rb
@@ -266,7 +266,7 @@ module OpenC3
       result['response_timeout'] = @response_timeout
       result['response_polling_period'] = @response_polling_period
       if @connect_complete_time
-        result['connect_complete_time'] = @connect_complete_time.iso8601
+        result['connect_complete_time'] = @connect_complete_time.getutc.iso8601(6)
       else
         result['connect_complete_time'] = nil
       end
@@ -285,7 +285,7 @@ module OpenC3
       result['response_timeout'] = @response_timeout
       result['response_polling_period'] = @response_polling_period
       if @connect_complete_time
-        result['connect_complete_time'] = @connect_complete_time.iso8601
+        result['connect_complete_time'] = @connect_complete_time.getutc.iso8601(6)
       else
         result['connect_complete_time'] = nil
       end

--- a/openc3/lib/openc3/microservices/interface_microservice.rb
+++ b/openc3/lib/openc3/microservices/interface_microservice.rb
@@ -221,7 +221,12 @@ module OpenC3
               next 'SUCCESS'
             end
             if msg_hash.key?('interface_details')
-              next @interface.details.as_json.to_json(allow_nan: true)
+              begin
+                next @interface.details.as_json.to_json(allow_nan: true)
+              rescue => e
+                @logger.error "#{@interface.name}: interface_details: #{e.formatted}"
+                next e.message
+              end
             end
           end
 
@@ -508,7 +513,12 @@ module OpenC3
             next 'SUCCESS'
           end
           if msg_hash.key?('router_details')
-            next @router.details.as_json.to_json(allow_nan: true)
+            begin
+              next @router.details.as_json.to_json(allow_nan: true)
+            rescue => e
+              @logger.error "#{@router.name}: router_details: #{e.formatted}"
+              next e.message
+            end
           end
           next 'SUCCESS'
         end

--- a/openc3/lib/openc3/topics/interface_topic.rb
+++ b/openc3/lib/openc3/topics/interface_topic.rb
@@ -212,7 +212,12 @@ module OpenC3
       while (Time.now - time) < timeout
         Topic.read_topics([ack_topic], db_shard: db_shard) do |_topic, _msg_id, msg_hash, _redis|
           if msg_hash["id"] == cmd_id
-            return JSON.parse(msg_hash["result"], :allow_nan => true, :create_additions => true)
+            begin
+              return JSON.parse(msg_hash["result"], :allow_nan => true, :create_additions => true)
+            rescue JSON::ParserError
+              # The microservice returns a plain error message rather than JSON if details raises
+              raise "interface_details failed: #{msg_hash['result']}"
+            end
           end
         end
       end

--- a/openc3/lib/openc3/topics/router_topic.rb
+++ b/openc3/lib/openc3/topics/router_topic.rb
@@ -170,7 +170,12 @@ module OpenC3
       while (Time.now - time) < timeout
         Topic.read_topics([ack_topic], db_shard: db_shard) do |_topic, _msg_id, msg_hash, _redis|
           if msg_hash["id"] == cmd_id
-            return JSON.parse(msg_hash["result"], :allow_nan => true, :create_additions => true)
+            begin
+              return JSON.parse(msg_hash["result"], :allow_nan => true, :create_additions => true)
+            rescue JSON::ParserError
+              # The microservice returns a plain error message rather than JSON if details raises
+              raise "router_details failed: #{msg_hash['result']}"
+            end
           end
         end
       end

--- a/openc3/python/openc3/interfaces/interface.py
+++ b/openc3/python/openc3/interfaces/interface.py
@@ -33,6 +33,9 @@ class WriteRejectError(RuntimeError):
 class Interface:
     """Defines all the attributes and methods common to all interface classes used by OpenC3."""
 
+    # Matches the Ruby Time#iso8601(6) output format so details() is identical in both languages
+    DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
     # Initialize default attribute values
     def __init__(self):
         self.state = "DISCONNECTED"
@@ -530,11 +533,11 @@ class Interface:
         result["read_raw_data"] = self.read_raw_data
         result["written_raw_data"] = self.written_raw_data
         if self.read_raw_data_time is not None:
-            result["read_raw_data_time"] = self.read_raw_data_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            result["read_raw_data_time"] = self.read_raw_data_time.strftime(self.DATETIME_FORMAT)
         else:
             result["read_raw_data_time"] = None
         if self.written_raw_data_time is not None:
-            result["written_raw_data_time"] = self.written_raw_data_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            result["written_raw_data_time"] = self.written_raw_data_time.strftime(self.DATETIME_FORMAT)
         else:
             result["written_raw_data_time"] = None
 

--- a/openc3/python/openc3/interfaces/protocols/protocol.py
+++ b/openc3/python/openc3/interfaces/protocols/protocol.py
@@ -19,6 +19,7 @@ from openc3.config.config_parser import ConfigParser
 # Base class for all OpenC3 protocols which defines a framework which must be
 # implemented by a subclass.
 class Protocol:
+    # Matches the Ruby Time#iso8601(6) output format so details() is identical in both languages
     DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     # self.param allow_empty_data [True/False/None] Whether or not this protocol will allow an empty string

--- a/openc3/python/openc3/interfaces/protocols/template_protocol.py
+++ b/openc3/python/openc3/interfaces/protocols/template_protocol.py
@@ -283,7 +283,7 @@ class TemplateProtocol(TerminatedProtocol):
         result["response_polling_period"] = self.response_polling_period
         if self.connect_complete_time:
             result["connect_complete_time"] = datetime.fromtimestamp(self.connect_complete_time, timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%S.%fZ"
+                self.DATETIME_FORMAT
             )
         else:
             result["connect_complete_time"] = None
@@ -302,7 +302,7 @@ class TemplateProtocol(TerminatedProtocol):
         result["response_polling_period"] = self.response_polling_period
         if self.connect_complete_time:
             result["connect_complete_time"] = datetime.fromtimestamp(self.connect_complete_time, timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%S.%fZ"
+                self.DATETIME_FORMAT
             )
         else:
             result["connect_complete_time"] = None

--- a/openc3/python/openc3/microservices/interface_microservice.py
+++ b/openc3/python/openc3/microservices/interface_microservice.py
@@ -79,7 +79,7 @@ class InterfaceCmdHandlerThread:
             self.metric.set(name="interface_cmd_total", value=self.count, type="counter")
 
     def start(self):
-        self.thread = threading.Thread(target=self.run, daemon=True)
+        self.thread = threading.Thread(target=self.run_thread_body, daemon=True)
         self.thread.start()
         ThreadManager.instance().register(self.thread, stop_object=self)
         return self.thread
@@ -90,6 +90,15 @@ class InterfaceCmdHandlerThread:
     def graceful_kill(self):
         InterfaceTopic.shutdown(self.interface, scope=self.scope)
         time.sleep(0.001)  # Allow other threads to run
+
+    # Log why the thread died before letting the exception take down the microservice.
+    # ThreadManager treats a dead handler thread as fatal so the exception is re-raised.
+    def run_thread_body(self):
+        try:
+            self.run()
+        except Exception:
+            self.logger.error(f"{self.interface.name}: Command handler thread died: {traceback.format_exc()}")
+            raise
 
     def run(self):
         # receive_commands does a while True and does not return
@@ -264,7 +273,13 @@ class InterfaceCmdHandlerThread:
                     return str(e)
                 return "SUCCESS"
             if msg_hash.get(b"interface_details"):
-                return json.dumps(self.interface.details(), cls=JsonEncoder)
+                try:
+                    return json.dumps(self.interface.details(), cls=JsonEncoder)
+                except Exception as e:
+                    self.logger.error(
+                        f"{self.interface.name}: interface_details: {''.join(traceback.format_exception(e))}"
+                    )
+                    return str(e)
 
         target_name = msg_hash[b"target_name"].decode()
         if target_name and not self.interface.cmd_target_enabled.get(target_name, False):
@@ -444,7 +459,7 @@ class RouterTlmHandlerThread:
             self.metric.set(name="router_tlm_total", value=self.count, type="counter")
 
     def start(self):
-        self.thread = threading.Thread(target=self.run, daemon=True)
+        self.thread = threading.Thread(target=self.run_thread_body, daemon=True)
         self.thread.start()
         ThreadManager.instance().register(self.thread, stop_object=self)
         return self.thread
@@ -455,6 +470,15 @@ class RouterTlmHandlerThread:
     def graceful_kill(self):
         RouterTopic.shutdown(self.router, scope=self.scope)
         time.sleep(0.001)  # Allow other threads to run
+
+    # Log why the thread died before letting the exception take down the microservice.
+    # ThreadManager treats a dead handler thread as fatal so the exception is re-raised.
+    def run_thread_body(self):
+        try:
+            self.run()
+        except Exception:
+            self.logger.error(f"{self.router.name}: Telemetry handler thread died: {traceback.format_exc()}")
+            raise
 
     def run(self):
         generator = RouterTopic.receive_telemetry(self.router, scope=self.scope, db_shard=self.db_shard)
@@ -569,7 +593,13 @@ class RouterTlmHandlerThread:
                         )
                         result = str(e)
                 elif msg_hash.get(b"router_details"):
-                    result = json.dumps(self.router.details(), cls=JsonEncoder)
+                    try:
+                        result = json.dumps(self.router.details(), cls=JsonEncoder)
+                    except Exception as e:
+                        self.logger.error(
+                            f"{self.router.name}: router_details: {''.join(traceback.format_exception(e))}"
+                        )
+                        result = str(e)
                 else:
                     result = "SUCCESS"
 

--- a/openc3/python/openc3/topics/interface_topic.py
+++ b/openc3/python/openc3/topics/interface_topic.py
@@ -262,5 +262,10 @@ class InterfaceTopic(Topic):
         while (time.time() - start_time) < timeout:
             for _, _, msg_hash, _ in Topic.read_topics([ack_topic], db_shard=db_shard):
                 if msg_hash[b"id"] == cmd_id:
-                    return json.loads(msg_hash[b"result"].decode(), cls=JsonDecoder)
+                    result = msg_hash[b"result"].decode()
+                    try:
+                        return json.loads(result, cls=JsonDecoder)
+                    except json.JSONDecodeError:
+                        # The microservice returns a plain error message rather than JSON if details raises
+                        raise RuntimeError(f"interface_details failed: {result}") from None
         raise RuntimeError(f"Timeout of {timeout}s waiting for cmd ack")

--- a/openc3/python/openc3/topics/router_topic.py
+++ b/openc3/python/openc3/topics/router_topic.py
@@ -200,5 +200,10 @@ class RouterTopic(Topic):
         while (time.time() - start_time) < timeout:
             for _, _, msg_hash, _ in Topic.read_topics([ack_topic], db_shard=db_shard):
                 if msg_hash[b"id"] == cmd_id:
-                    return json.loads(msg_hash[b"result"].decode(), cls=JsonDecoder)
+                    result = msg_hash[b"result"].decode()
+                    try:
+                        return json.loads(result, cls=JsonDecoder)
+                    except json.JSONDecodeError:
+                        # The microservice returns a plain error message rather than JSON if details raises
+                        raise RuntimeError(f"router_details failed: {result}") from None
         raise RuntimeError(f"Timeout of {timeout}s waiting for cmd ack")

--- a/openc3/python/test/microservices/test_interface_microservice.py
+++ b/openc3/python/test/microservices/test_interface_microservice.py
@@ -602,6 +602,32 @@ class TestInterfaceMicroservice(unittest.TestCase):
         self.assertNotEqual(handler.process_cmd(topic, msg_id, {b"protocol_cmd": b"{}"}, None), "SUCCESS")
         self.assertNotEqual(handler.process_cmd(topic, msg_id, {b"inject_tlm": b"not valid"}, None), "SUCCESS")
 
+    def test_process_cmd_interface_details_error_does_not_kill_the_thread(self):
+        """A custom interface whose details() raises must not take down the microservice.
+        The error is returned as the ack so the caller sees it instead of timing out."""
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        self.addCleanup(im.shutdown)
+        handler = im.handler_thread
+        topic = "{DEFAULT__CMD}INTERFACE__INST_INT"
+        msg_id = f"{int(time.time() * 1000)}-0"
+
+        # A common mistake in a custom interface is shadowing the num_clients method
+        # with an attribute, which makes as_json raise TypeError
+        im.interface.num_clients = 0
+        result = handler.process_cmd(topic, msg_id, {b"interface_details": b"1"}, None)
+        self.assertIn("not callable", result)
+
+        # A details() that returns something JSON cannot encode is also reported
+        del im.interface.num_clients  # restore the class method
+        im.interface.options["BAD"] = object()
+        result = handler.process_cmd(topic, msg_id, {b"interface_details": b"1"}, None)
+        self.assertIn("not JSON serializable", result)
+
+        # The handler still works for other directives afterwards
+        del im.interface.options["BAD"]
+        result = handler.process_cmd(topic, msg_id, {b"interface_details": b"1"}, None)
+        self.assertEqual(json.loads(result)["name"], "INST_INT")
+
     def test_process_cmd_connected_interface_directives(self):
         """Raw write and stream logging directives against a connected interface."""
         im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")

--- a/openc3/python/test/topics/test_interface_topic.py
+++ b/openc3/python/test/topics/test_interface_topic.py
@@ -1,0 +1,53 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+import json
+import unittest
+from unittest.mock import patch
+
+from openc3.topics.interface_topic import InterfaceTopic
+from test.test_helper import mock_redis
+
+
+class TestInterfaceTopicDetails(unittest.TestCase):
+    def setUp(self):
+        mock_redis(self)
+        for target, value in [
+            ("openc3.topics.interface_topic.InterfaceTopic._db_shard_for_interface", 0),
+            ("openc3.topics.interface_topic.Topic.update_topic_offsets", None),
+            ("openc3.topics.interface_topic.Topic.write_topic", "1234-0"),
+        ]:
+            p = patch(target, return_value=value)
+            p.start()
+            self.addCleanup(p.stop)
+
+    # Yield a single ack message carrying the given result for the cmd_id
+    # returned by the patched write_topic
+    def stub_ack(self, result):
+        p = patch(
+            "openc3.topics.interface_topic.Topic.read_topics",
+            return_value=[("ACKTOPIC", "1234-1", {b"id": "1234-0", b"result": result}, None)],
+        )
+        p.start()
+        self.addCleanup(p.stop)
+
+    def test_parses_the_json_result_from_the_microservice(self):
+        self.stub_ack(json.dumps({"name": "INST_INT", "state": "CONNECTED"}).encode())
+        details = InterfaceTopic.interface_details("INST_INT", scope="DEFAULT")
+        self.assertEqual(details["name"], "INST_INT")
+        self.assertEqual(details["state"], "CONNECTED")
+
+    def test_raises_with_the_error_text_if_the_result_is_not_json(self):
+        # The microservice returns the exception message rather than JSON if
+        # details raises, so surface that text instead of a JSON decode error
+        self.stub_ack(b"'int' object is not callable")
+        with self.assertRaisesRegex(RuntimeError, r"interface_details failed: 'int' object is not callable"):
+            InterfaceTopic.interface_details("INST_INT", scope="DEFAULT")

--- a/openc3/spec/microservices/interface_microservice_spec.rb
+++ b/openc3/spec/microservices/interface_microservice_spec.rb
@@ -192,6 +192,42 @@ module OpenC3
       end
     end
 
+    describe "interface_details directive" do
+      # Drive the command handler block directly. receive_commands is stubbed so
+      # the block runs once with a crafted message and its return value (which
+      # becomes the ack payload) is captured.
+      def handle_interface_details(interface)
+        handler = InterfaceCmdHandlerThread.new(interface, double("tlm").as_null_object, scope: "DEFAULT")
+        result = nil
+        allow(InterfaceTopic).to receive(:receive_commands) do |*_args, **_kwargs, &block|
+          result = block.call("{DEFAULT__CMD}INTERFACE__INST_INT",
+                              "#{(Time.now.to_f * 1000).to_i}-0",
+                              { 'interface_details' => 'true' }, nil)
+        end
+        handler.run
+        result
+      end
+
+      it "returns the interface details as JSON" do
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        interface = im.instance_variable_get(:@interface)
+        expect(JSON.parse(handle_interface_details(interface))['name']).to eql "INST_INT"
+        im.shutdown
+        sleep 0.1 # Allow threads to exit
+      end
+
+      it "returns the error message instead of raising if details raises" do
+        # A custom interface with a broken details implementation must not take
+        # down the microservice, so the error is returned as the ack instead.
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        interface = im.instance_variable_get(:@interface)
+        allow(interface).to receive(:details).and_raise('boom')
+        expect(handle_interface_details(interface)).to eql 'boom'
+        im.shutdown
+        sleep 0.1 # Allow threads to exit
+      end
+    end
+
     describe "handle_packet" do
       it "does not write the status model after cancel_thread is set" do
         # A packet already buffered can be returned from read() after stop()

--- a/openc3/spec/topics/interface_topic_spec.rb
+++ b/openc3/spec/topics/interface_topic_spec.rb
@@ -1,0 +1,51 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require 'spec_helper'
+require 'openc3/topics/interface_topic'
+
+module OpenC3
+  describe InterfaceTopic do
+    before(:each) do
+      mock_redis()
+      allow(InterfaceTopic).to receive(:_db_shard_for_interface).and_return(0)
+      allow(Topic).to receive(:update_topic_offsets)
+      allow(Topic).to receive(:write_topic).and_return("1234-0")
+    end
+
+    # Yield a single ack message carrying the given result for the cmd_id
+    # returned by the stubbed write_topic
+    def stub_ack(result)
+      allow(Topic).to receive(:read_topics) do |_topics, **_kwargs, &block|
+        block.call("ACKTOPIC", "1234-1", { "id" => "1234-0", "result" => result }, nil)
+      end
+    end
+
+    describe "interface_details" do
+      it "parses the JSON result from the microservice" do
+        stub_ack({ 'name' => 'INST_INT', 'state' => 'CONNECTED' }.to_json)
+        details = InterfaceTopic.interface_details("INST_INT", scope: "DEFAULT")
+        expect(details['name']).to eql "INST_INT"
+        expect(details['state']).to eql "CONNECTED"
+      end
+
+      it "raises with the error text if the microservice returns a plain error message" do
+        # The microservice returns the exception message rather than JSON if
+        # details raises, so surface that text instead of a JSON parse error
+        stub_ack("undefined method 'foo' for nil")
+        expect { InterfaceTopic.interface_details("INST_INT", scope: "DEFAULT") }.to \
+          raise_error(/interface_details failed: undefined method 'foo' for nil/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- timestamp format alignment
- report/log error from calling `details` instead of crashing script
- add return details of `interface_details` to documentation (Claude generated)
- add `details` to "Custom Interfaces" documentation

## Why it changed

Support email about custom interface crashing when calling `interface_details` on it, digging deeper into how this function works and what it calls

## Testing strategy

- Ruby and Python unit tests
- Manual testing on `main` vs on this branch
  1. check out `main`, edit `simulated_target_interface.py` to have the implementation of `details` method
```py
def details(self):
    super().details()
    Logger.info("Simulated Target Interface Details:")
    raise NotImplementedError("details() not implemented for SimulatedTargetInterface")
```
  2. `openc3.sh start`
  3. click "details" on INST2
### Result
on `main`: interface crashes and reboots, see logs and connected status of INST2
on this branch: error logged, interface does not crash/reboot

## Review notes

A lot was added to the documentation detailing the return format of `interface_details` with both common keys and interface-specific keys. They are tabbed so that not all information is shown at once, but it is a lot of lines and still a fairly large section on the docs page. Details about what is returned is a big hole in the documentation, and it is possible that this opens a can of worms, but this feels like one of the most complex returns of methods that are offered to users.
