### PR TITLE
build(justfile): add module hierarchy and unified check recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ __pycache__
 
 playwright/tests/enterprise
 .vscode
+
+# RuboCop JSON report generated for SonarQube import
+rubocop-report.json

--- a/.rubocop-src.yml
+++ b/.rubocop-src.yml
@@ -1,0 +1,26 @@
+# RuboCop config for source-only runs: everything in .rubocop.yml, minus test code.
+#
+# Test code accounts for roughly 60% of the repo's offenses and is mostly noise
+# for source-quality work (long example blocks, throwaway constants, deliberate
+# edge-case code). Use `just lint-ruby-src` when you want to see only what the
+# shipped library and API code reports; `just lint-ruby` still covers
+# everything.
+#
+# Both a directory rule and a filename rule are needed: most specs live under a
+# spec/ or test/ directory, but some sit elsewhere (for example
+# openc3/test/integration/tsdb/ruby/cvt_model_tsdb_spec.rb). Demo and example
+# procedures named *_test.rb are shipped source, not test code, so they are
+# deliberately not excluded.
+inherit_from: .rubocop.yml
+
+# Without this, AllCops/Exclude below would replace the inherited list rather
+# than add to it, and the node_modules/.venv excludes would come back.
+inherit_mode:
+  merge:
+    - Exclude
+
+AllCops:
+  Exclude:
+    - '**/spec/**/*'
+    - '**/test/**/*'
+    - '**/*_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,3 +45,33 @@ Lint/RedundantStringCoercion:
 # This rule interferes with a lot of unit tests as well as json_accessor.rb
 Lint/ConstantDefinitionInBlock:
   Enabled: false
+
+# ---------------------------------------------------------------------------
+# SonarQube coexistence
+#
+# SonarQube owns behavior, security, and complexity findings; RuboCop owns
+# layout and naming. The cops below are RuboCop's "unsafe correctable" set -
+# their autocorrections can change semantics, which means `rubocop -A` could
+# silently undo a hand-written fix for a SonarQube issue. Autocorrect is
+# disabled on them so they report only and a human decides. Safe corrections
+# are semantics-preserving by RuboCop's own contract and stay enabled.
+# ---------------------------------------------------------------------------
+Lint/AmbiguousRange:
+  AutoCorrect: false
+Lint/AssignmentInCondition:
+  AutoCorrect: false
+Lint/DuplicateRequire:
+  AutoCorrect: false
+Lint/IncompatibleIoSelectWithFiberScheduler:
+  AutoCorrect: false
+Lint/InterpolationCheck:
+  AutoCorrect: false
+Lint/Loop:
+  AutoCorrect: false
+# Sonar flags the same TOCTOU race; let Sonar's fix stand
+Lint/NonAtomicFileOperation:
+  AutoCorrect: false
+Lint/RedundantDirGlobSort:
+  AutoCorrect: false
+Lint/UselessMethodDefinition:
+  AutoCorrect: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,21 @@
 AllCops:
   NewCops: enable
   TargetRubyVersion: 3.4
+  # RuboCop's built-in excludes (node_modules, vendor, tmp, .git) are anchored at
+  # the config directory, so they only cover the repo root. This is a monorepo
+  # with node_modules, vendor and build output nested several levels deep, and
+  # pnpm's node_modules/.pnpm is a symlink graph - walking it enumerates a
+  # combinatorial number of paths and exhausts memory before any file is parsed.
+  # Re-state the excludes with a '**/' prefix so they match at any depth.
+  Exclude:
+    - '**/node_modules/**/*'
+    - '**/vendor/**/*'
+    - '**/tmp/**/*'
+    - '**/.git/**/*'
+    - '**/.venv/**/*'
+    - '**/coverage/**/*'
+    - '**/dist/**/*'
+    - '**/.yardoc/**/*'
 
 # Layout
 Layout/LineLength:

--- a/justfile
+++ b/justfile
@@ -3,9 +3,20 @@
 
 plugins_dir := "openc3-cosmos-init/plugins/packages"
 
+# Component command namespaces
+mod playwright 'playwright/justfile'
+mod python 'openc3/python/justfile'
+mod ruby 'openc3/justfile'
+
 # Default recipe - show available commands
 default:
     @just --list
+
+# Run checks for all components
+check: lint-all
+    just ruby::check
+    just python::check
+    just playwright::check
 
 # ---------------------------------------------------------------------------
 # Shared dependency builds

--- a/justfile
+++ b/justfile
@@ -1,7 +1,10 @@
 # OpenC3 COSMOS Root Development Commands
 # Run `just` or `just --list` to see all available commands
-
-plugins_dir := "openc3-cosmos-init/plugins/packages"
+#
+# Component commands live in per-component justfiles and are reached through
+# their namespace, e.g. `just plugins::lint-all` or `just python::test`. Only
+# repo-wide recipes belong here; RuboCop is one because its config, Gemfile
+# and scan scope all span the whole repository.
 
 # The root Gemfile reads its source from RUBYGEMS_URL (see .env)
 rubygems_url := env("RUBYGEMS_URL", "https://rubygems.org")
@@ -11,6 +14,7 @@ rubocop_src_config := ".rubocop-src.yml"
 
 # Component command namespaces
 mod playwright 'playwright/justfile'
+mod plugins 'openc3-cosmos-init/plugins/justfile'
 mod python 'openc3/python/justfile'
 mod ruby 'openc3/justfile'
 
@@ -19,146 +23,15 @@ default:
     @just --list
 
 # Run every linter/formatter check in the repo (no tests)
-check: lint-all
+check:
     just lint-ruby
+    just plugins::lint-check
     just python::lint-check
     just playwright::lint-check
 
 # ---------------------------------------------------------------------------
-# Shared dependency builds
-# ---------------------------------------------------------------------------
-
-# Build all shared frontend dependencies (js-common, vue-common, tool-base)
-# Skips packages whose src/ hasn't changed since the last build
-build-deps:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    build_if_stale() {
-        local name="$1" src="$2" out="$3"
-        local dir="{{ plugins_dir }}/$name"
-        if [[ ! -d "$dir/$out" ]] || [[ -n "$(find "$dir/$src" -newer "$dir/$out" -type f 2>/dev/null | head -1)" ]]; then
-            echo "Building $name ..."
-            (cd "$dir" && pnpm install && pnpm build)
-        else
-            echo "Skipping $name (up to date)"
-        fi
-    }
-    build_if_stale openc3-js-common  src dist
-    build_if_stale openc3-vue-common src dist
-    build_if_stale openc3-tool-base  src tools/base
-
-# Force-build all shared frontend dependencies (ignore cache)
-build-deps-force:
-    cd {{ plugins_dir }}/openc3-js-common && pnpm install && pnpm build
-    cd {{ plugins_dir }}/openc3-vue-common && pnpm install && pnpm build
-    cd {{ plugins_dir }}/openc3-tool-base && pnpm install && pnpm build
-
-# ---------------------------------------------------------------------------
-# Generic dev server
-# ---------------------------------------------------------------------------
-
-# Run any plugin dev server: just dev openc3-cosmos-tool-admin
-dev plugin *FLAGS:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    plugin="{{ plugin }}"
-    skip_deps=false
-    for flag in {{ FLAGS }}; do
-        if [[ "$flag" == "--skip-deps" ]]; then
-            skip_deps=true
-        fi
-    done
-    dir="{{ plugins_dir }}/$plugin"
-    if [[ ! -d "$dir" ]]; then
-        echo "Error: plugin '$plugin' not found in {{ plugins_dir }}"
-        echo ""
-        echo "Available plugins:"
-        ls {{ plugins_dir }} | grep openc3-cosmos-tool-
-        exit 1
-    fi
-    if [[ "$skip_deps" == false ]]; then
-        just build-deps
-    fi
-    cd "$dir"
-    pnpm install
-    port=$(grep -o 'port: [0-9]*' vite.config.js 2>/dev/null | grep -o '[0-9]*' | head -1)
-    port="${port:-2900}"
-    echo ""
-    echo "Starting $plugin on http://localhost:$port"
-    echo ""
-    pnpm serve
-
-# ---------------------------------------------------------------------------
-# Individual tool dev servers (alphabetical)
-# ---------------------------------------------------------------------------
-
-# Dev server for Admin (port 2930)
-dev-admin *FLAGS:
-    just dev openc3-cosmos-tool-admin {{ FLAGS }}
-
-# Dev server for Bucket Explorer (port 2921)
-dev-bucket-explorer *FLAGS:
-    just dev openc3-cosmos-tool-bucketexplorer {{ FLAGS }}
-
-# Dev server for Command Sender (port 2913)
-dev-cmd-sender *FLAGS:
-    just dev openc3-cosmos-tool-cmdsender {{ FLAGS }}
-
-# Dev server for CmdTlm Server (port 2911)
-dev-cmd-tlm-server *FLAGS:
-    just dev openc3-cosmos-tool-cmdtlmserver {{ FLAGS }}
-
-# Dev server for Data Extractor (port 2918)
-dev-data-extractor *FLAGS:
-    just dev openc3-cosmos-tool-dataextractor {{ FLAGS }}
-
-# Dev server for Data Viewer (port 2919)
-dev-data-viewer *FLAGS:
-    just dev openc3-cosmos-tool-dataviewer {{ FLAGS }}
-
-# Dev server for Handbooks (port 2922)
-dev-handbooks *FLAGS:
-    just dev openc3-cosmos-tool-handbooks {{ FLAGS }}
-
-# Dev server for iFrame (port 2915)
-dev-iframe *FLAGS:
-    just dev openc3-cosmos-tool-iframe {{ FLAGS }}
-
-# Dev server for Limits Monitor (port 2912)
-dev-limits-monitor *FLAGS:
-    just dev openc3-cosmos-tool-limitsmonitor {{ FLAGS }}
-
-# Dev server for Packet Viewer (port 2915)
-dev-packet-viewer *FLAGS:
-    just dev openc3-cosmos-tool-packetviewer {{ FLAGS }}
-
-# Dev server for Script Runner (port 2914)
-dev-script-runner *FLAGS:
-    just dev openc3-cosmos-tool-scriptrunner {{ FLAGS }}
-
-# Dev server for Table Manager (port 2916)
-dev-table-manager *FLAGS:
-    just dev openc3-cosmos-tool-tablemanager {{ FLAGS }}
-
-# Dev server for Telemetry Grapher (port 2917)
-dev-tlm-grapher *FLAGS:
-    just dev openc3-cosmos-tool-tlmgrapher {{ FLAGS }}
-
-# Dev server for Telemetry Viewer (port 2920)
-dev-tlm-viewer *FLAGS:
-    just dev openc3-cosmos-tool-tlmviewer {{ FLAGS }}
-
-# ---------------------------------------------------------------------------
 # Linting
 # ---------------------------------------------------------------------------
-
-# Lint a specific package: just lint openc3-cosmos-tool-dataextractor
-lint package:
-    cd {{ plugins_dir }}/{{ package }} && pnpm lint
-
-# Lint and auto-fix a specific package
-lint-fix package:
-    cd {{ plugins_dir }}/{{ package }} && pnpm lint --fix
 
 # Install the RuboCop gems declared in the root Gemfile
 lint-ruby-install:
@@ -193,49 +66,3 @@ lint-ruby-src-stats:
 # Write a RuboCop JSON report for SonarQube (sonar.ruby.rubocop.reportPaths)
 lint-ruby-report:
     RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop --format json --out rubocop-report.json
-
-# Lint all packages that have a lint script
-lint-all:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    failed=0
-    for dir in {{ plugins_dir }}/openc3-*/; do
-        if grep -q '"lint"' "$dir/package.json" 2>/dev/null; then
-            name=$(basename "$dir")
-            echo "Linting $name ..."
-            if (cd "$dir" && pnpm lint --max-warnings 0); then
-                echo "  OK"
-            else
-                echo "  FAILED"
-                failed=$((failed + 1))
-            fi
-        fi
-    done
-    if [ $failed -gt 0 ]; then
-        echo ""
-        echo "$failed package(s) failed linting"
-        exit 1
-    fi
-    echo ""
-    echo "All packages passed!"
-
-# Lint and auto-fix all packages that have a lint script
-lint-fix-all:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    for dir in {{ plugins_dir }}/openc3-*/; do
-        if grep -q '"lint"' "$dir/package.json" 2>/dev/null; then
-            name=$(basename "$dir")
-            echo "Fixing $name ..."
-            (cd "$dir" && pnpm lint --fix) || true
-        fi
-    done
-    echo "Done"
-
-# ---------------------------------------------------------------------------
-# Utilities
-# ---------------------------------------------------------------------------
-
-# List all available frontend plugins
-list-plugins:
-    @ls {{ plugins_dir }} | grep openc3-cosmos-tool-

--- a/justfile
+++ b/justfile
@@ -3,6 +3,9 @@
 
 plugins_dir := "openc3-cosmos-init/plugins/packages"
 
+# The root Gemfile reads its source from RUBYGEMS_URL (see .env)
+rubygems_url := env("RUBYGEMS_URL", "https://rubygems.org")
+
 # Component command namespaces
 mod playwright 'playwright/justfile'
 mod python 'openc3/python/justfile'
@@ -12,11 +15,11 @@ mod ruby 'openc3/justfile'
 default:
     @just --list
 
-# Run checks for all components
+# Run every linter/formatter check in the repo (no tests)
 check: lint-all
-    just ruby::check
-    just python::check
-    just playwright::check
+    just lint-ruby
+    just python::lint-check
+    just playwright::lint-check
 
 # ---------------------------------------------------------------------------
 # Shared dependency builds
@@ -153,6 +156,28 @@ lint package:
 # Lint and auto-fix a specific package
 lint-fix package:
     cd {{ plugins_dir }}/{{ package }} && pnpm lint --fix
+
+# Install the RuboCop gems declared in the root Gemfile
+lint-ruby-install:
+    RUBYGEMS_URL={{ rubygems_url }} bundle install
+
+# Lint Ruby with RuboCop: just lint-ruby openc3/lib
+lint-ruby *ARGS:
+    RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop {{ ARGS }}
+
+# Never use -A/--autocorrect-all here: unsafe corrections can undo a SonarQube
+# fix. The unsafe cops also have AutoCorrect: false set in .rubocop.yml.
+# Auto-fix Ruby with RuboCop, safe corrections only
+lint-ruby-fix *ARGS:
+    RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop --autocorrect {{ ARGS }}
+
+# Show RuboCop offense counts by cop
+lint-ruby-stats:
+    RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop --format offenses
+
+# Write a RuboCop JSON report for SonarQube (sonar.ruby.rubocop.reportPaths)
+lint-ruby-report:
+    RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop --format json --out rubocop-report.json
 
 # Lint all packages that have a lint script
 lint-all:

--- a/justfile
+++ b/justfile
@@ -6,6 +6,9 @@ plugins_dir := "openc3-cosmos-init/plugins/packages"
 # The root Gemfile reads its source from RUBYGEMS_URL (see .env)
 rubygems_url := env("RUBYGEMS_URL", "https://rubygems.org")
 
+# RuboCop config that inherits .rubocop.yml but excludes spec files
+rubocop_src_config := ".rubocop-src.yml"
+
 # Component command namespaces
 mod playwright 'playwright/justfile'
 mod python 'openc3/python/justfile'
@@ -165,15 +168,27 @@ lint-ruby-install:
 lint-ruby *ARGS:
     RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop {{ ARGS }}
 
+# Lint Ruby source only, skipping spec files: just lint-ruby-src openc3/lib
+lint-ruby-src *ARGS:
+    RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop -c {{ rubocop_src_config }} --force-exclusion {{ ARGS }}
+
 # Never use -A/--autocorrect-all here: unsafe corrections can undo a SonarQube
 # fix. The unsafe cops also have AutoCorrect: false set in .rubocop.yml.
 # Auto-fix Ruby with RuboCop, safe corrections only
 lint-ruby-fix *ARGS:
     RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop --autocorrect {{ ARGS }}
 
+# Auto-fix Ruby source only, skipping spec files, safe corrections only
+lint-ruby-src-fix *ARGS:
+    RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop -c {{ rubocop_src_config }} --force-exclusion --autocorrect {{ ARGS }}
+
 # Show RuboCop offense counts by cop
 lint-ruby-stats:
     RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop --format offenses
+
+# Show RuboCop offense counts by cop for source only, skipping spec files
+lint-ruby-src-stats:
+    RUBYGEMS_URL={{ rubygems_url }} bundle exec rubocop -c {{ rubocop_src_config }} --format offenses
 
 # Write a RuboCop JSON report for SonarQube (sonar.ruby.rubocop.reportPaths)
 lint-ruby-report:

--- a/openc3-cosmos-init/plugins/justfile
+++ b/openc3-cosmos-init/plugins/justfile
@@ -1,0 +1,189 @@
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+# OpenC3 COSMOS Frontend Plugin Commands
+# Run `just` or `just --list` to see all available commands
+#
+# From the repository root these are namespaced: `just plugins::lint-all`.
+# Recipes run with this directory (the pnpm workspace root) as the working
+# directory, so paths below are relative to openc3-cosmos-init/plugins.
+#
+# Quick Start:
+#   just build-deps       - Build the shared packages the tools import
+#   just dev-admin        - Run a tool's dev server
+#   just lint-all         - Lint every workspace package
+
+packages_dir := "packages"
+
+# Default recipe - show available commands
+default:
+    @just --list
+
+# ---------------------------------------------------------------------------
+# Shared dependency builds
+# ---------------------------------------------------------------------------
+
+# Skips packages whose src/ hasn't changed since the last build
+
+# Build all shared frontend dependencies (js-common, vue-common, tool-base)
+build-deps:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    build_if_stale() {
+        local name="$1" src="$2" out="$3"
+        local dir="{{ packages_dir }}/$name"
+        if [[ ! -d "$dir/$out" ]] || [[ -n "$(find "$dir/$src" -newer "$dir/$out" -type f 2>/dev/null | head -1)" ]]; then
+            echo "Building $name ..."
+            (cd "$dir" && pnpm install && pnpm build)
+        else
+            echo "Skipping $name (up to date)"
+        fi
+    }
+    build_if_stale openc3-js-common  src dist
+    build_if_stale openc3-vue-common src dist
+    build_if_stale openc3-tool-base  src tools/base
+
+# Force-build all shared frontend dependencies (ignore cache)
+build-deps-force:
+    cd {{ packages_dir }}/openc3-js-common && pnpm install && pnpm build
+    cd {{ packages_dir }}/openc3-vue-common && pnpm install && pnpm build
+    cd {{ packages_dir }}/openc3-tool-base && pnpm install && pnpm build
+
+# ---------------------------------------------------------------------------
+# Generic dev server
+# ---------------------------------------------------------------------------
+
+# Run any plugin dev server: just dev openc3-cosmos-tool-admin
+dev plugin *FLAGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    plugin="{{ plugin }}"
+    skip_deps=false
+    for flag in {{ FLAGS }}; do
+        if [[ "$flag" == "--skip-deps" ]]; then
+            skip_deps=true
+        fi
+    done
+    dir="{{ packages_dir }}/$plugin"
+    if [[ ! -d "$dir" ]]; then
+        echo "Error: plugin '$plugin' not found in {{ packages_dir }}"
+        echo ""
+        echo "Available plugins:"
+        ls {{ packages_dir }} | grep openc3-cosmos-tool-
+        exit 1
+    fi
+    if [[ "$skip_deps" == false ]]; then
+        just build-deps
+    fi
+    cd "$dir"
+    pnpm install
+    port=$(grep -o 'port: [0-9]*' vite.config.js 2>/dev/null | grep -o '[0-9]*' | head -1)
+    port="${port:-2900}"
+    echo ""
+    echo "Starting $plugin on http://localhost:$port"
+    echo ""
+    pnpm serve
+
+# ---------------------------------------------------------------------------
+# Individual tool dev servers (alphabetical)
+# ---------------------------------------------------------------------------
+
+# Dev server for Admin (port 2930)
+dev-admin *FLAGS:
+    just dev openc3-cosmos-tool-admin {{ FLAGS }}
+
+# Dev server for Bucket Explorer (port 2921)
+dev-bucket-explorer *FLAGS:
+    just dev openc3-cosmos-tool-bucketexplorer {{ FLAGS }}
+
+# Dev server for Command Sender (port 2913)
+dev-cmd-sender *FLAGS:
+    just dev openc3-cosmos-tool-cmdsender {{ FLAGS }}
+
+# Dev server for CmdTlm Server (port 2911)
+dev-cmd-tlm-server *FLAGS:
+    just dev openc3-cosmos-tool-cmdtlmserver {{ FLAGS }}
+
+# Dev server for Data Extractor (port 2918)
+dev-data-extractor *FLAGS:
+    just dev openc3-cosmos-tool-dataextractor {{ FLAGS }}
+
+# Dev server for Data Viewer (port 2919)
+dev-data-viewer *FLAGS:
+    just dev openc3-cosmos-tool-dataviewer {{ FLAGS }}
+
+# Dev server for Handbooks (port 2922)
+dev-handbooks *FLAGS:
+    just dev openc3-cosmos-tool-handbooks {{ FLAGS }}
+
+# Dev server for iFrame (port 2915)
+dev-iframe *FLAGS:
+    just dev openc3-cosmos-tool-iframe {{ FLAGS }}
+
+# Dev server for Limits Monitor (port 2912)
+dev-limits-monitor *FLAGS:
+    just dev openc3-cosmos-tool-limitsmonitor {{ FLAGS }}
+
+# Dev server for Packet Viewer (port 2915)
+dev-packet-viewer *FLAGS:
+    just dev openc3-cosmos-tool-packetviewer {{ FLAGS }}
+
+# Dev server for Script Runner (port 2914)
+dev-script-runner *FLAGS:
+    just dev openc3-cosmos-tool-scriptrunner {{ FLAGS }}
+
+# Dev server for Table Manager (port 2916)
+dev-table-manager *FLAGS:
+    just dev openc3-cosmos-tool-tablemanager {{ FLAGS }}
+
+# Dev server for Telemetry Grapher (port 2917)
+dev-tlm-grapher *FLAGS:
+    just dev openc3-cosmos-tool-tlmgrapher {{ FLAGS }}
+
+# Dev server for Telemetry Viewer (port 2920)
+dev-tlm-viewer *FLAGS:
+    just dev openc3-cosmos-tool-tlmviewer {{ FLAGS }}
+
+# ---------------------------------------------------------------------------
+# Linting
+# ---------------------------------------------------------------------------
+
+# Lint a single package: just plugins::lint openc3-cosmos-tool-dataextractor
+lint package *ARGS:
+    cd {{ packages_dir }}/{{ package }} && pnpm lint --max-warnings 0 {{ ARGS }}
+
+# Auto-fix a single package
+lint-fix package *ARGS:
+    cd {{ packages_dir }}/{{ package }} && pnpm lint --fix {{ ARGS }}
+
+# ESLint 9 flat config does not cascade, so each package must be linted from
+# its own directory against its own eslint.config.mjs. The workspace `lint`
+# script (lint-all.mjs) handles that, and additionally fails when a package
+# has a src/ but no eslint config - source that would otherwise go unchecked.
+
+# Lint every workspace package
+lint-all *ARGS:
+    pnpm lint --max-warnings 0 {{ ARGS }}
+
+# Auto-fix every workspace package
+lint-fix-all *ARGS:
+    pnpm lint --fix {{ ARGS }}
+
+# Check lint only, no tests (used by the root `just check`)
+lint-check: lint-all
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+# List all available frontend tool plugins
+list-plugins:
+    @ls {{ packages_dir }} | grep openc3-cosmos-tool-

--- a/openc3/justfile
+++ b/openc3/justfile
@@ -45,6 +45,9 @@ ruby-verify:
     bundle exec rspec
     @echo "All Ruby specs passed!"
 
+# Check code without making changes
+check: ruby-verify
+
 # Build the gem
 ruby-gem:
     bundle exec rake gems

--- a/openc3/justfile
+++ b/openc3/justfile
@@ -45,9 +45,6 @@ ruby-verify:
     bundle exec rspec
     @echo "All Ruby specs passed!"
 
-# Check code without making changes
-check: ruby-verify
-
 # Build the gem
 ruby-gem:
     bundle exec rake gems

--- a/openc3/python/justfile
+++ b/openc3/python/justfile
@@ -149,6 +149,10 @@ verify-changed:
 
     echo "✅ Changed files verified!"
 
+# Check lint and formatting only, no tests (used by the root `just check`)
+lint-check: format-check lint-strict
+    @echo "✅ Lint and format checks passed!"
+
 # Check code without making changes (for CI - fails on any issues)
 check: format-check lint-strict test
     @echo "✅ All checks passed!"

--- a/playwright/justfile
+++ b/playwright/justfile
@@ -63,6 +63,9 @@ check-running:
 test: check-running
     pnpm test:parallel --quiet && pnpm test:serial --quiet
 
+# Check end-to-end tests
+check: test
+
 # Run only parallel tests
 test-parallel *ARGS: check-running
     pnpm test:parallel {{ ARGS }}

--- a/playwright/justfile
+++ b/playwright/justfile
@@ -63,8 +63,20 @@ check-running:
 test: check-running
     pnpm test:parallel --quiet && pnpm test:serial --quiet
 
-# Check end-to-end tests
-check: test
+# Lint test files with ESLint
+lint:
+    pnpm lint --max-warnings 0
+
+# Lint and auto-fix test files
+lint-fix:
+    pnpm lint --fix
+
+# Check formatting without making changes
+format-check:
+    pnpm exec prettier --check ./
+
+# Check lint and formatting only, no tests (used by the root `just check`)
+lint-check: lint format-check
 
 # Run only parallel tests
 test-parallel *ARGS: check-running


### PR DESCRIPTION
- Import the playwright, python, and ruby justfiles as mod namespaces from the root justfile so their recipes are reachable as just <component>::<recipe>
- Add a root check recipe that runs lint-all then each component's check, giving one entry point for the whole repo
- Add check aliases in openc3/justfile (ruby-verify) and playwright/justfile (test) so every component answers to the same recipe name

### What changed

The ability to call the other check commands in other justfiles. Now they can all be ran at the top-level; python, ruby and front-end

### Why it changed

Easier then trying to find the correct justfile
