### PR TITLE
Fix structure of Copyright header

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/RawBuffer.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdtlmserver/src/tools/CmdTlmServer/RawBuffer.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025, OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/openc3-cosmos-tool-iframe.gemspec
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/openc3-cosmos-tool-iframe.gemspec
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2025, OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/src/App.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/src/App.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/src/router.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-iframe/src/router.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2023, OpenC3, Inc.
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/formatter.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/formatter.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025, OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/routeUtils.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/utils/routeUtils.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/viteDevServerPlugin.mjs
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/viteDevServerPlugin.mjs
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/CommandEditor.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/ace/AceEditorUtils.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/ace/AceEditorUtils.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025, OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/ace/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/ace/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/config/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/dataviewer/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/dataviewer/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginProps.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/PluginProps.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/plugins/plugin-store/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025, OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/admin/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/base/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/calendar/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2024, OpenC3, Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/tools/scriptrunner/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025, OpenC3, Inc.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/buttonScriptSandbox.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/buttonScriptSandbox.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/settingsCache.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/util/settingsCache.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LimitsColor.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LimitsColor.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/index.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/index.js
@@ -1,5 +1,5 @@
 /*
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/lib/openc3/api/metrics_api.rb
+++ b/openc3/lib/openc3/api/metrics_api.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/lib/openc3/api/offline_access_api.rb
+++ b/openc3/lib/openc3/api/offline_access_api.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2022 OpenC3, Inc
+# Copyright 2022 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/lib/openc3/api/stash_api.rb
+++ b/openc3/lib/openc3/api/stash_api.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2024 OpenC3, Inc
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/lib/openc3/microservices/multi_microservice.rb
+++ b/openc3/lib/openc3/microservices/multi_microservice.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2024 OpenC3 Inc.
+# Copyright 2024 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/openc3/api/config_api.py
+++ b/openc3/python/openc3/api/config_api.py
@@ -1,4 +1,4 @@
-# Copyright 2023 OpenC3, Inc
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/openc3/api/offline_access_api.py
+++ b/openc3/python/openc3/api/offline_access_api.py
@@ -1,4 +1,4 @@
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/openc3/api/settings_api.py
+++ b/openc3/python/openc3/api/settings_api.py
@@ -1,4 +1,4 @@
-# Copyright 2026 OpenC3, Inc
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/openc3/api/stash_api.py
+++ b/openc3/python/openc3/api/stash_api.py
@@ -1,4 +1,4 @@
-# Copyright 2023 OpenC3, Inc
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/openc3/api/target_api.py
+++ b/openc3/python/openc3/api/target_api.py
@@ -1,4 +1,4 @@
-# Copyright 2023 OpenC3, Inc
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/openc3/io/stdout.py
+++ b/openc3/python/openc3/io/stdout.py
@@ -1,4 +1,4 @@
-# Copyright 2023, OpenC3, Inc.
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/openc3/tools/table_manager/__init__.py
+++ b/openc3/python/openc3/tools/table_manager/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 OpenC3, Incx.
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/test/test_json_rpc_error.py
+++ b/openc3/python/test/test_json_rpc_error.py
@@ -1,4 +1,4 @@
-# Copyright 2023 OpenC3, Inc
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/test/test_json_rpc_request.py
+++ b/openc3/python/test/test_json_rpc_request.py
@@ -1,4 +1,4 @@
-# Copyright 2023 OpenC3, Inc
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/python/test/utilities/test_questdb_client.py
+++ b/openc3/python/test/utilities/test_questdb_client.py
@@ -1,4 +1,4 @@
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/spec/logs/buffered_packet_log_writer_spec.rb
+++ b/openc3/spec/logs/buffered_packet_log_writer_spec.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/spec/utilities/bucket_require_spec.rb
+++ b/openc3/spec/utilities/bucket_require_spec.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2023 OpenC3, Inc
+# Copyright 2023 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/spec/utilities/bucket_spec.rb
+++ b/openc3/spec/utilities/bucket_spec.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2022 OpenC3, Inc
+# Copyright 2022 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/spec/utilities/bucket_utilities_spec.rb
+++ b/openc3/spec/utilities/bucket_utilities_spec.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2022 OpenC3, Inc
+# Copyright 2022 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/spec/utilities/questdb_client_spec.rb
+++ b/openc3/spec/utilities/questdb_client_spec.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved
 #
 # This program is distributed in the hope that it will be useful,

--- a/openc3/test/benchmarks/c_extensions_benchmark.rb
+++ b/openc3/test/benchmarks/c_extensions_benchmark.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-# Copyright 2026, OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This file may also be used under the terms of a commercial license

--- a/playwright/tests/admin/interfaces.p.spec.ts
+++ b/playwright/tests/admin/interfaces.p.spec.ts
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/playwright/tests/admin/microservices.p.spec.ts
+++ b/playwright/tests/admin/microservices.p.spec.ts
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/playwright/tests/admin/packages.p.spec.ts
+++ b/playwright/tests/admin/packages.p.spec.ts
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/playwright/tests/admin/redis.p.spec.ts
+++ b/playwright/tests/admin/redis.p.spec.ts
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/playwright/tests/admin/routers.p.spec.ts
+++ b/playwright/tests/admin/routers.p.spec.ts
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/playwright/tests/admin/secrets.p.spec.ts
+++ b/playwright/tests/admin/secrets.p.spec.ts
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/playwright/tests/admin/targets.p.spec.ts
+++ b/playwright/tests/admin/targets.p.spec.ts
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,

--- a/playwright/tests/admin/tools.p.spec.ts
+++ b/playwright/tests/admin/tools.p.spec.ts
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 OpenC3, Inc
+# Copyright 2025 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
### What changed

Some Copyright headers changed

### Why it changed

These headers were not exactly the right format, so they would not have the year updated by the pre-commit hook

### Testing strategy

No testing, comments only, explicitly committed with `--no-verify` to _not_ update the copyright year for these files as part of this commit
