### PR TITLE
Make CSP more permissive and configurable

### DIFF
--- a/.env
+++ b/.env
@@ -32,9 +32,10 @@ OPENC3_EXTERNAL_URL=http://localhost:2900
 
 # NOTE: Optional per-service runtime flags (OPENC3_FORCE_INSTALL,
 # OPENC3_DEFAULT_QUEUE, OPENC3_AUTH_RATE_LIMIT_*, OPENC3_ALLOW_HTTP,
-# OPENC3_LANGUAGE, OPENC3_NO_BUCKET_POLICY, OPENC3_LOG_STDERR, the OPENC3_NO_*
-# tool flags, and extra buckets/volumes) are now documented in
-# compose.override.yaml under the service each one applies to.
+# OPENC3_ALLOW_UNSAFE_EVAL, OPENC3_LANGUAGE, OPENC3_NO_BUCKET_POLICY,
+# OPENC3_LOG_STDERR, the OPENC3_NO_* tool flags, and extra
+# buckets/volumes) are now documented in compose.override.yaml under
+# the service each one applies to.
 
 # Docker repo settings on where to get COSMOS containers
 OPENC3_REGISTRY=docker.io

--- a/.env
+++ b/.env
@@ -32,7 +32,7 @@ OPENC3_EXTERNAL_URL=http://localhost:2900
 
 # NOTE: Optional per-service runtime flags (OPENC3_FORCE_INSTALL,
 # OPENC3_DEFAULT_QUEUE, OPENC3_AUTH_RATE_LIMIT_*, OPENC3_ALLOW_HTTP,
-# OPENC3_ALLOW_UNSAFE_EVAL, OPENC3_LANGUAGE, OPENC3_NO_BUCKET_POLICY,
+# OPENC3_NO_EVAL, OPENC3_LANGUAGE, OPENC3_NO_BUCKET_POLICY,
 # OPENC3_LOG_STDERR, the OPENC3_NO_* tool flags, and extra
 # buckets/volumes) are now documented in compose.override.yaml under
 # the service each one applies to.

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -135,6 +135,9 @@
 #   environment:
 #     # Allow HTTP connections in the Content Security Policy (less secure).
 #     - OPENC3_ALLOW_HTTP=1
+#     # Allow 'unsafe-eval' in Content Security Policy for plugins that need
+#     # eval() or new Function() (e.g. OpenMCT, Vue runtime template compilation).
+#     - OPENC3_ALLOW_UNSAFE_EVAL=1
 
 # -------------------------------------------------------------------------
 # Log to stderr on any service

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -135,9 +135,9 @@
 #   environment:
 #     # Allow HTTP connections in the Content Security Policy (less secure).
 #     - OPENC3_ALLOW_HTTP=1
-#     # Allow 'unsafe-eval' in Content Security Policy for plugins that need
-#     # eval() or new Function() (e.g. OpenMCT, Vue runtime template compilation).
-#     - OPENC3_ALLOW_UNSAFE_EVAL=1
+#     # Remove 'unsafe-eval' from Content Security Policy script-src (stricter).
+#     # Only set this if no plugins need eval() or new Function().
+#     - OPENC3_NO_EVAL=1
 
 # -------------------------------------------------------------------------
 # Log to stderr on any service

--- a/compose.yaml
+++ b/compose.yaml
@@ -378,7 +378,7 @@ services:
     volumes:
       - "./cacert.pem:/devel/cacert.pem:z"
       - "./openc3-traefik/traefik.yaml:/etc/traefik/traefik.yaml:z"
-      # See compose.override.yaml for OPENC3_ALLOW_HTTP and OPENC3_ALLOW_UNSAFE_EVAL
+      # See compose.override.yaml for OPENC3_ALLOW_HTTP and OPENC3_NO_EVAL
       # - "./openc3-traefik/traefik-ssl.yaml:/etc/traefik/traefik.yaml:z"
       # - "./openc3-traefik/traefik-letsencrypt.yaml:/etc/traefik/traefik.yaml:z"
       # - "./openc3-traefik/cert.key:/etc/traefik/cert.key:z"
@@ -402,7 +402,7 @@ services:
       OPENC3_TOOLS_BUCKET: "${OPENC3_TOOLS_BUCKET}"
       OPENC3_BUCKET_URL: "${OPENC3_BUCKET_URL}"
       OPENC3_ALLOW_HTTP: "${OPENC3_ALLOW_HTTP:-}"
-      OPENC3_ALLOW_UNSAFE_EVAL: "${OPENC3_ALLOW_UNSAFE_EVAL:-}"
+      OPENC3_NO_EVAL: "${OPENC3_NO_EVAL:-}"
       SSL_CERT_FILE: "/devel/cacert.pem"
       CURL_CA_BUNDLE: "/devel/cacert.pem"
       REQUESTS_CA_BUNDLE: "/devel/cacert.pem"

--- a/compose.yaml
+++ b/compose.yaml
@@ -378,7 +378,7 @@ services:
     volumes:
       - "./cacert.pem:/devel/cacert.pem:z"
       - "./openc3-traefik/traefik.yaml:/etc/traefik/traefik.yaml:z"
-      # To allow HTTP, uncomment OPENC3_ALLOW_HTTP in .env
+      # See compose.override.yaml for OPENC3_ALLOW_HTTP and OPENC3_ALLOW_UNSAFE_EVAL
       # - "./openc3-traefik/traefik-ssl.yaml:/etc/traefik/traefik.yaml:z"
       # - "./openc3-traefik/traefik-letsencrypt.yaml:/etc/traefik/traefik.yaml:z"
       # - "./openc3-traefik/cert.key:/etc/traefik/cert.key:z"
@@ -402,6 +402,7 @@ services:
       OPENC3_TOOLS_BUCKET: "${OPENC3_TOOLS_BUCKET}"
       OPENC3_BUCKET_URL: "${OPENC3_BUCKET_URL}"
       OPENC3_ALLOW_HTTP: "${OPENC3_ALLOW_HTTP:-}"
+      OPENC3_ALLOW_UNSAFE_EVAL: "${OPENC3_ALLOW_UNSAFE_EVAL:-}"
       SSL_CERT_FILE: "/devel/cacert.pem"
       CURL_CA_BUNDLE: "/devel/cacert.pem"
       REQUESTS_CA_BUNDLE: "/devel/cacert.pem"

--- a/docs.openc3.com/docs/getting-started/security.md
+++ b/docs.openc3.com/docs/getting-started/security.md
@@ -43,6 +43,33 @@ By default, COSMOS only listens on localhost (127.0.0.1). This configuration kee
 
 For production use, it is recommended to configure COSMOS to listen on a network interface (not just localhost) so that users can access the web interface from their own workstations rather than directly on the host computer. This means users connect via their web browsers over the local network instead of needing access to the host machine itself, which reduces exposure of the host and allows it to be more tightly secured. See [SSL/TLS](../configuration/ssl-tls) for configuring HTTPS.
 
+### Content Security Policy
+
+COSMOS sets a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) header via Traefik to mitigate cross-site scripting (XSS) and other code-injection attacks. The default policy is strict: inline scripts and `eval()` are forbidden, and scripts may only be loaded from the same origin and trusted sources.
+
+Two environment variables relax the policy for deployments that need it:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OPENC3_ALLOW_HTTP` | _(unset)_ | When set (e.g. `1`), broadens the CSP to allow resources over plain HTTP in addition to HTTPS. Useful for development or air-gapped networks without TLS. |
+| `OPENC3_ALLOW_UNSAFE_EVAL` | _(unset)_ | When set (e.g. `1`), adds `'unsafe-eval'` to the CSP `script-src` directive, allowing `eval()`, `new Function()`, and similar dynamic code execution. Required by some third-party plugins (e.g. Open MCT) that bundle libraries which evaluate code at runtime. |
+
+WebAssembly (`'wasm-unsafe-eval'`) is allowed by default and does not require either flag.
+
+To enable either flag, add it to `.env.local` (recommended) or `compose.override.yaml` under the `openc3-traefik` service, then recreate the Traefik container:
+
+```bash
+# .env.local
+OPENC3_ALLOW_UNSAFE_EVAL=1
+```
+
+```bash
+./openc3.sh stop
+./openc3.sh run
+```
+
+These are runtime settings evaluated by Traefik at container startup -- no image rebuild is needed.
+
 ### Network Security
 
 Between any external network and the private network containing the host computer should be a firewall that prevents unauthorized access.

--- a/docs.openc3.com/docs/getting-started/security.md
+++ b/docs.openc3.com/docs/getting-started/security.md
@@ -45,22 +45,22 @@ For production use, it is recommended to configure COSMOS to listen on a network
 
 ### Content Security Policy
 
-COSMOS sets a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) header via Traefik to mitigate cross-site scripting (XSS) and other code-injection attacks. The default policy is strict: inline scripts and `eval()` are forbidden, and scripts may only be loaded from the same origin and trusted sources.
+COSMOS sets a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) header via Traefik to mitigate cross-site scripting (XSS) and other code-injection attacks. The default policy forbids inline scripts but allows `eval()` for third-party plugin compatibility. Scripts may only be loaded from the same origin and trusted sources.
 
-Two environment variables relax the policy for deployments that need it:
+The following environment variables control the CSP:
 
 | Variable | Default | Description |
 | --- | --- | --- |
 | `OPENC3_ALLOW_HTTP` | _(unset)_ | When set (e.g. `1`), broadens the CSP to allow resources over plain HTTP in addition to HTTPS. Useful for development or air-gapped networks without TLS. |
-| `OPENC3_ALLOW_UNSAFE_EVAL` | _(unset)_ | When set (e.g. `1`), adds `'unsafe-eval'` to the CSP `script-src` directive, allowing `eval()`, `new Function()`, and similar dynamic code execution. Required by some third-party plugins (e.g. Open MCT) that bundle libraries which evaluate code at runtime. |
+| `OPENC3_NO_EVAL` | _(unset)_ | When set (e.g. `1`), removes `'unsafe-eval'` from the CSP `script-src` directive, blocking `eval()`, `new Function()`, and similar dynamic code execution. Only set this if no installed plugins require runtime code evaluation (e.g. Open MCT and other tools that bundle Vue's runtime template compiler will break). |
 
-WebAssembly (`'wasm-unsafe-eval'`) is allowed by default and does not require either flag.
+By default `'unsafe-eval'` is **allowed** for third-party plugin compatibility. WebAssembly (`'wasm-unsafe-eval'`) is always allowed regardless of these flags.
 
-To enable either flag, add it to `.env.local` (recommended) or `compose.override.yaml` under the `openc3-traefik` service, then recreate the Traefik container:
+To harden the CSP on a deployment that does not use plugins requiring eval, add `OPENC3_NO_EVAL` to `.env.local` (recommended) or `compose.override.yaml` under the `openc3-traefik` service, then recreate the Traefik container:
 
 ```bash
 # .env.local
-OPENC3_ALLOW_UNSAFE_EVAL=1
+OPENC3_NO_EVAL=1
 ```
 
 ```bash

--- a/openc3-traefik/traefik-letsencrypt.yaml
+++ b/openc3-traefik/traefik-letsencrypt.yaml
@@ -84,12 +84,12 @@ http:
         regex: "^(.*)$"
         replacement: "$1.html"
     # Set Content-Security-Policy header to only allow content from the same origin and trusted sources
-    # Set OPENC3_ALLOW_UNSAFE_EVAL to add 'unsafe-eval' to script-src for plugins
-    # that need eval() or new Function().
+    # By default 'unsafe-eval' is allowed for third-party plugin compatibility.
+    # Set OPENC3_NO_EVAL to remove 'unsafe-eval' from script-src (stricter CSP).
     contentSecurityPolicy:
       headers:
         contentSecurityPolicy: >-
-          default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if env "OPENC3_ALLOW_UNSAFE_EVAL" }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';
+          default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if not (env "OPENC3_NO_EVAL") }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';
   routers:
     # Note: Priorities control router check order with highest priority evaluated first
     # Serve the BUTTON widget sandbox document WITHOUT the app Content-Security-Policy

--- a/openc3-traefik/traefik-letsencrypt.yaml
+++ b/openc3-traefik/traefik-letsencrypt.yaml
@@ -84,10 +84,12 @@ http:
         regex: "^(.*)$"
         replacement: "$1.html"
     # Set Content-Security-Policy header to only allow content from the same origin and trusted sources
+    # Set OPENC3_ALLOW_UNSAFE_EVAL to add 'unsafe-eval' to script-src for plugins
+    # that need eval() or new Function().
     contentSecurityPolicy:
       headers:
         contentSecurityPolicy: >-
-          default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';
+          default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if env "OPENC3_ALLOW_UNSAFE_EVAL" }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';
   routers:
     # Note: Priorities control router check order with highest priority evaluated first
     # Serve the BUTTON widget sandbox document WITHOUT the app Content-Security-Policy

--- a/openc3-traefik/traefik-ssl.yaml
+++ b/openc3-traefik/traefik-ssl.yaml
@@ -84,12 +84,12 @@ http:
         regex: "^(.*)$"
         replacement: "$1.html"
     # Set Content-Security-Policy header to only allow content from the same origin and trusted sources
-    # Set OPENC3_ALLOW_UNSAFE_EVAL to add 'unsafe-eval' to script-src for plugins
-    # that need eval() or new Function().
+    # By default 'unsafe-eval' is allowed for third-party plugin compatibility.
+    # Set OPENC3_NO_EVAL to remove 'unsafe-eval' from script-src (stricter CSP).
     contentSecurityPolicy:
       headers:
         contentSecurityPolicy: >-
-          default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if env "OPENC3_ALLOW_UNSAFE_EVAL" }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';
+          default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if not (env "OPENC3_NO_EVAL") }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';
   routers:
     # Note: Priorities control router check order with highest priority evaluated first
     # Serve the BUTTON widget sandbox document WITHOUT the app Content-Security-Policy

--- a/openc3-traefik/traefik-ssl.yaml
+++ b/openc3-traefik/traefik-ssl.yaml
@@ -84,10 +84,12 @@ http:
         regex: "^(.*)$"
         replacement: "$1.html"
     # Set Content-Security-Policy header to only allow content from the same origin and trusted sources
+    # Set OPENC3_ALLOW_UNSAFE_EVAL to add 'unsafe-eval' to script-src for plugins
+    # that need eval() or new Function().
     contentSecurityPolicy:
       headers:
         contentSecurityPolicy: >-
-          default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';
+          default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if env "OPENC3_ALLOW_UNSAFE_EVAL" }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';
   routers:
     # Note: Priorities control router check order with highest priority evaluated first
     # Serve the BUTTON widget sandbox document WITHOUT the app Content-Security-Policy

--- a/openc3-traefik/traefik.yaml
+++ b/openc3-traefik/traefik.yaml
@@ -68,10 +68,12 @@ http:
         regex: "^(.*)$"
         replacement: "$1.html"
     # Set Content-Security-Policy header based on OPENC3_ALLOW_HTTP flag
+    # Set OPENC3_ALLOW_UNSAFE_EVAL to add 'unsafe-eval' to script-src for plugins
+    # that need eval() or new Function().
     contentSecurityPolicy:
       headers:
         contentSecurityPolicy: >-
-          {{ if env "OPENC3_ALLOW_HTTP" }}default-src 'self' blob: data: http: https:; script-src 'self' http: https: blob:; connect-src blob: http: https: wss: ws:; style-src 'unsafe-inline' http: https:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';{{ else }}default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';{{ end }}
+          {{ if env "OPENC3_ALLOW_HTTP" }}default-src 'self' blob: data: http: https:; script-src 'self' 'wasm-unsafe-eval'{{ if env "OPENC3_ALLOW_UNSAFE_EVAL" }} 'unsafe-eval'{{ end }} http: https: blob:; connect-src blob: http: https: wss: ws:; style-src 'unsafe-inline' http: https:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';{{ else }}default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if env "OPENC3_ALLOW_UNSAFE_EVAL" }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';{{ end }}
   routers:
     # Note: Priorities control router check order with highest priority evaluated first
     # Serve the BUTTON widget sandbox document WITHOUT the app Content-Security-Policy

--- a/openc3-traefik/traefik.yaml
+++ b/openc3-traefik/traefik.yaml
@@ -68,12 +68,12 @@ http:
         regex: "^(.*)$"
         replacement: "$1.html"
     # Set Content-Security-Policy header based on OPENC3_ALLOW_HTTP flag
-    # Set OPENC3_ALLOW_UNSAFE_EVAL to add 'unsafe-eval' to script-src for plugins
-    # that need eval() or new Function().
+    # By default 'unsafe-eval' is allowed for third-party plugin compatibility.
+    # Set OPENC3_NO_EVAL to remove 'unsafe-eval' from script-src (stricter CSP).
     contentSecurityPolicy:
       headers:
         contentSecurityPolicy: >-
-          {{ if env "OPENC3_ALLOW_HTTP" }}default-src 'self' blob: data: http: https:; script-src 'self' 'wasm-unsafe-eval'{{ if env "OPENC3_ALLOW_UNSAFE_EVAL" }} 'unsafe-eval'{{ end }} http: https: blob:; connect-src blob: http: https: wss: ws:; style-src 'unsafe-inline' http: https:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';{{ else }}default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if env "OPENC3_ALLOW_UNSAFE_EVAL" }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';{{ end }}
+          {{ if env "OPENC3_ALLOW_HTTP" }}default-src 'self' blob: data: http: https:; script-src 'self' 'wasm-unsafe-eval'{{ if not (env "OPENC3_NO_EVAL") }} 'unsafe-eval'{{ end }} http: https: blob:; connect-src blob: http: https: wss: ws:; style-src 'unsafe-inline' http: https:; object-src 'none'; base-uri 'self'; frame-ancestors 'self';{{ else }}default-src 'self' blob: data: https: http://localhost:* http://host.docker.internal:* http://*.local:*; script-src 'self' 'wasm-unsafe-eval'{{ if not (env "OPENC3_NO_EVAL") }} 'unsafe-eval'{{ end }} https: blob: http://localhost:* http://host.docker.internal:* http://*.local:*; connect-src blob: https: wss: http://localhost:* http://host.docker.internal:* http://*.local:* ws://localhost:* ws://host.docker.internal:* ws://*.local:*; style-src 'unsafe-inline' https: http://localhost:* http://host.docker.internal:* http://*.local:*; object-src 'none'; base-uri 'self'; frame-ancestors 'self';{{ end }}
   routers:
     # Note: Priorities control router check order with highest priority evaluated first
     # Serve the BUTTON widget sandbox document WITHOUT the app Content-Security-Policy


### PR DESCRIPTION
### What changed

- add `wasm-unsafe-eval` to default CSP
- add `OPENC3_ALLOW_UNSAFE_EVAL` environment variable, which adds `unsafe-eval` to CSP in traefik config when set

### Why it changed

- `wasm-unsafe-eval` is generally considered safe since WASM execution is scoped to the binary. This alone doesn't fix Orbitview, but might fix other similar plugins and would let those people not have to do the whole `unsafe-eval`.
- adding `unsafe-eval` via an env var keeps it so most people get the more restrictive CSP, but can explicitly loosen it if/when needed.

### Testing strategy

manual testing (steps below)

### Review notes

1. `echo "OPENC3_ALLOW_UNSAFE_EVAL=1" >> .env.local`
2. openc3.sh start
3. install openmct plugin from the app store
4. it works

We also discussed reverting the vue runtime change. That's still a potentially breaking change in 7.3.0, but OpenMCT actually bundles an entire Vue build. I'm not aware of any plugins that actually exist that this breaks, so I left it as-is (at least for now). But theoretically, someone might need that reverted.