### PR TITLE
Prevent double underscores in scope names

### DIFF
--- a/openc3/lib/openc3/models/scope_model.rb
+++ b/openc3/lib/openc3/models/scope_model.rb
@@ -154,6 +154,8 @@ module OpenC3
     def create(update: false, force: false, queued: false)
       # Ensure there are no "." in the scope name - prevents gems accidentally becoming scope names
       raise "Invalid scope name: #{@name}" if !/^[a-zA-Z0-9_-]+$/.match?(@name)
+      # Double underscore is the COSMOS separator used to build microservice and topic names
+      raise "Invalid scope name: #{@name} (double underscore not allowed)" if @name.include?("__")
       @name = @name.upcase
       @scope = @name # Ensure @scope matches @name
       # Ensure the various cycle and retain times are integers

--- a/openc3/spec/models/scope_model_spec.rb
+++ b/openc3/spec/models/scope_model_spec.rb
@@ -95,6 +95,29 @@ module OpenC3
       end
     end
 
+    describe "create" do
+      it "raises on invalid characters in the scope name" do
+        model = ScopeModel.new(name: "INVALID:SCOPE")
+        expect { model.create() }.to raise_error(/Invalid scope name: INVALID:SCOPE/)
+      end
+
+      it "raises on double underscores in the scope name" do
+        model = ScopeModel.new(name: "BAD__SCOPE")
+        expect { model.create() }.to raise_error(/Invalid scope name: BAD__SCOPE \(double underscore not allowed\)/)
+      end
+
+      it "raises on a trailing double underscore in the scope name" do
+        model = ScopeModel.new(name: "SCOPE__")
+        expect { model.create() }.to raise_error(/double underscore not allowed/)
+      end
+
+      it "allows a single underscore in the scope name" do
+        model = ScopeModel.new(name: "GOOD_SCOPE")
+        expect { model.create() }.to_not raise_error
+        expect(ScopeModel.names()).to include("GOOD_SCOPE")
+      end
+    end
+
     describe "update" do
       it "updates command_authority and works in core" do
         model = ScopeModel.new(name: "DEFAULT", command_authority: true, critical_commanding: "ALL", updated_at: 12345)


### PR DESCRIPTION
### What changed

Prevent double underscores in scope names

### Why it changed

We use double underscores as delimiters in the Redis data store

### Testing strategy

Unit test