### PR TITLE
Cleanup file handling

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/models/screen.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/screen.rb
@@ -38,7 +38,7 @@ class Screen < OpenC3::TargetFile
   end
 
   def self.find(scope, target, screen)
-    name = strip_modified(screen).downcase # Filenames are lowercase
+    name = strip_modified(screen).downcase # Remove '*' that indicates modified - Filenames are lowercase
     body(scope, "#{target}/screens/#{name}.txt")
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/screen.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/screen.rb
@@ -27,7 +27,7 @@ class Screen < OpenC3::TargetFile
     installed_targets = OpenC3::TargetModel.names(scope: scope)
     screens = []
     result.each do |path|
-      filename = path.split('*')[0] # Don't differentiate modified - TODO: Should we?
+      filename = strip_modified(path) # Don't differentiate modified - TODO: Should we?
       next unless File.extname(filename) == ".txt"
       next if File.basename(filename, ".txt")[0] == '_' # underscore filenames are partials
       target = filename.split('/')[0]
@@ -38,7 +38,7 @@ class Screen < OpenC3::TargetFile
   end
 
   def self.find(scope, target, screen)
-    name = screen.split('*')[0].downcase # Split '*' that indicates modified - Filenames are lowercase
+    name = strip_modified(screen).downcase # Filenames are lowercase
     body(scope, "#{target}/screens/#{name}.txt")
   end
 

--- a/openc3-cosmos-cmd-tlm-api/app/models/table.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/table.rb
@@ -149,17 +149,17 @@ class Table < OpenC3::TargetFile
   end
 
   def self.lock(scope, name, user)
-    name = name.split('*')[0] # Split '*' that indicates modified
+    name = strip_modified(name) # Remove '*' that indicates modified
     OpenC3::Store.hset("#{scope}__table-locks", name, user)
   end
 
   def self.unlock(scope, name)
-    name = name.split('*')[0] # Split '*' that indicates modified
+    name = strip_modified(name) # Remove '*' that indicates modified
     OpenC3::Store.hdel("#{scope}__table-locks", name)
   end
 
   def self.locked?(scope, name)
-    name = name.split('*')[0] # Split '*' that indicates modified
+    name = strip_modified(name) # Remove '*' that indicates modified
     locked_by = OpenC3::Store.hget("#{scope}__table-locks", name)
     locked_by ||= false
     locked_by

--- a/openc3-cosmos-cmd-tlm-api/spec/controllers/screens_controller_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/controllers/screens_controller_spec.rb
@@ -96,23 +96,13 @@ RSpec.describe ScreensController, :type => :controller do
 
   describe "show" do
     it "returns 404 if not found" do
-      class Screen < OpenC3::TargetFile
-        def self.find(scope, target, screen)
-          # Override Screen.find to return nothing
-          nil
-        end
-      end
+      allow(Screen).to receive(:find).and_return(nil)
       get :show, params: { scope: 'DEFAULT', target: 'INST', screen: 'TEST' }
       expect(response).to have_http_status(:not_found)
     end
 
     it "returns the screen" do
-      class Screen < OpenC3::TargetFile
-        def self.find(scope, target, screen)
-          # Override Screen.find to return a screen
-          "SCREEN"
-        end
-      end
+      allow(Screen).to receive(:find).and_return("SCREEN")
       get :show, params: { scope: 'DEFAULT', target: 'INST', screen: 'TEST' }
       expect(response).to have_http_status(:ok)
       expect(response.body).to eql 'SCREEN'
@@ -121,22 +111,13 @@ RSpec.describe ScreensController, :type => :controller do
 
   describe "destroy" do
     it "returns ok" do
-      class Screen < OpenC3::TargetFile
-        def self.destroy(scope, target, screen)
-          # Override Screen.destroy to do nothing
-        end
-      end
+      allow(Screen).to receive(:destroy).and_return(nil)
       delete :destroy, params: { scope: 'DEFAULT', target: 'INST', screen: 'TEST' }
       expect(response).to have_http_status(:ok)
     end
 
     it "handles exceptions" do
-      class Screen < OpenC3::TargetFile
-        def self.destroy(scope, target, screen)
-          # Override Screen.destroy to raise an exception
-          raise 'whoops'
-        end
-      end
+      allow(Screen).to receive(:destroy).and_raise('whoops')
       delete :destroy, params: { scope: 'DEFAULT', target: 'INST', screen: 'TEST' }
       expect(response).to have_http_status(:error)
       ret = JSON.parse(response.body, allow_nan: true, create_additions: true)

--- a/openc3-cosmos-cmd-tlm-api/spec/models/screen_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/models/screen_spec.rb
@@ -1,0 +1,72 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require 'rails_helper'
+require 'openc3/utilities/target_file'
+
+RSpec.describe Screen, :type => :model do
+  before(:each) do
+    mock_redis()
+    ENV.delete('OPENC3_LOCAL_MODE')
+  end
+
+  describe "self.all" do
+    before(:each) do
+      allow(OpenC3::TargetModel).to receive(:names).with(scope: 'DEFAULT').and_return(['INST'])
+    end
+
+    it "strips the modified marker from the returned names" do
+      allow(OpenC3::TargetFile).to receive(:all).and_return(
+        ['INST/screens/screen1.txt', 'INST/screens/screen2.txt*']
+      )
+      expect(Screen.all('DEFAULT')).to eql(['INST/screens/screen1.txt', 'INST/screens/screen2.txt'])
+    end
+
+    it "keeps a '*' which is part of the filename" do
+      allow(OpenC3::TargetFile).to receive(:all).and_return(
+        ['INST/screens/scr*een.txt', 'INST/screens/scr*een.txt*']
+      )
+      # Both list entries resolve to the same underlying file
+      expect(Screen.all('DEFAULT')).to eql(['INST/screens/scr*een.txt', 'INST/screens/scr*een.txt'])
+    end
+  end
+
+  describe "self.find" do
+    it "downcases the screen name and requests the screen file" do
+      expect(Screen).to receive(:body).with('DEFAULT', 'INST/screens/adcs.txt').and_return('SCREEN')
+      expect(Screen.find('DEFAULT', 'INST', 'ADCS')).to eql('SCREEN')
+    end
+
+    it "strips the modified marker from the screen name" do
+      expect(Screen).to receive(:body).with('DEFAULT', 'INST/screens/adcs.txt').and_return('SCREEN')
+      expect(Screen.find('DEFAULT', 'INST', 'ADCS*')).to eql('SCREEN')
+    end
+
+    it "keeps a '*' which is part of the screen name" do
+      expect(Screen).to receive(:body).with('DEFAULT', 'INST/screens/ad*cs.txt').and_return('SCREEN')
+      expect(Screen.find('DEFAULT', 'INST', 'AD*CS*')).to eql('SCREEN')
+    end
+
+    it "returns nil if the screen does not exist" do
+      expect(Screen).to receive(:body).with('DEFAULT', 'INST/screens/nope.txt').and_return(nil)
+      expect(Screen.find('DEFAULT', 'INST', 'NOPE')).to be_nil
+    end
+  end
+
+  describe "self.destroy" do
+    it "downcases the screen name and deletes the screen file" do
+      expect(OpenC3::TargetFile).to receive(:destroy).with('DEFAULT', 'INST/screens/adcs.txt')
+      Screen.destroy('DEFAULT', 'INST', 'ADCS')
+    end
+  end
+end

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
@@ -447,7 +447,7 @@ export default {
       } else {
         this.unlockFile() // first unlock what was just being edited
         // Strip the '*' which indicates a file is modified on the server
-        this.filename = file.name ? file.name.replace(/\*$/, '') : file.name
+        this.filename = file.name.replace(/\*$/, '')
         this.fileModified = ''
         this.lockedBy = locked
         this.getDefinition()

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
@@ -492,7 +492,7 @@ export default {
     saveAsFilename: function (filename) {
       Api.put(`/openc3-api/tables/${this.filename}/save-as/${filename}`).then(
         (response) => {
-          this.filename = filename
+          this.filename = filename.replace(/\*$/, '')
           this.getDefinition(this.definitionFilename)
         },
       )

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tablemanager/src/tools/TableManager/TableManager.vue
@@ -446,8 +446,8 @@ export default {
         }
       } else {
         this.unlockFile() // first unlock what was just being edited
-        // Split off the ' *' which indicates a file is modified on the server
-        this.filename = file.name.split('*')[0]
+        // Strip the '*' which indicates a file is modified on the server
+        this.filename = file.name ? file.name.replace(/\*$/, '') : file.name
         this.fileModified = ''
         this.lockedBy = locked
         this.getDefinition()

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/NewScreenDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-tlmviewer/src/tools/TlmViewer/NewScreenDialog.vue
@@ -87,6 +87,7 @@
               clearable
               label="Screen Name (without .txt)"
               :rules="[rules.required]"
+              :error-messages="error"
               data-test="new-screen-name"
               @keyup="newScreenKeyup($event)"
             />
@@ -100,7 +101,9 @@
       <v-card-actions class="px-2">
         <v-spacer />
         <v-btn variant="outlined" @click="show = false"> Cancel </v-btn>
-        <v-btn variant="flat" @click="saveNewScreen"> Save </v-btn>
+        <v-btn variant="flat" :disabled="!!error" @click="saveNewScreen">
+          Save
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -152,6 +155,12 @@ export default {
       } else {
         return 'None'
       }
+    },
+    error: function () {
+      if (this.newScreenName && this.newScreenName.match(/\*$/)) {
+        return `${this.newScreenName} is not a valid filename. Must not end in '*'.`
+      }
+      return null
     },
   },
   watch: {
@@ -218,7 +227,7 @@ export default {
       }
     },
     saveNewScreen() {
-      if (this.duplicateScreenAlert || this.newScreenName === '') {
+      if (this.duplicateScreenAlert || !this.newScreenName || this.error) {
         return
       }
       this.newScreenSaving = true

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1958,8 +1958,8 @@ export default {
     // This only gets called when the user changes the filename dropdown
     // Or when a user hits Go
     fileNameChanged(filename) {
-      // Split off the '*' which indicates modified
-      filename = filename.split('*')[0]
+      // Strip the '*' which indicates modified
+      filename = filename ? filename.replace(/\*$/, '') : filename
       this.editor.setValue(this.files[filename].content)
       this.restoreBreakpoints(filename)
       this.editor.clearSelection()
@@ -3166,8 +3166,8 @@ export default {
       // since we're installing fresh content
       this.saveAllowed = true
       this.files = {} // Clear the cached file list
-      // Split off the ' *' which indicates a file is modified on the server
-      let newFilename = file.name.split('*')[0]
+      // Strip the '*' which indicates a file is modified on the server
+      let newFilename = file.name ? file.name.replace(/\*$/, '') : file.name
       if (local === false) {
         // We only need to unlock if the file is different
         if (this.filename !== newFilename) {
@@ -3366,7 +3366,7 @@ export default {
       this.showSaveAs = true
     },
     async saveAsFilename(filename) {
-      this.filename = filename.split('*')[0]
+      this.filename = filename ? filename.replace(/\*$/, '') : filename
       this.currentFilename = null
       // The lifecycle state belongs to the file, not the editor contents,
       // so clear it before saving under the new name. The server still

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1959,7 +1959,7 @@ export default {
     // Or when a user hits Go
     fileNameChanged(filename) {
       // Strip the '*' which indicates modified
-      filename = filename ? filename.replace(/\*$/, '') : filename
+      filename = filename.replace(/\*$/, '')
       this.editor.setValue(this.files[filename].content)
       this.restoreBreakpoints(filename)
       this.editor.clearSelection()
@@ -3167,7 +3167,7 @@ export default {
       this.saveAllowed = true
       this.files = {} // Clear the cached file list
       // Strip the '*' which indicates a file is modified on the server
-      let newFilename = file.name ? file.name.replace(/\*$/, '') : file.name
+      let newFilename = file.name.replace(/\*$/, '')
       if (local === false) {
         // We only need to unlock if the file is different
         if (this.filename !== newFilename) {
@@ -3366,7 +3366,7 @@ export default {
       this.showSaveAs = true
     },
     async saveAsFilename(filename) {
-      this.filename = filename ? filename.replace(/\*$/, '') : filename
+      this.filename = filename.replace(/\*$/, '')
       this.currentFilename = null
       // The lifecycle state belongs to the file, not the editor contents,
       // so clear it before saving under the new name. The server still

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1978,7 +1978,7 @@ export default {
     // Or when a user hits Go
     fileNameChanged(filename) {
       // Strip the '*' which indicates modified
-      filename = filename ? filename.replace(/\*$/, '') : filename
+      filename = filename.replace(/\*$/, '')
       this.editor.setValue(this.files[filename].content)
       this.restoreBreakpoints(filename)
       this.markLine(this.files[filename].lineNo, this.state)
@@ -3352,7 +3352,7 @@ export default {
       this.saveAllowed = true
       this.files = {} // Clear the cached file list
       // Strip the '*' which indicates a file is modified on the server
-      let newFilename = file.name ? file.name.replace(/\*$/, '') : file.name
+      let newFilename = file.name.replace(/\*$/, '')
       if (local === false) {
         // We only need to unlock if the file is different
         if (this.filename !== newFilename) {
@@ -3551,7 +3551,7 @@ export default {
       this.showSaveAs = true
     },
     async saveAsFilename(filename) {
-      this.filename = filename ? filename.replace(/\*$/, '') : filename
+      this.filename = filename.replace(/\*$/, '')
       this.currentFilename = null
       // The lifecycle state belongs to the file, not the editor contents,
       // so clear it before saving under the new name. The server still

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/ScriptRunner.vue
@@ -1977,9 +1977,9 @@ export default {
     // This only gets called when the user changes the filename dropdown
     // Or when a user hits Go
     fileNameChanged(filename) {
-      // Split off the '*' which indicates modified
-      filename = filename.split('*')[0]
-      this.setEditorContent(this.files[filename].content)
+      // Strip the '*' which indicates modified
+      filename = filename ? filename.replace(/\*$/, '') : filename
+      this.editor.setValue(this.files[filename].content)
       this.restoreBreakpoints(filename)
       this.markLine(this.files[filename].lineNo, this.state)
     },
@@ -3351,8 +3351,8 @@ export default {
       // since we're installing fresh content
       this.saveAllowed = true
       this.files = {} // Clear the cached file list
-      // Split off the ' *' which indicates a file is modified on the server
-      let newFilename = file.name.split('*')[0]
+      // Strip the '*' which indicates a file is modified on the server
+      let newFilename = file.name ? file.name.replace(/\*$/, '') : file.name
       if (local === false) {
         // We only need to unlock if the file is different
         if (this.filename !== newFilename) {
@@ -3551,7 +3551,7 @@ export default {
       this.showSaveAs = true
     },
     async saveAsFilename(filename) {
-      this.filename = filename.split('*')[0]
+      this.filename = filename ? filename.replace(/\*$/, '') : filename
       this.currentFilename = null
       // The lifecycle state belongs to the file, not the editor contents,
       // so clear it before saving under the new name. The server still

--- a/openc3/lib/openc3/utilities/script.rb
+++ b/openc3/lib/openc3/utilities/script.rb
@@ -37,12 +37,6 @@ class Script < OpenC3::TargetFile
     super(scope, nil, target: target) # No path matchers
   end
 
-  # Split off the '*' that indicates a file is modified on the server
-  def self.strip_modified(name)
-    name.split('*')[0]
-  end
-  private_class_method :strip_modified
-
   def self.lock(scope, name, username)
     OpenC3::Store.hset("#{scope}__script-locks", strip_modified(name), username)
   end

--- a/openc3/lib/openc3/utilities/target_file.rb
+++ b/openc3/lib/openc3/utilities/target_file.rb
@@ -21,6 +21,16 @@ module OpenC3
     # Matches ScriptRunner.vue const TEMP_FOLDER
     TEMP_FOLDER = '__TEMP__'
 
+    # self.all appends '*' to a name to mark it as modified on the server. The
+    # marker is display-only, so every path in and out of the bucket strips it.
+    #
+    # Strip only '*' at the end of a file name. '*' is a legal S3 object key character
+    # and is allowed by FileOpenSaveDialog's filename charset, so files named that
+    # way exist in the field and have to stay addressable.
+    def self.strip_modified(name)
+      name.sub(/\*$/, '')
+    end
+
     def self.all(scope, path_matchers, target: nil)
       target = target.upcase if target
 
@@ -89,7 +99,7 @@ module OpenC3
     end
 
     def self.body(scope, name)
-      name = name.split('*')[0] # Split '*' that indicates modified
+      name = strip_modified(name) # Remove '*' that indicates modified
       # First try opening a potentially modified version by looking for the modified target
       if ENV['OPENC3_LOCAL_MODE']
         local_file = OpenC3::LocalMode.open_local_file(name, scope: scope)
@@ -122,6 +132,10 @@ module OpenC3
 
     def self.create(scope, name, text, content_type: 'text/plain')
       return false unless text
+      # A trailing '*' here is the display-only modified marker leaking in from a
+      # file listing, not a name any caller means to write. Remove it to avoid 
+      # creating a file with a '*' in the name.
+      name = strip_modified(name)
       if ENV['OPENC3_LOCAL_MODE']
         OpenC3::LocalMode.put_target_file("#{scope}/targets_modified/#{name}", text, scope: scope)
       end
@@ -146,6 +160,9 @@ module OpenC3
     end
 
     def self.destroy(scope, name)
+      # Match body/create so deleting a name taken straight from a listing
+      # removes the file the user actually picked
+      name = strip_modified(name)
       if ENV['OPENC3_LOCAL_MODE']
         OpenC3::LocalMode.delete_local("#{scope}/targets_modified/#{name}")
       end

--- a/openc3/python/openc3/utilities/running_script.py
+++ b/openc3/python/openc3/utilities/running_script.py
@@ -731,8 +731,8 @@ class RunningScript:
     @classmethod
     def script_get_breakpoints(cls, scope, name):
         breakpoints = Store.hget(
-            f"{scope}__script-breakpoints", name.split("*")[0]
-        )  # Split '*' that indicates modified
+            f"{scope}__script-breakpoints", TargetFile.strip_modified(name)
+        ) # Remove '*' that indicates modified
         if breakpoints:
             return json.loads(breakpoints)
         return []

--- a/openc3/python/openc3/utilities/running_script.py
+++ b/openc3/python/openc3/utilities/running_script.py
@@ -732,7 +732,7 @@ class RunningScript:
     def script_get_breakpoints(cls, scope, name):
         breakpoints = Store.hget(
             f"{scope}__script-breakpoints", TargetFile.strip_modified(name)
-        ) # Remove '*' that indicates modified
+        )  # Remove '*' that indicates modified
         if breakpoints:
             return json.loads(breakpoints)
         return []

--- a/openc3/python/openc3/utilities/target_file.py
+++ b/openc3/python/openc3/utilities/target_file.py
@@ -15,9 +15,20 @@ from openc3.utilities.local_mode import LocalMode
 
 
 class TargetFile:
+    # The file listing appends '*' to a name to mark it as modified on the server
+    # (see TargetFile.all in the Ruby library). The marker is display-only, so
+    # every read strips it.
+    #
+    # Strip only '*' at the end of a file name. '*' is a legal S3 object key character
+    # and is allowed by FileOpenSaveDialog's filename charset, so files named that
+    # way exist in the field and have to stay addressable.
+    @classmethod
+    def strip_modified(cls, name):
+        return name[:-1] if name.endswith("*") else name
+
     @classmethod
     def body(cls, scope, name):
-        name = name.split("*")[0]  # Split '*' that indicates modified
+        name = cls.strip_modified(name) # Remove '*' that indicates modified
         # First try opening a potentially modified version by looking for the modified target
         if OPENC3_LOCAL_MODE:
             local_file = LocalMode.open_local_file(name, scope=scope)

--- a/openc3/python/openc3/utilities/target_file.py
+++ b/openc3/python/openc3/utilities/target_file.py
@@ -28,7 +28,7 @@ class TargetFile:
 
     @classmethod
     def body(cls, scope, name):
-        name = cls.strip_modified(name) # Remove '*' that indicates modified
+        name = cls.strip_modified(name)  # Remove '*' that indicates modified
         # First try opening a potentially modified version by looking for the modified target
         if OPENC3_LOCAL_MODE:
             local_file = LocalMode.open_local_file(name, scope=scope)

--- a/openc3/spec/utilities/target_file_spec.rb
+++ b/openc3/spec/utilities/target_file_spec.rb
@@ -1,0 +1,83 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require "spec_helper"
+require "openc3/utilities/target_file"
+require "openc3/utilities/aws_bucket"
+
+module OpenC3
+  describe TargetFile do
+    # TargetFile.all marks a file that has a targets_modified copy by appending
+    # '*' to its name. The marker is display-only, so it must not survive into a
+    # bucket key -- body() strips it before looking a name up, so a '*'-suffixed
+    # key can be written and then never read back.
+    # See https://github.com/OpenC3/cosmos/issues/3780
+    describe "self.strip_modified" do
+      it "removes a trailing marker" do
+        expect(TargetFile.strip_modified("TGT/procedures/test.rb*")).to eql "TGT/procedures/test.rb"
+      end
+
+      it "leaves an unmarked name alone" do
+        expect(TargetFile.strip_modified("TGT/procedures/test.rb")).to eql "TGT/procedures/test.rb"
+      end
+
+      # '*' is a legal S3 object key character and FileOpenSaveDialog's filename
+      # charset allows it, so files named this way exist and must stay
+      # addressable
+      it "keeps a '*' that is not the trailing marker" do
+        expect(TargetFile.strip_modified("TGT/procedures/a*b.rb")).to eql "TGT/procedures/a*b.rb"
+      end
+
+      it "strips only the marker from a name that also contains a '*'" do
+        expect(TargetFile.strip_modified("TGT/procedures/a*b.rb*")).to eql "TGT/procedures/a*b.rb"
+      end
+    end
+
+    describe "marker handling on bucket keys" do
+      before(:each) do
+        @fsys_s3 = ENV['OPENC3_CLOUD'].nil? || ENV['OPENC3_CLOUD'] == 'local'
+        local_s3() if @fsys_s3
+        ENV['OPENC3_CONFIG_BUCKET'] = "config"
+        @bucket = Bucket.getClient.create("config")
+      end
+
+      after(:each) do
+        Bucket.getClient.delete(@bucket) if @bucket
+        local_s3_unset()
+      end
+
+      it "writes the unmarked key when create is handed a marked name" do
+        expect(TargetFile.create("DEFAULT", "TGT/procedures/marked.rb*", "puts 'hi'")).to be true
+        # The whole point: the file is readable afterwards, under either spelling
+        expect(TargetFile.body("DEFAULT", "TGT/procedures/marked.rb")).to eql "puts 'hi'"
+        expect(TargetFile.body("DEFAULT", "TGT/procedures/marked.rb*")).to eql "puts 'hi'"
+        # And no stray '*' key was left behind
+        expect(Bucket.getClient.check_object(
+          bucket: "config", key: "DEFAULT/targets_modified/TGT/procedures/marked.rb*"
+        )).to be false
+      end
+
+      it "deletes the unmarked key when destroy is handed a marked name" do
+        TargetFile.create("DEFAULT", "TGT/procedures/gone.rb", "puts 'bye'")
+        expect(TargetFile.body("DEFAULT", "TGT/procedures/gone.rb")).to eql "puts 'bye'"
+        TargetFile.destroy("DEFAULT", "TGT/procedures/gone.rb*")
+        expect(TargetFile.body("DEFAULT", "TGT/procedures/gone.rb")).to be_nil
+      end
+
+      it "round trips a name that legitimately contains a '*'" do
+        expect(TargetFile.create("DEFAULT", "TGT/procedures/a*b.rb", "puts 'star'")).to be true
+        expect(TargetFile.body("DEFAULT", "TGT/procedures/a*b.rb")).to eql "puts 'star'"
+      end
+    end
+  end
+end

--- a/playwright/tests/tlm-viewer.p.spec.ts
+++ b/playwright/tests/tlm-viewer.p.spec.ts
@@ -253,6 +253,12 @@ test('creates new blank screen', async ({ page, utils }) => {
   await expect(page.locator('.v-dialog')).toContainText(
     'Screen ADCS already exists!',
   )
+  // Check a name ending in '*' is rejected since '*' marks a modified file
+  await page.locator('[data-test="new-screen-name"] input').fill('adcs2*')
+  await expect(page.locator('.v-dialog')).toContainText(
+    "adcs2* is not a valid filename. Must not end in '*'.",
+  )
+  await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()
   // Create the screen name as upcase because OpenC3 upcases the name
   const screen = 'SCREEN' + Math.floor(Math.random() * 10000)
   await page.locator('[data-test="new-screen-name"] input').fill(screen)


### PR DESCRIPTION
### What changed

- Update the pattern we follow when stripping the modified marker `*` from the end a file
- Add error message to the New Screen dialog in Telemetry Viewer that will block creating a screen ending in `*` 

### Why it changed

- The marker is meant to be display only, so it's important that we strip it when saving or loading files. However the old  `split('*')[0]` pattern would also truncate at a `*` in the middle of a name. This would turn 'TGT/lib/a*b.rb' into 'TGT/lib/a'. `*` is a legal S3 object key character, so such a file can exist (shipped by a plugin, say) and has to stay addressable.
- If a user can create a screen ending in `*` and another screen already has that same root name(ex, ADCS and ADCS*), then changes made for the screen without `*` are applied to the screen with `*`

### Testing strategy

Added unit tests to cover TargetFile and screen behaviors. Script Runner & Table Manager playwright tests that cover this functionality still pass 

### Review notes
Found this issue while addressing the Save As bug that was resolved in the below PR
https://github.com/OpenC3/cosmos/pull/3785