### PR TITLE
[Feature] OPENC3_LOG_LEVEL to control log levels

### DIFF
--- a/.env
+++ b/.env
@@ -33,7 +33,7 @@ OPENC3_EXTERNAL_URL=http://localhost:2900
 # NOTE: Optional per-service runtime flags (OPENC3_FORCE_INSTALL,
 # OPENC3_DEFAULT_QUEUE, OPENC3_AUTH_RATE_LIMIT_*, OPENC3_ALLOW_HTTP,
 # OPENC3_NO_EVAL, OPENC3_LANGUAGE, OPENC3_NO_BUCKET_POLICY,
-# OPENC3_LOG_STDERR, the OPENC3_NO_* tool flags, and extra
+# OPENC3_LOG_STDERR, OPENC3_LOG_LEVEL, the OPENC3_NO_* tool flags, and extra
 # buckets/volumes) are now documented in compose.override.yaml under
 # the service each one applies to.
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -140,6 +140,16 @@
 #     - OPENC3_NO_EVAL=1
 
 # -------------------------------------------------------------------------
+# Log level on any service
+# -------------------------------------------------------------------------
+# OPENC3_LOG_LEVEL sets the minimum level logged: DEBUG, INFO (default),
+# WARN, ERROR, or FATAL. It is read by every container - add it under
+# whichever service(s) you want, or set it in .env for all of them:
+# openc3-operator:
+#   environment:
+#     - OPENC3_LOG_LEVEL=DEBUG
+
+# -------------------------------------------------------------------------
 # Log to stderr on any service
 # -------------------------------------------------------------------------
 # OPENC3_LOG_STDERR logs warnings and higher to stderr instead of stdout.

--- a/compose.yaml
+++ b/compose.yaml
@@ -227,6 +227,7 @@ services:
       - OPENC3_AUTH_RATE_LIMIT_TO
       - OPENC3_AUTH_RATE_LIMIT_WITHIN
       - OPENC3_LOG_STDERR
+      - OPENC3_LOG_LEVEL
     extra_hosts:
       - host.docker.internal:host-gateway
 
@@ -294,6 +295,7 @@ services:
       - OPENC3_SERVICE_PASSWORD=${OPENC3_SERVICE_PASSWORD}
       # Optional: bare pass-through (only forwarded if set in host env or .env)
       - OPENC3_LOG_STDERR
+      - OPENC3_LOG_LEVEL
 
   openc3-operator:
     read_only: true
@@ -368,6 +370,7 @@ services:
       - OPENC3_SERVICE_PASSWORD=${OPENC3_SERVICE_PASSWORD}
       # Optional: bare pass-through (only forwarded if set in host env or .env)
       - OPENC3_LOG_STDERR
+      - OPENC3_LOG_LEVEL
     extra_hosts:
       - host.docker.internal:host-gateway
 
@@ -483,6 +486,7 @@ services:
       - OPENC3_INIT_WAIT_TIMEOUT
       - OPENC3_ISTIO_ENABLED
       - OPENC3_LOG_STDERR
+      - OPENC3_LOG_LEVEL
       # Per-tool install opt-outs
       - OPENC3_NO_CMDTLMSERVER
       - OPENC3_NO_LIMITSMONITOR

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/microservices/EXAMPLE/example_target.rb
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/microservices/EXAMPLE/example_target.rb
@@ -119,7 +119,7 @@ module OpenC3
     end
 
     def run
-      Logger.level = Logger::INFO
+      Logger.level = Logger.default_level
       Thread.abort_on_exception = true
 
       # This state probably won't even display because we immediately

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/microservices/TEMPLATED/scpi_target.rb
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/microservices/TEMPLATED/scpi_target.rb
@@ -68,7 +68,7 @@ module OpenC3
     end
 
     def run
-      Logger.level = Logger::INFO
+      Logger.level = Logger.default_level
       Thread.abort_on_exception = true
 
       # This state probably won't even display because we immediately

--- a/openc3/lib/openc3/operators/operator.rb
+++ b/openc3/lib/openc3/operators/operator.rb
@@ -233,7 +233,7 @@ module OpenC3
     PROCESS_SHUTDOWN_SECONDS = 5.0
 
     def initialize
-      Logger.level = Logger::INFO
+      Logger.level = Logger.default_level
       Logger.microservice_name = 'MicroserviceOperator'
 
       OperatorProcess.setup()

--- a/openc3/lib/openc3/utilities/logger.rb
+++ b/openc3/lib/openc3/utilities/logger.rb
@@ -44,22 +44,28 @@ module OpenC3
     @@instance = nil
     @@scope = ENV.fetch('OPENC3_SCOPE', 'DEFAULT')
 
-    # DEBUG only prints DEBUG messages
+    # Levels in increasing severity. Logging at a level prints that level
+    # and everything above it, e.g. WARN prints WARN, ERROR and FATAL.
     DEBUG = ::Logger::DEBUG
-    # INFO prints INFO, DEBUG messages
     INFO  = ::Logger::INFO
-    # WARN prints WARN, INFO, DEBUG messages
     WARN  = ::Logger::WARN
-    # ERROR prints ERROR, WARN, INFO, DEBUG messages
     ERROR = ::Logger::ERROR
-    # FATAL prints FATAL, ERROR, WARN, INFO, DEBUG messages
     FATAL = ::Logger::FATAL
 
+    # Level names as they appear in log messages and OPENC3_LOG_LEVEL
     DEBUG_LEVEL = 'DEBUG'
     INFO_LEVEL = 'INFO'
     WARN_LEVEL = 'WARN'
     ERROR_LEVEL = 'ERROR'
     FATAL_LEVEL = 'FATAL'
+
+    LEVELS = {
+      DEBUG_LEVEL => DEBUG,
+      INFO_LEVEL => INFO,
+      WARN_LEVEL => WARN,
+      ERROR_LEVEL => ERROR,
+      FATAL_LEVEL => FATAL
+    }.freeze
 
     # Types
     LOG = 'log'
@@ -67,8 +73,23 @@ module OpenC3
     ALERT = 'alert'
     EPHEMERAL = 'ephemeral'
 
+    # @return [Integer] Level named by the OPENC3_LOG_LEVEL env var.
+    #   INFO if the var is unset or isn't a level name.
+    def self.default_level
+      name = ENV['OPENC3_LOG_LEVEL'].to_s.strip.upcase
+      return INFO if name.empty?
+
+      LEVELS.fetch(name) do
+        unless @warned_bad_level
+          @warned_bad_level = true
+          $stderr.puts "OPENC3_LOG_LEVEL '#{ENV['OPENC3_LOG_LEVEL']}' is not one of #{LEVELS.keys.join(', ')}, using INFO"
+        end
+        INFO
+      end
+    end
+
     # @param level [Integer] The initial logging level
-    def initialize(level = Logger::INFO)
+    def initialize(level = Logger.default_level)
       @stdout = true
       @level = level
       @detail_string = nil

--- a/openc3/lib/openc3/utilities/logger.rb
+++ b/openc3/lib/openc3/utilities/logger.rb
@@ -76,13 +76,14 @@ module OpenC3
     # @return [Integer] Level named by the OPENC3_LOG_LEVEL env var.
     #   INFO if the var is unset or isn't a level name.
     def self.default_level
-      name = ENV['OPENC3_LOG_LEVEL'].to_s.strip.upcase
+      level = ENV.fetch('OPENC3_LOG_LEVEL', '')
+      name = level.to_s.strip.upcase
       return INFO if name.empty?
 
       LEVELS.fetch(name) do
         unless @warned_bad_level
           @warned_bad_level = true
-          $stderr.puts "OPENC3_LOG_LEVEL '#{ENV['OPENC3_LOG_LEVEL']}' is not one of #{LEVELS.keys.join(', ')}, using INFO"
+          $stderr.puts "OPENC3_LOG_LEVEL '#{level}' is not one of #{LEVELS.keys.join(', ')}, using INFO"
         end
         INFO
       end

--- a/openc3/lib/openc3/utilities/running_script.rb
+++ b/openc3/lib/openc3/utilities/running_script.rb
@@ -1556,7 +1556,7 @@ class RunningScript
     $stdout = OpenC3::Stdout.instance
     $stderr = OpenC3::Stderr.instance
     OpenC3::Logger.stdout = true
-    OpenC3::Logger.level = OpenC3::Logger::INFO
+    OpenC3::Logger.level = OpenC3::Logger.default_level
   end
 
   def output_thread

--- a/openc3/python/docs/environment.md
+++ b/openc3/python/docs/environment.md
@@ -138,7 +138,7 @@ OPENC3_API_PASSWORD=password
 
 > CORE, ENTERPRISE
 
-The library can log much more of what is happening in the library. If you wish to enable this you can set the environment variable `OPENC3_LOG_LEVEL` to equal "DEBUG". If this is not set you will not get log messages if this is an incorrect log level you will get a ValueError.
+Sets the minimum level logged: `DEBUG`, `INFO`, `WARN`, `ERROR`, or `FATAL`. Logging at a level prints that level and everything above it, so `DEBUG` logs everything and `FATAL` logs almost nothing. Names are case insensitive. If the variable is unset the level is `INFO`; if it names something else the level is `INFO` and a warning is printed to stderr.
 
 Example:
 

--- a/openc3/python/openc3/__init__.py
+++ b/openc3/python/openc3/__init__.py
@@ -14,7 +14,17 @@ import logging
 from openc3.environment import OPENC3_LOG_LEVEL
 
 
+# Level names COSMOS accepts in OPENC3_LOG_LEVEL, mapped to the stdlib
+# logging levels. Anything else (including unset) logs at INFO.
+LOG_LEVELS = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARN": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "FATAL": logging.CRITICAL,
+}
+
 logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    level=logging.getLevelName(OPENC3_LOG_LEVEL),
+    level=LOG_LEVELS.get(OPENC3_LOG_LEVEL.strip().upper(), logging.INFO),
 )

--- a/openc3/python/openc3/utilities/logger.py
+++ b/openc3/python/openc3/utilities/logger.py
@@ -84,6 +84,27 @@ class LogLevel(IntEnum):
     FATAL = 4
 
 
+warned_bad_level = False
+
+
+# Level named by the OPENC3_LOG_LEVEL env var.
+# INFO if the var is unset or isn't a level name.
+def default_level():
+    global warned_bad_level
+
+    name = OPENC3_LOG_LEVEL.strip().upper()
+    if not name:
+        return LogLevel.INFO
+    try:
+        return LogLevel[name]
+    except KeyError:
+        if not warned_bad_level:
+            warned_bad_level = True
+            names = ", ".join(level.name for level in LogLevel)
+            print(f"OPENC3_LOG_LEVEL '{OPENC3_LOG_LEVEL}' is not one of {names}, using INFO", file=sys.stderr)
+        return LogLevel.INFO
+
+
 # Supports different levels of logging and only writes if the level
 # is exceeded.
 class Logger(metaclass=LoggerMeta):
@@ -102,10 +123,10 @@ class Logger(metaclass=LoggerMeta):
     ALERT = "alert"
     EPHEMERAL = "ephemeral"
 
-    # @param level [Integer] The initial logging level
-    def __init__(self, level=LogLevel.INFO):
+    # @param level [LogLevel] The initial logging level
+    def __init__(self, level=None):
         self.stdout = True
-        self.level = level
+        self.level = default_level() if level is None else level
         self.detail_string = None
         self.container_name = socket.gethostname()
         self.microservice_name = None
@@ -116,7 +137,7 @@ class Logger(metaclass=LoggerMeta):
 
     # Get the singleton instance
     @classmethod
-    def instance(cls, level=LogLevel.INFO):
+    def instance(cls, level=None):
         if cls.my_instance:
             return cls.my_instance
 

--- a/openc3/python/openc3/utilities/running_script.py
+++ b/openc3/python/openc3/utilities/running_script.py
@@ -144,7 +144,7 @@ from openc3.script.exceptions import CheckError, SkipScriptError, StopScriptErro
 from openc3.script.suite import Group
 from openc3.tools.test_runner.test import SkipTestCase
 from openc3.top_level import kill_thread
-from openc3.utilities.logger import Logger
+from openc3.utilities.logger import Logger, default_level
 from openc3.utilities.message_log import MessageLog
 from openc3.utilities.script_instrumentor import ScriptInstrumentor
 from openc3.utilities.sleeper import Sleeper
@@ -1270,7 +1270,7 @@ class RunningScript:
         sys.stdout = Stdout.instance()
         sys.stderr = Stderr.instance()
         Logger.stdout = True
-        Logger.level = Logger.INFO
+        Logger.level = default_level()
 
     def output_thread_body(self):
         RunningScript.cancel_output = False

--- a/openc3/python/test/utilities/test_logger.py
+++ b/openc3/python/test/utilities/test_logger.py
@@ -17,16 +17,12 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
-import openc3.utilities.logger
 from openc3.utilities.logger import Logger, default_level
 
 
 class TestDefaultLevel(unittest.TestCase):
-    def setUp(self):
-        openc3.utilities.logger.warned_bad_level = False
-
     def set_env_level(self, value):
-        return patch.object(openc3.utilities.logger, "OPENC3_LOG_LEVEL", value)
+        return patch("openc3.utilities.logger.OPENC3_LOG_LEVEL", value)
 
     def test_returns_info_if_not_set(self):
         with self.set_env_level(""):
@@ -53,7 +49,8 @@ class TestDefaultLevel(unittest.TestCase):
         orig = sys.stderr
         sys.stderr = StringIO()
         try:
-            with self.set_env_level("WARNING"):
+            # patch restores warned_bad_level, so this test can't leak into others
+            with patch("openc3.utilities.logger.warned_bad_level", False), self.set_env_level("WARNING"):
                 self.assertEqual(default_level(), Logger.INFO)
                 self.assertEqual(default_level(), Logger.INFO)
             stderr = sys.stderr.getvalue()
@@ -68,11 +65,11 @@ class TestLogger(unittest.TestCase):
         Logger.stdout = True
 
     def test_initializes_the_level_to_info(self):
-        with patch.object(openc3.utilities.logger, "OPENC3_LOG_LEVEL", ""):
+        with patch("openc3.utilities.logger.OPENC3_LOG_LEVEL", ""):
             self.assertEqual(Logger().level, Logger.INFO)
 
     def test_initializes_the_level_from_openc3_log_level(self):
-        with patch.object(openc3.utilities.logger, "OPENC3_LOG_LEVEL", "DEBUG"):
+        with patch("openc3.utilities.logger.OPENC3_LOG_LEVEL", "DEBUG"):
             self.assertEqual(Logger().level, Logger.DEBUG)
 
     def test_gets_and_set_the_level(self):

--- a/openc3/python/test/utilities/test_logger.py
+++ b/openc3/python/test/utilities/test_logger.py
@@ -17,7 +17,50 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
-from openc3.utilities.logger import Logger
+import openc3.utilities.logger
+from openc3.utilities.logger import Logger, default_level
+
+
+class TestDefaultLevel(unittest.TestCase):
+    def setUp(self):
+        openc3.utilities.logger.warned_bad_level = False
+
+    def set_env_level(self, value):
+        return patch.object(openc3.utilities.logger, "OPENC3_LOG_LEVEL", value)
+
+    def test_returns_info_if_not_set(self):
+        with self.set_env_level(""):
+            self.assertEqual(default_level(), Logger.INFO)
+
+    def test_accepts_every_level_name(self):
+        for name, level in [
+            ("DEBUG", Logger.DEBUG),
+            ("INFO", Logger.INFO),
+            ("WARN", Logger.WARN),
+            ("ERROR", Logger.ERROR),
+            ("FATAL", Logger.FATAL),
+        ]:
+            with self.set_env_level(name):
+                self.assertEqual(default_level(), level)
+
+    def test_ignores_case_and_surrounding_whitespace(self):
+        with self.set_env_level("debug"):
+            self.assertEqual(default_level(), Logger.DEBUG)
+        with self.set_env_level(" warn "):
+            self.assertEqual(default_level(), Logger.WARN)
+
+    def test_warns_once_and_returns_info_for_an_unknown_level(self):
+        orig = sys.stderr
+        sys.stderr = StringIO()
+        try:
+            with self.set_env_level("WARNING"):
+                self.assertEqual(default_level(), Logger.INFO)
+                self.assertEqual(default_level(), Logger.INFO)
+            stderr = sys.stderr.getvalue()
+        finally:
+            sys.stderr = orig
+        self.assertEqual(stderr.count("OPENC3_LOG_LEVEL 'WARNING'"), 1)
+        self.assertIn("DEBUG, INFO, WARN, ERROR, FATAL", stderr)
 
 
 class TestLogger(unittest.TestCase):
@@ -25,7 +68,12 @@ class TestLogger(unittest.TestCase):
         Logger.stdout = True
 
     def test_initializes_the_level_to_info(self):
-        self.assertEqual(Logger().level, Logger.INFO)
+        with patch.object(openc3.utilities.logger, "OPENC3_LOG_LEVEL", ""):
+            self.assertEqual(Logger().level, Logger.INFO)
+
+    def test_initializes_the_level_from_openc3_log_level(self):
+        with patch.object(openc3.utilities.logger, "OPENC3_LOG_LEVEL", "DEBUG"):
+            self.assertEqual(Logger().level, Logger.DEBUG)
 
     def test_gets_and_set_the_level(self):
         Logger.level = Logger.DEBUG

--- a/openc3/python/test/utilities/test_logger.py
+++ b/openc3/python/test/utilities/test_logger.py
@@ -14,6 +14,7 @@ import os
 import sys
 import time
 import unittest
+from contextlib import redirect_stderr
 from io import StringIO
 from unittest.mock import patch
 
@@ -46,16 +47,16 @@ class TestDefaultLevel(unittest.TestCase):
             self.assertEqual(default_level(), Logger.WARN)
 
     def test_warns_once_and_returns_info_for_an_unknown_level(self):
-        orig = sys.stderr
-        sys.stderr = StringIO()
-        try:
-            # patch restores warned_bad_level, so this test can't leak into others
-            with patch("openc3.utilities.logger.warned_bad_level", False), self.set_env_level("WARNING"):
-                self.assertEqual(default_level(), Logger.INFO)
-                self.assertEqual(default_level(), Logger.INFO)
-            stderr = sys.stderr.getvalue()
-        finally:
-            sys.stderr = orig
+        capture = StringIO()
+        # patch restores warned_bad_level, so this test can't leak into others
+        with (
+            redirect_stderr(capture),
+            patch("openc3.utilities.logger.warned_bad_level", False),
+            self.set_env_level("WARNING"),
+        ):
+            self.assertEqual(default_level(), Logger.INFO)
+            self.assertEqual(default_level(), Logger.INFO)
+        stderr = capture.getvalue()
         self.assertEqual(stderr.count("OPENC3_LOG_LEVEL 'WARNING'"), 1)
         self.assertIn("DEBUG, INFO, WARN, ERROR, FATAL", stderr)
 

--- a/openc3/spec/utilities/logger_spec.rb
+++ b/openc3/spec/utilities/logger_spec.rb
@@ -26,7 +26,58 @@ module OpenC3
 
     describe "initialize" do
       it "initializes the level to INFO" do
+        ENV.delete('OPENC3_LOG_LEVEL')
         expect(Logger.new.level).to eql Logger::INFO
+      end
+
+      it "initializes the level from OPENC3_LOG_LEVEL" do
+        ENV['OPENC3_LOG_LEVEL'] = 'DEBUG'
+        expect(Logger.new.level).to eql Logger::DEBUG
+      ensure
+        ENV.delete('OPENC3_LOG_LEVEL')
+      end
+    end
+
+    describe "default_level" do
+      after(:each) do
+        ENV.delete('OPENC3_LOG_LEVEL')
+        Logger.instance_variable_set(:@warned_bad_level, nil)
+      end
+
+      it "returns INFO if OPENC3_LOG_LEVEL isn't set" do
+        expect(Logger.default_level).to eql Logger::INFO
+      end
+
+      it "accepts every level name" do
+        {
+          'DEBUG' => Logger::DEBUG,
+          'INFO' => Logger::INFO,
+          'WARN' => Logger::WARN,
+          'ERROR' => Logger::ERROR,
+          'FATAL' => Logger::FATAL
+        }.each do |name, level|
+          ENV['OPENC3_LOG_LEVEL'] = name
+          expect(Logger.default_level).to eql level
+        end
+      end
+
+      it "ignores case and surrounding whitespace" do
+        ENV['OPENC3_LOG_LEVEL'] = 'debug'
+        expect(Logger.default_level).to eql Logger::DEBUG
+        ENV['OPENC3_LOG_LEVEL'] = ' warn '
+        expect(Logger.default_level).to eql Logger::WARN
+      end
+
+      it "warns once and returns INFO for an unknown level" do
+        stderr = StringIO.new('', 'r+')
+        $stderr = stderr
+        ENV['OPENC3_LOG_LEVEL'] = 'WARNING'
+        expect(Logger.default_level).to eql Logger::INFO
+        expect(Logger.default_level).to eql Logger::INFO
+        expect(stderr.string.scan("OPENC3_LOG_LEVEL 'WARNING'").length).to eql 1
+        expect(stderr.string).to match("DEBUG, INFO, WARN, ERROR, FATAL")
+      ensure
+        $stderr = STDERR
       end
     end
 


### PR DESCRIPTION
### What changed

OPENC3_LOG_LEVEL env var to control log levels produced by the OpenC3 Logger

### Why it changed

External requirements to be able to control log levels
