### PR TITLE
Fix/screen error reporting

### DIFF
--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/screens/adcs.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/screens/adcs.txt
@@ -1,7 +1,7 @@
 SCREEN AUTO AUTO 1.0
 
 VERTICAL
-  TITLE "<%= target_name %> Instrument ADCS Information" Courier 20 NORMAL true
+  TITLE "<%= target_name %> Instrument ADCS Information"
   # Note @original_target_name is also available
 
   HORIZONTAL

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/screens/other.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/screens/other.txt
@@ -3,7 +3,7 @@ SCREEN 500 200 1.0
 SCROLLWINDOW 200
 
   # Change the title font to 10 pt courier without bold and make it italic
-  TITLE "<%= target_name %> Other Widget Examples" courier 10 normal true
+  TITLE "<%= target_name %> Other Widget Examples"
 
   HORIZONTAL
     LABEL "TestText œ © ®" # Throw in some UTF-8 chars

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/screens/other.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST/screens/other.txt
@@ -2,8 +2,13 @@ SCREEN 500 200 1.0
 
 SCROLLWINDOW 200
 
-  # Change the title font to 10 pt courier without bold and make it italic
+  # TITLE only takes the text. Style it with SETTING RAW, which is how the
+  # COSMOS 4 font parameters (10 pt courier, not bold, italic) are done now.
   TITLE "<%= target_name %> Other Widget Examples"
+    SETTING RAW font-family Courier
+    SETTING RAW font-size 10pt
+    SETTING RAW font-weight normal
+    SETTING RAW font-style italic
 
   HORIZONTAL
     LABEL "TestText œ © ®" # Throw in some UTF-8 chars

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/screens/adcs.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/screens/adcs.txt
@@ -1,7 +1,7 @@
 SCREEN AUTO AUTO 1.0
 
 VERTICAL
-  TITLE "<%= target_name %> Instrument ADCS Information" Courier 20 NORMAL true
+  TITLE "<%= target_name %> Instrument ADCS Information"
   # Note @original_target_name is also available
 
   HORIZONTAL

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/screens/other.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/screens/other.txt
@@ -3,7 +3,7 @@ SCREEN 500 200 1.0
 SCROLLWINDOW 200
 
   # Change the title font to 10 pt courier without bold and make it italic
-  TITLE "<%= target_name %> Other Widget Examples" courier 10 normal true
+  TITLE "<%= target_name %> Other Widget Examples"
 
   HORIZONTAL
     LABEL "TestText"

--- a/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/screens/other.txt
+++ b/openc3-cosmos-init/plugins/packages/openc3-cosmos-demo/targets/INST2/screens/other.txt
@@ -2,8 +2,13 @@ SCREEN 500 200 1.0
 
 SCROLLWINDOW 200
 
-  # Change the title font to 10 pt courier without bold and make it italic
+  # TITLE only takes the text. Style it with SETTING RAW, which is how the
+  # COSMOS 4 font parameters (10 pt courier, not bold, italic) are done now.
   TITLE "<%= target_name %> Other Widget Examples"
+    SETTING RAW font-family Courier
+    SETTING RAW font-size 10pt
+    SETTING RAW font-weight normal
+    SETTING RAW font-style italic
 
   HORIZONTAL
     LABEL "TestText"

--- a/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-js-common/src/services/cable.js
@@ -91,10 +91,17 @@ class ResilientSubscription {
       {
         ...this._callbacks,
         disconnected: (data) => {
+          // We tore this subscription down ourselves (unsubscribe, or the
+          // whole cable disconnecting because the component unmounted). The
+          // caller isn't interested and may already be half destroyed, so
+          // don't report it as a connection problem.
+          if (this._unsubscribed) {
+            return
+          }
           // allowReconnect false means the client has given up on this
-          // subscription: either we unsubscribed it (nothing to do) or the
-          // subscribe failed unrecoverably and the consumer needs rebuilding.
-          if (!this._unsubscribed && data?.allowReconnect === false) {
+          // subscription: the subscribe failed unrecoverably and the consumer
+          // needs rebuilding.
+          if (data?.allowReconnect === false) {
             this._cable._scheduleRecovery()
           }
           this._callbacks.disconnected?.(data)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
@@ -120,7 +120,14 @@ export default {
           (a, b) => a.lineNumber - b.lineNumber,
         )
         for (const error of sortedErrors) {
-          let msg = `At ${error.lineNumber}: (${error.line}) ${error.message}.`
+          if (messages.has(error.message)) {
+            continue
+          }
+          // Runtime errors (a lost connection, say) aren't tied to a line in
+          // the definition, so only prefix the location when we have one
+          let msg = error.lineNumber
+            ? `At ${error.lineNumber}: (${error.line}) ${error.message}.`
+            : `${error.message}.`
           if (error.usage) {
             msg += ` Usage: ${error.usage}`
           }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/EditScreenDialog.vue
@@ -120,7 +120,11 @@ export default {
           (a, b) => a.lineNumber - b.lineNumber,
         )
         for (const error of sortedErrors) {
-          if (messages.has(error.message)) {
+          // Dedupe on the line as well as the message: the same message on two
+          // different lines is two different things to go fix, and addError
+          // keeps both for that reason
+          const key = `${error.lineNumber}:${error.message}`
+          if (messages.has(key)) {
             continue
           }
           // Runtime errors (a lost connection, say) aren't tied to a line in
@@ -132,7 +136,7 @@ export default {
             msg += ` Usage: ${error.usage}`
           }
           result.push(msg)
-          messages.add(error.message)
+          messages.add(key)
         }
         return result
       }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -417,6 +417,7 @@ export default {
     'click',
     'close-graph',
     'edit',
+    'error',
     'min-max-graph',
     'pause',
     'resize',
@@ -1247,6 +1248,14 @@ export default {
     clearErrors: function () {
       this.errors = []
     },
+    // Our own error list is only reachable through the toolbar, which is hidden
+    // when we're embedded in a screen (LINEGRAPH), so also emit so the screen
+    // can show it. See emitScreenError in Widget.js.
+    addError: function (error) {
+      const entry = { time: new Date().getTime(), ...error }
+      this.errors.push(entry)
+      this.$emit('error', entry)
+    },
     editGraphClose: function (graph) {
       this.editGraph = false
       this.title = graph.title
@@ -1355,18 +1364,16 @@ export default {
             // If allowReconnect is true it means we got a disconnect due to connection lost or server disconnect
             // If allowReconnect is false this is a normal server close or client close
             if (data.allowReconnect) {
-              this.errors.push({
+              this.addError({
                 type: 'disconnected',
                 message: 'OpenC3 backend connection disconnected',
-                time: new Date().getTime(),
               })
             }
           },
           rejected: () => {
-            this.errors.push({
+            this.addError({
               type: 'rejected',
               message: 'OpenC3 backend connection rejected',
-              time: new Date().getTime(),
             })
           },
         })

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Graph.vue
@@ -420,6 +420,7 @@ export default {
     'error',
     'min-max-graph',
     'pause',
+    'recovered',
     'resize',
     'start',
     'started',
@@ -1354,6 +1355,10 @@ export default {
         .createSubscription('StreamingChannel', window.openc3Scope, {
           received: (data) => this.received(data),
           connected: () => {
+            // The connection is back, so drop the disconnect we reported below
+            // and tell whoever embedded us (LINEGRAPH) to do the same
+            this.errors = this.errors.filter((error) => !error.transient)
+            this.$emit('recovered')
             const itemsToAdd = [...this.items]
             if (!this.xAxisIsDefault && !this.xAxisIsAlsoGraphedItem) {
               itemsToAdd.push(this.actualXAxisItem)
@@ -1367,6 +1372,8 @@ export default {
               this.addError({
                 type: 'disconnected',
                 message: 'OpenC3 backend connection disconnected',
+                // Cleared when 'connected' fires again, not left on the screen
+                transient: true,
               })
             }
           },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -152,6 +152,8 @@
             @open="open"
             @close="close"
             @close-all="closeAll"
+            @screen-error="addError"
+            @screen-check-items="checkItems"
           />
         </div>
       </v-expand-transition>
@@ -188,6 +190,8 @@
         @open="open"
         @close="close"
         @close-all="closeAll"
+        @screen-error="addError"
+        @screen-check-items="checkItems"
       />
     </div>
 
@@ -459,24 +463,20 @@ export default {
   // We need this because an error can occur from any of the children
   // in the widget stack and are typically thrown on create()
   errorCaptured(err, vm, info) {
-    if (this.errors.length < MAX_ERRORS) {
-      if (err.usage) {
-        this.errors.push({
-          type: 'usage',
-          message: err.message,
-          usage: err.usage,
-          line: err.line,
-          lineNumber: err.lineNumber,
-          time: new Date().getTime(),
-        })
-      } else {
-        this.errors.push({
-          type: 'error',
-          message: err,
-          time: new Date().getTime(),
-        })
-      }
-    }
+    // Keep the stack for debugging, it isn't preserved in this.errors
+    console.error('Screen widget error', err, info)
+    // Widgets throw ConfigParserError (see screenError in Widget.js) which
+    // carries the screen definition line, but anything else thrown from a
+    // widget lands here too, so pull out what's there rather than assuming.
+    this.addError({
+      type: err.usage ? 'usage' : 'error',
+      // ConfigParserError isn't an Error so String(err) is useless on it,
+      // but a bare throw of a non-Error still needs something readable
+      message: err.message ?? String(err),
+      usage: err.usage,
+      line: err.line,
+      lineNumber: err.lineNumber,
+    })
     return false
   },
   created() {
@@ -525,6 +525,29 @@ export default {
     clearErrors: function () {
       this.errors = []
     },
+    // Single entry point for every screen error: errorCaptured for widgets that
+    // throw while building, and the 'screen-error' event (emitScreenError in
+    // Widget.js) for widgets that fail after they're built.
+    addError: function (error) {
+      if (!error?.message || this.errors.length >= MAX_ERRORS) {
+        return
+      }
+      // A widget that keeps failing (a reconnect loop, say) would otherwise
+      // fill the list with the same message and push out everything else
+      const duplicate = this.errors.find(
+        (existing) =>
+          existing.message === error.message &&
+          existing.lineNumber === error.lineNumber,
+      )
+      if (duplicate) {
+        return
+      }
+      this.errors.push({
+        ...error,
+        type: error.type || 'error',
+        time: error.time || new Date().getTime(),
+      })
+    },
     updateRefreshInterval: function () {
       if (this.updater) {
         clearInterval(this.updater)
@@ -543,6 +566,15 @@ export default {
       // Each time we start over and parse the screen definition
       this.clearErrors()
       this.screenItems = []
+      // Reset what we poll along with it. The new definition may register no
+      // items at all (a screen of nothing but graphs, say) in which case
+      // nothing calls debouncedUpdateTlmAvailable and this would otherwise
+      // keep polling the previous screen's items forever.
+      this.actualScreenItems = []
+      if (this.tlmAvailableTimeout != null) {
+        clearTimeout(this.tlmAvailableTimeout)
+        this.tlmAvailableTimeout = null
+      }
       this.namedWidgets = {}
       this.layoutStack = []
       this.dynamicWidgets = []
@@ -550,10 +582,56 @@ export default {
       this.layoutStack.push({
         type: 'VerticalWidget',
         parameters: [],
+        // SETTING with no widget in front of it applies to the layout, so this
+        // has to exist even though nothing can set it on the implicit one
+        settings: [],
         widgets: [],
       })
       this.currentLayout = this.layoutStack[this.layoutStack.length - 1]
 
+      // parse_string runs our callback synchronously, so anything it throws
+      // comes back out here. It has to be caught: this runs from created() and
+      // from rerender(), neither of which is a place errorCaptured can see, so
+      // an uncaught throw takes down the whole screen instead of reporting the
+      // bad line.
+      try {
+        this.parseKeywords()
+      } catch (error) {
+        this.addError({
+          type: error.usage ? 'usage' : 'error',
+          message: error.message ?? String(error),
+          usage: error.usage,
+          line: error.line,
+          lineNumber: error.lineNumber,
+        })
+      }
+      // This can happen if there is a typo in a layout widget with a corresponding END
+      if (typeof this.layoutStack[0] === 'undefined') {
+        let names = []
+        let lines = []
+        for (const widget of this.dynamicWidgets) {
+          names.push(widget.name)
+          lines.push(widget.lineNumber)
+        }
+        // Warn about any of the Dynamic widgets we found .. they could be typos
+        this.addError({
+          type: 'usage',
+          message: `Unknown widget! Are these widgets: ${names.join(',')}?`,
+          lineNumber: lines.join(','),
+        })
+        // Create a simple VerticalWidget to replace the bad widget so
+        // the layout stack can successfully unwind
+        this.layoutStack[0] = {
+          type: 'VerticalWidget',
+          parameters: [],
+          settings: [],
+          widgets: [],
+        }
+      } else {
+        this.applyGlobalSettings(this.layoutStack[0].widgets)
+      }
+    },
+    parseKeywords: function () {
       this.configParser.parse_string(
         this.currentDefinition,
         '',
@@ -610,6 +688,16 @@ export default {
               }
               case 'END':
                 this.configParser.verify_num_parameters(0, 0, `${keyword}`)
+                // Never pop the implicit VerticalWidget every screen starts
+                // with. Without this an extra END leaves currentLayout
+                // undefined and the next keyword dies with a TypeError.
+                if (this.layoutStack.length === 1) {
+                  throw new ConfigParserError(
+                    this.configParser,
+                    'END without a matching layout widget',
+                    `${keyword}`,
+                  )
+                }
                 this.layoutStack.pop()
                 this.currentLayout =
                   this.layoutStack[this.layoutStack.length - 1]
@@ -709,33 +797,6 @@ export default {
           } // if keyword
         },
       )
-      // This can happen if there is a typo in a layout widget with a corresponding END
-      if (typeof this.layoutStack[0] === 'undefined') {
-        let names = []
-        let lines = []
-        for (const widget of this.dynamicWidgets) {
-          names.push(widget.name)
-          lines.push(widget.lineNumber)
-        }
-        // Warn about any of the Dynamic widgets we found .. they could be typos
-        if (this.errors.length < MAX_ERRORS) {
-          this.errors.push({
-            type: 'usage',
-            message: `Unknown widget! Are these widgets: ${names.join(',')}?`,
-            lineNumber: lines.join(','),
-            time: new Date().getTime(),
-          })
-        }
-        // Create a simple VerticalWidget to replace the bad widget so
-        // the layout stack can successfully unwind
-        this.layoutStack[0] = {
-          type: 'VerticalWidget',
-          parameters: [],
-          widgets: [],
-        }
-      } else {
-        this.applyGlobalSettings(this.layoutStack[0].widgets)
-      }
     },
     openEdit: function () {
       // Make a copy in case they edit and cancel
@@ -865,9 +926,10 @@ export default {
       this.updateRefreshInterval()
       // Force re-render
       this.screenKey = Math.floor(Math.random() * 1000000)
-      // After re-render clear any errors
+      // Don't clear errors here: parseDefinition already cleared the previous
+      // screen's, and the widgets report theirs as they're created, which
+      // happens before this tick runs
       this.$nextTick(function () {
-        this.clearErrors()
         this.$emit('edit-screen')
       })
     },
@@ -1041,21 +1103,10 @@ export default {
             // Note: OpenC3Api rejects with an Error built from the server
             // response so the message is the useful part. JSON.stringify on an
             // Error returns '{}' because its fields aren't enumerable.
-            let message = error.message || JSON.stringify(error, null, 2)
-            if (
-              !this.errors.find((existing) => {
-                return existing.message === message
-              })
-            ) {
-              if (this.errors.length < MAX_ERRORS) {
-                this.errors.push({
-                  type: 'error',
-                  message: message,
-                  time: new Date().getTime(),
-                  transient: true,
-                })
-              }
-            }
+            this.addError({
+              message: error.message || JSON.stringify(error, null, 2),
+              transient: true,
+            })
           })
       }
     },
@@ -1087,9 +1138,15 @@ export default {
         clearTimeout(this.tlmAvailableTimeout)
       }
       this.tlmAvailableTimeout = setTimeout(() => {
+        // The screen can be re-parsed while this is in flight, which leaves the
+        // response describing items we no longer have
+        const requestedItems = [...this.screenItems]
         this.api
-          .get_tlm_available(this.screenItems, {}, { 'Ignore-Errors': '403' })
+          .get_tlm_available(requestedItems, {}, { 'Ignore-Errors': '403' })
           .then((data) => {
+            if (requestedItems.length !== this.screenItems.length) {
+              return
+            }
             this.actualScreenItems = data
             // This must be the same or we're going to have problems
             // because the data comes back in an ordered array
@@ -1113,18 +1170,15 @@ export default {
                         line.includes(parts[2]),
                     ) + 1 // +1 for 1-based line number
                   if (itemLine > 0) {
-                    this.errors.push({
+                    this.addError({
                       type: 'usage',
                       message: `Null for ${parts.join(' ')}! Does it exist?`,
                       line: lines[itemLine - 1], // 0-based line array
                       lineNumber: itemLine,
-                      time: new Date().getTime(),
                     })
                   } else {
-                    this.errors.push({
-                      type: 'error',
+                    this.addError({
                       message: `Null for ${parts.join(' ')}! Does it exist?`,
-                      time: new Date().getTime(),
                     })
                   }
                 }
@@ -1133,10 +1187,39 @@ export default {
           })
           .catch((error) => {
             console.error('Error getting tlm available', error)
-            this.actualScreenItems = this.screenItems
+            if (requestedItems.length === this.screenItems.length) {
+              this.actualScreenItems = [...this.screenItems]
+            }
           })
         this.tlmAvailableTimeout = null
       }, 100)
+    },
+    // Widgets that stream their own data (the graphs) ask us to confirm their
+    // items exist. Unlike screenItems these aren't polled, we just look them up
+    // once so a typo shows up as a screen error instead of an empty series.
+    checkItems: function ({ valueIds, line, lineNumber }) {
+      if (!valueIds?.length) {
+        return
+      }
+      this.api
+        .get_tlm_available(valueIds, {}, { 'Ignore-Errors': '403' })
+        .then((available) => {
+          available.forEach((item, index) => {
+            if (item !== null) {
+              return
+            }
+            const parts = valueIds[index].split('__').slice(0, 3)
+            this.addError({
+              type: 'usage',
+              message: `Null for ${parts.join(' ')}! Does it exist?`,
+              line: line,
+              lineNumber: lineNumber,
+            })
+          })
+        })
+        .catch((error) => {
+          console.error('Error getting tlm available', error)
+        })
     },
     addItem: function (valueId) {
       this.screenItems.push(valueId)

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -154,6 +154,7 @@
             @close-all="closeAll"
             @screen-error="addError"
             @screen-check-items="checkItems"
+            @screen-errors-cleared="clearErrorSource"
           />
         </div>
       </v-expand-transition>
@@ -192,6 +193,7 @@
         @close-all="closeAll"
         @screen-error="addError"
         @screen-check-items="checkItems"
+        @screen-errors-cleared="clearErrorSource"
       />
     </div>
 
@@ -243,6 +245,8 @@ import WidgetComponents from '@/widgets/WidgetComponents'
 import EditScreenDialog from './EditScreenDialog.vue'
 
 const MAX_ERRORS = 20
+// Identifies our own get_tlm_values poll as the source of a transient error
+const POLL_ERROR_SOURCE = 'screen:get_tlm_values'
 
 export default {
   components: {
@@ -524,6 +528,15 @@ export default {
     },
     clearErrors: function () {
       this.errors = []
+    },
+    // A transient error belongs to whatever produced it and is cleared when
+    // that recovers, so this only drops the errors from one source. Clearing
+    // every transient error on any success would let a screen that both polls
+    // and streams hide a stream that is still disconnected.
+    clearErrorSource: function ({ source }) {
+      this.errors = this.errors.filter(
+        (error) => !error.transient || error.source !== source,
+      )
     },
     // Single entry point for every screen error: errorCaptured for widgets that
     // throw while building, and the 'screen-error' event (emitScreenError in
@@ -1097,8 +1110,10 @@ export default {
           .then((data) => {
             if (data && data.length > 0) {
               this.updateValues(data)
-              // Clear transient request errors on successful fetch
-              this.errors = this.errors.filter((error) => !error.transient)
+              // Clear the errors from this poll on a successful fetch, but not
+              // errors from anything else: a streaming widget's disconnect has
+              // nothing to do with whether the REST API answered.
+              this.clearErrorSource({ source: POLL_ERROR_SOURCE })
             }
           })
           .catch((error) => {
@@ -1108,6 +1123,7 @@ export default {
             this.addError({
               message: error.message || JSON.stringify(error, null, 2),
               transient: true,
+              source: POLL_ERROR_SOURCE,
             })
           })
       }
@@ -1210,9 +1226,16 @@ export default {
       if (!valueIds?.length) {
         return
       }
+      // rerender() clears the errors and installs a different definition, so a
+      // response that arrives after it would report the previous screen's line
+      // text and number against the new screen
+      const requestedKey = this.screenKey
       this.api
         .get_tlm_available(valueIds, {}, { 'Ignore-Errors': '403' })
         .then((available) => {
+          if (this.screenKey !== requestedKey) {
+            return
+          }
           available.forEach((item, index) => {
             if (item !== null) {
               return

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/components/Openc3Screen.vue
@@ -607,17 +607,19 @@ export default {
       }
       // This can happen if there is a typo in a layout widget with a corresponding END
       if (typeof this.layoutStack[0] === 'undefined') {
-        let names = []
-        let lines = []
-        for (const widget of this.dynamicWidgets) {
-          names.push(widget.name)
-          lines.push(widget.lineNumber)
-        }
         // Warn about any of the Dynamic widgets we found .. they could be typos
+        const names = this.dynamicWidgets.map(
+          (widget) => `${widget.name} (line ${widget.lineNumber})`,
+        )
+        // lineNumber must stay numeric so the errors sort and format correctly,
+        // so anchor the error on the first suspect and name the rest in the
+        // message
+        const suspect = this.dynamicWidgets[0]
         this.addError({
           type: 'usage',
-          message: `Unknown widget! Are these widgets: ${names.join(',')}?`,
-          lineNumber: lines.join(','),
+          message: `Unknown widget! Are these widgets: ${names.join(', ')}?`,
+          line: suspect?.line,
+          lineNumber: suspect?.lineNumber,
         })
         // Create a simple VerticalWidget to replace the bad widget so
         // the layout stack can successfully unwind
@@ -1129,6 +1131,15 @@ export default {
         }
       }
     },
+    // The screen can be re-parsed while a get_tlm_available call is in flight.
+    // The response describes the items we asked for, so it only applies if the
+    // screen still has exactly those items in the same order.
+    sameScreenItems: function (items) {
+      return (
+        items.length === this.screenItems.length &&
+        items.every((item, index) => item === this.screenItems[index])
+      )
+    },
     debouncedUpdateTlmAvailable: function () {
       // Skip API calls when frozen - we're using saved values
       if (this.frozen) {
@@ -1138,13 +1149,11 @@ export default {
         clearTimeout(this.tlmAvailableTimeout)
       }
       this.tlmAvailableTimeout = setTimeout(() => {
-        // The screen can be re-parsed while this is in flight, which leaves the
-        // response describing items we no longer have
         const requestedItems = [...this.screenItems]
         this.api
           .get_tlm_available(requestedItems, {}, { 'Ignore-Errors': '403' })
           .then((data) => {
-            if (requestedItems.length !== this.screenItems.length) {
+            if (!this.sameScreenItems(requestedItems)) {
               return
             }
             this.actualScreenItems = data
@@ -1187,7 +1196,7 @@ export default {
           })
           .catch((error) => {
             console.error('Error getting tlm available', error)
-            if (requestedItems.length === this.screenItems.length) {
+            if (this.sameScreenItems(requestedItems)) {
               this.actualScreenItems = [...this.screenItems]
             }
           })

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ArrayplotWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ArrayplotWidget.vue
@@ -172,18 +172,15 @@ export default {
             // If allowReconnect is true it means we got a disconnect due to connection lost or server disconnect
             // If allowReconnect is false this is a normal server close or client close
             if (data.allowReconnect) {
-              this.errors.push({
+              this.emitScreenError('OpenC3 backend connection disconnected', {
                 type: 'disconnected',
-                message: 'OpenC3 backend connection disconnected',
-                time: new Date().getTime(),
+                transient: true,
               })
             }
           },
           rejected: () => {
-            this.errors.push({
+            this.emitScreenError('OpenC3 backend connection rejected', {
               type: 'rejected',
-              message: 'OpenC3 backend connection rejected',
-              time: new Date().getTime(),
             })
           },
         })
@@ -199,14 +196,17 @@ export default {
           // or an array with both X and Y values, e.g. [[x1,x2,x3...], [y1,y2,y3...]]
           if (key === '__time') {
             // Explicitly setting the X axis values always wins
+            // data[1] is the first item's series, missing if the screen
+            // defined an ARRAYPLOT without any SETTING ITEM
+            const points = this.data[1]?.length || 0
             if (this.xAxis) {
               xaxis = Array.from(
-                { length: this.data[1].length },
+                { length: points },
                 (_, i) => this.xAxis.start + i * this.xAxis.step,
               )
             } else if (xaxis.length === 0) {
               // If we don't have an array of X values we generate them
-              xaxis = Array.from({ length: this.data[1].length }, (_, i) => i)
+              xaxis = Array.from({ length: points }, (_, i) => i)
             }
             this.data[0] = xaxis
           }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ArrayplotWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/ArrayplotWidget.vue
@@ -166,6 +166,10 @@ export default {
         .createSubscription('StreamingChannel', window.openc3Scope, {
           received: (data) => this.received(data),
           connected: () => {
+            // We're back, so drop the disconnect error we reported below.
+            // Nothing else clears it: a screen of nothing but graphs never
+            // polls the REST API.
+            this.clearScreenErrors()
             this.addItemsToSubscription(this.items)
           },
           disconnected: (data) => {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/DynamicWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/DynamicWidget.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -38,7 +38,9 @@ export default {
     try {
       this.widgetType = await System.import(/* webpackIgnore: true */ this.url)
     } catch (e) {
-      throw new Error(`Unknown widget: ${this.name}: ${e}`)
+      // Vue routes a rejected async lifecycle hook through errorCaptured, so
+      // throwing here still reports against the screen definition line
+      throw this.screenError(this.name, `Unknown widget: ${this.name}: ${e}`)
     }
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/GraphWidget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/GraphWidget.js
@@ -20,16 +20,22 @@ export default {
     return {
       id: Math.floor(Math.random() * 100000000000), // Unique-ish
       state: 'start',
-      items: [
-        {
-          targetName: this.parameters[0],
-          packetName: this.parameters[1],
-          itemName: this.parameters[2],
-          valueType: this.parameters[3] || 'CONVERTED',
-          reduced: this.parameters[4] || 'DECOM',
-          reducedType: this.parameters[5] || null,
-        },
-      ],
+      // LINEGRAPH names its item as parameters, ARRAYPLOT takes none and adds
+      // them all with SETTING ITEM. Only seed an item if we were given one,
+      // otherwise we subscribe to undefined/undefined/undefined and plot an
+      // empty series for it.
+      items: this.parameters[0]
+        ? [
+            {
+              targetName: this.parameters[0],
+              packetName: this.parameters[1],
+              itemName: this.parameters[2],
+              valueType: this.parameters[3] || 'CONVERTED',
+              reduced: this.parameters[4] || 'DECOM',
+              reducedType: this.parameters[5] || null,
+            },
+          ]
+        : [],
       startTime: null,
       // 1hr of data by default
       secondsGraphed: 3600,
@@ -125,5 +131,14 @@ export default {
       // and manage their own playback requests
       return item
     })
+    // We still want to know if any of them don't exist. Streaming just never
+    // sends data for a bad item, so without this the screen looks fine and the
+    // series stays empty.
+    this.checkScreenItems(
+      this.items.map(
+        (item) =>
+          `${item.targetName}__${item.packetName}__${item.itemName}__${item.valueType}`,
+      ),
+    )
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/GraphWidget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/GraphWidget.js
@@ -116,6 +116,7 @@ export default {
           break
       }
     })
+    const validationIds = []
     this.items = this.items.map((item) => {
       const parsed = this.parseItemName(item.itemName)
       if (parsed.arrayIndex !== null) {
@@ -127,6 +128,12 @@ export default {
         // a no-op for plain names.
         item.itemName = parsed.name
       }
+      // Validate the base name, not the streaming name: ARY[0] is a valid
+      // thing to stream but the packet only has an item called ARY, so
+      // get_tlm_available would report every array element as nonexistent.
+      validationIds.push(
+        `${item.targetName}__${item.packetName}__${parsed.name}__${item.valueType}`,
+      )
       // We don't emit 'addItem' because graphWidgets use streams in realtime
       // and manage their own playback requests
       return item
@@ -134,11 +141,6 @@ export default {
     // We still want to know if any of them don't exist. Streaming just never
     // sends data for a bad item, so without this the screen looks fine and the
     // series stays empty.
-    this.checkScreenItems(
-      this.items.map(
-        (item) =>
-          `${item.targetName}__${item.packetName}__${item.itemName}__${item.valueType}`,
-      ),
-    )
+    this.checkScreenItems(validationIds)
   },
 }

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LimitsbarWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LimitsbarWidget.vue
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2025 OpenC3, Inc.
+# Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
 # This program is distributed in the hope that it will be useful,
@@ -48,15 +48,11 @@ export default {
       if (values) {
         return values
       } else {
-        // See errorCaptured in Openc3Screen.vue for how this is parsed
-        throw {
-          line: this.line,
-          lineNumber: this.lineNumber,
-          keyword: 'LIMITSBAR',
-          parameters: this.parameters,
-          message: 'Item has no limits settings',
-          usage: 'Only items with limits',
-        }
+        throw this.screenError(
+          'LIMITSBAR',
+          'Item has no limits settings',
+          'Only items with limits',
+        )
       }
     },
     mergedStyle() {

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LimitscolumnWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LimitscolumnWidget.vue
@@ -66,15 +66,11 @@ export default {
           '--blue-height': this.blue + '%',
         }
       } else {
-        // See errorCaptured in Openc3Screen.vue for how this is parsed
-        throw {
-          line: this.line,
-          lineNumber: this.lineNumber,
-          keyword: 'LIMITSCOLUMN',
-          parameters: this.parameters,
-          message: 'Item has no limits settings',
-          usage: 'Only items with limits',
-        }
+        throw this.screenError(
+          'LIMITSCOLUMN',
+          'Item has no limits settings',
+          'Only items with limits',
+        )
       }
     },
   },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LinegraphWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LinegraphWidget.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2025, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license
@@ -34,6 +34,7 @@
     hide-overview
     @pause="() => (state = 'pause')"
     @start="() => (state = 'start')"
+    @error="(error) => emitScreenError(error.message, error)"
   />
 </template>
 

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LinegraphWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/LinegraphWidget.vue
@@ -35,6 +35,7 @@
     @pause="() => (state = 'pause')"
     @start="() => (state = 'start')"
     @error="(error) => emitScreenError(error.message, error)"
+    @recovered="() => clearScreenErrors()"
   />
 </template>
 

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TitleWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TitleWidget.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license 
@@ -32,9 +32,10 @@ export default {
     },
   },
   created() {
-    if (this.parameters.length < 1) {
-      throw new Error('Not enough parameters for TITLE.')
-    }
+    // Breaking change: COSMOS 4 took TITLE <Text> <Font> <Size> <Weight>
+    // <Italics> and those were silently ignored here for years. Style with
+    // SETTING instead, i.e. SETTING RAW font-family Courier.
+    this.verifyNumParams('TITLE', 1, 1, 'TITLE <Text>')
   },
 }
 </script>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TitleWidget.vue
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/TitleWidget.vue
@@ -8,7 +8,7 @@
 # See LICENSE.md for more details.
 
 # Modified by OpenC3, Inc.
-# All changes Copyright 2022, OpenC3, Inc.
+# All changes Copyright 2026, OpenC3, Inc.
 # All Rights Reserved
 #
 # This file may also be used under the terms of a commercial license 
@@ -32,9 +32,7 @@ export default {
     },
   },
   created() {
-    if (this.parameters.length < 1) {
-      throw new Error('Not enough parameters for TITLE.')
-    }
+    this.verifyNumParams('TITLE', 1, 1, 'TITLE <Text>')
   },
 }
 </script>

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/Widget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/Widget.js
@@ -177,6 +177,54 @@ export default {
     }
   },
   methods: {
+    // Build an error for something wrong with the screen definition. Callers
+    // throw it: Openc3Screen's errorCaptured hook catches the throw and records
+    // it against the screen definition line that created this widget.
+    screenError(keyword, message, usage = '') {
+      return new ConfigParserError(
+        {
+          line: this.line,
+          lineNumber: this.lineNumber,
+          keyword: keyword,
+          parameters: this.parameters,
+        },
+        message,
+        usage,
+        'https://docs.openc3.com/docs/configuration',
+      )
+    },
+    // Report an error that happens after the widget is built, i.e. from a
+    // websocket callback or a promise. These can't throw: errorCaptured only
+    // sees throws made from Vue's own call stack, so anything thrown from an
+    // async callback is lost (or worse, tears down an unrelated caller).
+    // Emit instead - the listener bubbles up through the layout widgets, which
+    // pass it down with v-bind="listeners", to Openc3Screen.
+    emitScreenError(message, options = {}) {
+      // Deliberately not called 'error': undeclared on* listeners get bound to
+      // the root DOM element, and a DOM error event (a broken img, say) would
+      // otherwise be reported as a screen error.
+      this.$emit('screen-error', {
+        type: options.type || 'error',
+        message: message,
+        line: this.line,
+        lineNumber: this.lineNumber,
+        // Transient errors are cleared the next time the screen successfully
+        // talks to the backend rather than sticking around forever
+        transient: options.transient || false,
+        time: new Date().getTime(),
+      })
+    },
+    // Ask the screen to check these TARGET__PACKET__ITEM__TYPE ids actually
+    // exist. Widgets that emit 'addItem' get this for free because the screen
+    // polls them, but ones that stream their own data (the graphs) never told
+    // anybody about their items, so a typo'd item just silently never plotted.
+    checkScreenItems(valueIds) {
+      this.$emit('screen-check-items', {
+        valueIds: valueIds,
+        line: this.line,
+        lineNumber: this.lineNumber,
+      })
+    },
     applyStyleSetting(setting) {
       switch (setting[0]) {
         case 'TEXTALIGN':
@@ -233,33 +281,24 @@ export default {
       }
     },
     verifyNumParams(keyword, min_num_params, max_num_params, usage = '') {
-      let parser = {
-        line: this.line,
-        lineNumber: this.lineNumber,
-        keyword: keyword,
-        parameters: this.parameters,
-      }
-
       // This syntax works with 0 because each doesn't return any values
       // for a backwards range
       for (let index = 1; index <= min_num_params; index++) {
         // If the parameter is nil (0 based) then we have a problem
         if (this.parameters[index - 1] === undefined) {
-          throw new ConfigParserError(
-            parser,
+          throw this.screenError(
+            keyword,
             `Not enough parameters for ${keyword}.`,
             usage,
-            'https://docs.openc3.com/docs/configuration',
           )
         }
       }
       // If they pass null for max_params we don't check for a maximum number
       if (max_num_params !== null && this.parameters.length > max_num_params) {
-        throw new ConfigParserError(
-          parser,
+        throw this.screenError(
+          keyword,
           `Too many parameters for ${keyword}.`,
           usage,
-          'https://docs.openc3.com/docs/configuration',
         )
       }
     },

--- a/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/Widget.js
+++ b/openc3-cosmos-init/plugins/packages/openc3-vue-common/src/widgets/Widget.js
@@ -115,6 +115,11 @@ export default {
         },
       }
     },
+    // Identifies this widget as the source of a transient screen error. The
+    // definition line is unique per widget, which is all this has to be.
+    errorSource: function () {
+      return `widget:${this.lineNumber}`
+    },
     listeners: function () {
       // Vue 3 deprecated $listeners, which was used to bubble up events to the Openc3Screen component. The new way is
       // to use v-bind="$attrs", but that also passes the `style` DOM attribute to children, which makes widgets
@@ -208,10 +213,22 @@ export default {
         message: message,
         line: this.line,
         lineNumber: this.lineNumber,
-        // Transient errors are cleared the next time the screen successfully
-        // talks to the backend rather than sticking around forever
+        // Transient errors are cleared when their source recovers (see
+        // clearScreenErrors) rather than sticking around forever
         transient: options.transient || false,
+        // A transient error is cleared by whatever produced it recovering, so
+        // it has to say what that was. Default to this widget so one graph
+        // reconnecting doesn't clear another graph's disconnect.
+        source: options.source || this.errorSource,
         time: new Date().getTime(),
+      })
+    },
+    // The counterpart to a transient emitScreenError: the thing that failed is
+    // working again, so drop the errors it reported. Errors from other sources
+    // and non-transient errors are left alone.
+    clearScreenErrors(source = null) {
+      this.$emit('screen-errors-cleared', {
+        source: source || this.errorSource,
       })
     },
     // Ask the screen to check these TARGET__PACKET__ITEM__TYPE ids actually


### PR DESCRIPTION
### What changed

Consolidated the error reporting in the TlmViewer widget chain. Some widgets now emit errors that are rescued at the  screen level. `LINEGRAPH` now confirms that all the items exist instead of just not graphing. `TITLE` now enforces a single parameter which will error a screen and require a user fix but has been the case since COSMOS 5.0. Extraneous `END` statements now error a screen and require a user fix but this helps expose weird rendering errors.

### Why it changed

Customer reported `At undefined: (undefined) TypeError: Cannot read properties of undefined (reading 'push').` I think this was due to the Graph widget having an invalid item.

### Testing strategy

Went through all screens and looked for render errors and console log errors. All resolved successfully.