### PR TITLE
fix(test): stop asserting exact elapsed time in wait timeout tests

### DIFF
--- a/openc3/python/test/api/test_api_shared.py
+++ b/openc3/python/test/api/test_api_shared.py
@@ -332,7 +332,7 @@ class TestApiShared(unittest.TestCase):
             result = wait("INST HEALTH_STATUS TEMP1 < 0", 0.1, 0.1)  # Last param is polling rate
             self.assertFalse(result)
             self.assertIn(
-                "WAIT: INST HEALTH_STATUS TEMP1 < 0 failed with value == 10 after waiting 0.1",
+                "WAIT: INST HEALTH_STATUS TEMP1 < 0 failed with value == 10 after waiting",
                 stdout.getvalue(),
             )
 
@@ -346,7 +346,7 @@ class TestApiShared(unittest.TestCase):
             result = wait("INST", "HEALTH_STATUS", "TEMP1", "== 0", 0.1, 0.1)  # Last param is polling rate
             self.assertFalse(result)
             self.assertIn(
-                "WAIT: INST HEALTH_STATUS TEMP1 == 0 failed with value == 10 after waiting 0.1",
+                "WAIT: INST HEALTH_STATUS TEMP1 == 0 failed with value == 10 after waiting",
                 stdout.getvalue(),
             )
 
@@ -385,7 +385,7 @@ class TestApiShared(unittest.TestCase):
             result = wait_tolerance("INST HEALTH_STATUS TEMP2", 11, 0.1, 0.1)
             self.assertFalse(result)
             self.assertIn(
-                "WAIT: INST HEALTH_STATUS TEMP2 failed to be within range 10.9 to 11.1 with value == 10.5 after waiting 0.1",
+                "WAIT: INST HEALTH_STATUS TEMP2 failed to be within range 10.9 to 11.1 with value == 10.5 after waiting",
                 stdout.getvalue(),
             )
 
@@ -494,7 +494,7 @@ class TestApiShared(unittest.TestCase):
             )
             result = wait_expression("True == False", 0.1)
             self.assertFalse(result)
-            self.assertIn("WAIT: True == False is FALSE after waiting 0.1", stdout.getvalue())
+            self.assertIn("WAIT: True == False is FALSE after waiting", stdout.getvalue())
 
     def test_waits_for_a_logical_expression(self):
         for stdout in capture_io():


### PR DESCRIPTION
### What changed

Removed the exact elapsed-time value from four timeout assertions in `openc3/python/test/api/test_api_shared.py`. They now assert on `"... after waiting"` instead of `"... after waiting 0.1"`.

### Why it changed

`TestApiShared::test_waits_for_an_expression` failed on the Python 3.14 job of [run 33422678518](https://github.com/OpenC3/cosmos/actions/runs/33422678518):

```
AssertionError: 'WAIT: True == False is FALSE after waiting 0.1' not found in
'WAIT: True == True is TRUE after waiting 0.000 seconds\nWARN: WAIT: True == False is FALSE after waiting 0.242 seconds\n'
```

The assertions compared the printed elapsed seconds against the requested timeout. On a slow runner the polling loop overshoots the timeout, so the printed value (0.242) no longer starts with the timeout value (0.1). The elapsed time is not what these tests are verifying — the sibling `test_waits_for_a_logical_expression` already asserts without the number.

This is a pre-existing flake on `main`, not introduced by #3794.

### Testing strategy

`uv run pytest test/api/test_api_shared.py` — 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)