### PR TITLE
[Documentation] Fix processor docs

### DIFF
--- a/docs.openc3.com/docs/configuration/_processors.md
+++ b/docs.openc3.com/docs/configuration/_processors.md
@@ -42,7 +42,7 @@ class SlopeProcessor(Processor):
         self.num_samples = int(num_samples)
         self.reset()
 
-    def call(self, value, packet, buffer):
+    def call(self, packet, buffer):
         value = packet.read(self.item_name, self.value_type, buffer)
         # Don't process NaN or Infinite values
         if math.isnan(value) or math.isinf(value):

--- a/docs.openc3.com/docs/configuration/processors.md
+++ b/docs.openc3.com/docs/configuration/processors.md
@@ -42,7 +42,7 @@ class SlopeProcessor(Processor):
         self.num_samples = int(num_samples)
         self.reset()
 
-    def call(self, value, packet, buffer):
+    def call(self, packet, buffer):
         value = packet.read(self.item_name, self.value_type, buffer)
         # Don't process NaN or Infinite values
         if math.isnan(value) or math.isinf(value):

--- a/openc3/templates/processor/processor.py
+++ b/openc3/templates/processor/processor.py
@@ -10,7 +10,7 @@ class <%= processor_class %>(Processor):
         self.num_samples = int(num_samples)
         self.reset()
 
-    def call(self, value, packet, buffer):
+    def call(self, packet, buffer):
         value = packet.read(self.item_name, self.value_type, buffer)
         # Don't process NaN or Infinite values
         if math.isnan(value) or math.isinf(value):


### PR DESCRIPTION
### What changed

Fix processor sample code

### Why it changed

Python processor `call` method takes 2 vars (not 3)
