### PR TITLE
fix(config_parser): contain read_file paths to config directory

### DIFF
--- a/openc3/data/config/command_modifiers.yaml
+++ b/openc3/data/config/command_modifiers.yaml
@@ -284,6 +284,8 @@ TEMPLATE_FILE:
     - name: Template File Path
       required: true
       description: The relative path to the template file. Filename should generally start with an underscore.
+        Absolute paths and paths containing '..' are not allowed. The file must be inside the directory
+        containing the definition file.
       values: .+
   since: 5.0.10
 RESPONSE:

--- a/openc3/data/config/telemetry_modifiers.yaml
+++ b/openc3/data/config/telemetry_modifiers.yaml
@@ -274,6 +274,8 @@ TEMPLATE_FILE:
     - name: Template File Path
       required: true
       description: The relative path to the template file. Filename should generally start with an underscore.
+        Absolute paths and paths containing '..' are not allowed. The file must be inside the directory
+        containing the definition file.
       values: .+
   since: 5.0.10
 IGNORE_OVERLAP:

--- a/openc3/lib/openc3/config/config_parser.rb
+++ b/openc3/lib/openc3/config/config_parser.rb
@@ -166,17 +166,44 @@ module OpenC3
       return ERB.new(read_file(template_name).comment_erb(), trim_mode: "-").result(b)
     end
 
-    # Can be called during parsing to read a referenced file
+    # Can be called during parsing to read a referenced file. The filename must
+    # be relative to the configuration file being parsed and must resolve to a
+    # location inside that file's directory.
     def read_file(filename)
-      # Assume the file is there. If not we raise a pretty obvious error
-      if File.expand_path(filename) == filename # absolute path
-        path = filename
-      else # relative to the current @filename
-        path = File.join(File.dirname(@filename), filename)
-      end
+      path = resolve_config_path(filename)
       OpenC3.set_working_dir(File.dirname(path)) do
         return File.read(path).force_encoding("UTF-8")
       end
+    end
+
+    # Resolves a filename referenced by a configuration file (TEMPLATE_FILE, ERB
+    # render, etc) into an absolute path contained by the directory of the file
+    # being parsed. Absolute paths and paths containing '..' are rejected so a
+    # configuration file can not read arbitrary files on the filesystem.
+    #
+    # @param filename [String] Relative path from the configuration file
+    # @return [String] Absolute path to the referenced file
+    private def resolve_config_path(filename)
+      filename = filename.to_s
+      raise Error.new(self, "Filename must be given") if filename.strip.empty?
+
+      if File.absolute_path?(filename) or File.expand_path(filename) == filename
+        raise Error.new(self, "Absolute paths are not allowed: #{filename}")
+      end
+      if filename.include?('..')
+        raise Error.new(self, "Path traversal is not allowed: #{filename}")
+      end
+      if @filename.nil? or @filename.to_s.empty?
+        raise Error.new(self, "No configuration file is being parsed, can not resolve: #{filename}")
+      end
+
+      base = File.expand_path(File.dirname(@filename))
+      path = File.expand_path(File.join(base, filename))
+      # Final containment check in case the OS or Ruby normalizes something unexpected
+      unless path.start_with?(base + File::SEPARATOR)
+        raise Error.new(self, "Path is outside the configuration directory: #{filename}")
+      end
+      path
     end
 
     # Processes a file and yields |config| to the given block

--- a/openc3/python/openc3/config/config_parser.py
+++ b/openc3/python/openc3/config/config_parser.py
@@ -81,19 +81,40 @@ class ConfigParser:
             url = self.url
         return self.Error(self, message, usage, url)
 
-    # Can be called during parsing to read a referenced file
+    # Can be called during parsing to read a referenced file. The filename must
+    # be relative to the configuration file being parsed and must resolve to a
+    # location inside that file's directory.
     def read_file(self, filename: str) -> bytes:
-        # Assume the file is there. If not we raise a pretty obvious error
-        if os.path.abspath(filename) == filename:  # absolute path
-            path = filename
-        else:  # relative to the current @filename
-            if not self.filename:
-                raise ValueError(f"Cannot resolve relative path '{filename}' - no current file context")
-            path = os.path.join(os.path.dirname(self.filename), filename)
+        path = self._resolve_config_path(filename)
         data: bytes = b""
         with open(path, "rb") as file:
             data = file.read()
         return data
+
+    # Resolves a filename referenced by a configuration file (TEMPLATE_FILE, etc)
+    # into an absolute path contained by the directory of the file being parsed.
+    # Absolute paths and paths containing '..' are rejected so a configuration
+    # file can not read arbitrary files on the filesystem.
+    #
+    # self.param filename [String] Relative path from the configuration file
+    # self.return [String] Absolute path to the referenced file
+    def _resolve_config_path(self, filename: str) -> str:
+        filename = str(filename)
+        if not filename.strip():
+            raise self.error("Filename must be given")
+        if os.path.isabs(filename) or os.path.abspath(filename) == filename:
+            raise self.error(f"Absolute paths are not allowed: {filename}")
+        if ".." in filename:
+            raise self.error(f"Path traversal is not allowed: {filename}")
+        if not self.filename:
+            raise self.error(f"No configuration file is being parsed, can not resolve: {filename}")
+
+        base = os.path.abspath(os.path.dirname(self.filename))
+        path = os.path.abspath(os.path.join(base, filename))
+        # Final containment check in case the OS normalizes something unexpected
+        if not path.startswith(base + os.sep):
+            raise self.error(f"Path is outside the configuration directory: {filename}")
+        return path
 
     def parse_file(
         self,

--- a/openc3/python/test/config/test_config_parser.py
+++ b/openc3/python/test/config/test_config_parser.py
@@ -48,14 +48,22 @@ class TestConfigParser(unittest.TestCase):
         self.assertEqual(results["KEYWORD2"], ["PARAM1"])
         tf.close()
 
-    def test_parse_file_reads_an_absolute_file(self):
-        tf = tempfile.NamedTemporaryFile(mode="w+t")
-        tf.writelines("EXAMPLE DATA")
-        tf.seek(0)
+    def test_read_file_rejects_an_absolute_file(self):
+        with tempfile.NamedTemporaryFile(mode="w+t") as tf:
+            tf.writelines("EXAMPLE DATA")
+            tf.seek(0)
 
-        data = self.cp.read_file(tf.name)
-        self.assertEqual(data, b"EXAMPLE DATA")
-        tf.close()
+            with self.assertRaisesRegex(ConfigParser.Error, "Absolute paths are not allowed"):
+                self.cp.read_file(tf.name)
+
+    def test_read_file_rejects_path_traversal(self):
+        with tempfile.NamedTemporaryFile(mode="w+t") as tf:
+            tf.writelines("EXAMPLE DATA")
+            tf.seek(0)
+            self.cp.filename = tf.name
+
+            with self.assertRaisesRegex(ConfigParser.Error, "Path traversal is not allowed"):
+                self.cp.read_file("../../../../etc/passwd")
 
     def test_parse_file_reads_a_relative_file(self):
         tf = tempfile.NamedTemporaryFile(mode="w+b")

--- a/openc3/python/test/packets/test_packet_config.py
+++ b/openc3/python/test/packets/test_packet_config.py
@@ -13,6 +13,7 @@
 # See https://github.com/OpenC3/cosmos/pull/1953
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -859,9 +860,11 @@ class TestPacketConfig(unittest.TestCase):
         )
 
     def test_sets_the_template_via_file(self):
-        with open("unittest.txt", "w+") as data_file:
-            data_file.write("File data")
         with tempfile.NamedTemporaryFile(mode="w") as tf:
+            subdir = os.path.join(os.path.dirname(tf.name), "templates")
+            os.makedirs(subdir, exist_ok=True)
+            with open(os.path.join(subdir, "unittest.txt"), "w+") as data_file:
+                data_file.write("File data")
             filename = "datafile2.txt"
             with open(os.path.dirname(tf.name) + "/" + filename, "wb") as fp:
                 data = {
@@ -876,7 +879,7 @@ class TestPacketConfig(unittest.TestCase):
                 }
                 dump(data, fp)
             tf.write('TELEMETRY tgt1 pkt1 LITTLE_ENDIAN "Description"\n')
-            tf.write(f"TEMPLATE_FILE {os.path.join(os.getcwd(), 'unittest.txt')}\n")
+            tf.write("TEMPLATE_FILE templates/unittest.txt\n")
             tf.write('COMMAND tgt1 pkt1 LITTLE_ENDIAN "Description"\n')
             tf.write("ACCESSOR openc3/accessors/cbor_accessor.py\n")
             tf.write(f"TEMPLATE_FILE {filename}\n")
@@ -931,7 +934,23 @@ class TestPacketConfig(unittest.TestCase):
                 },
             },
         )
-        os.remove(os.path.join(os.getcwd(), "unittest.txt"))
+        shutil.rmtree(subdir)
+
+    def test_rejects_absolute_template_files(self):
+        with tempfile.NamedTemporaryFile(mode="w") as tf:
+            tf.write('TELEMETRY tgt1 pkt1 LITTLE_ENDIAN "Description"\n')
+            tf.write(f"TEMPLATE_FILE {os.path.join(os.getcwd(), 'unittest.txt')}\n")
+            tf.seek(0)
+            with self.assertRaisesRegex(ConfigParser.Error, "Absolute paths are not allowed"):
+                self.pc.process_file(tf.name, "TGT1")
+
+    def test_rejects_template_files_outside_the_config_directory(self):
+        with tempfile.NamedTemporaryFile(mode="w") as tf:
+            tf.write('TELEMETRY tgt1 pkt1 LITTLE_ENDIAN "Description"\n')
+            tf.write("TEMPLATE_FILE ../../../../etc/passwd\n")
+            tf.seek(0)
+            with self.assertRaisesRegex(ConfigParser.Error, "Path traversal is not allowed"):
+                self.pc.process_file(tf.name, "TGT1")
 
     def test_handles_bad_template_files(self):
         with tempfile.NamedTemporaryFile(mode="w") as tf:

--- a/openc3/spec/config/config_parser_spec.rb
+++ b/openc3/spec/config/config_parser_spec.rb
@@ -124,7 +124,7 @@ module OpenC3
         end
       end
 
-      it "allows absolute paths to ERB partials" do
+      it "rejects absolute paths to ERB partials" do
         Dir.mktmpdir("partial_dir") do |dir|
           tf2 = Tempfile.new('_partial.txt', dir)
           tf2.puts "ABSOLUTE"
@@ -133,12 +133,27 @@ module OpenC3
           tf.puts "<%= render '#{tf2.path}' %>"
           tf.close
 
-          @cp.parse_file(tf.path) do |keyword, _params|
-            expect(keyword).to eql "ABSOLUTE"
-          end
+          expect { @cp.parse_file(tf.path) }.to raise_error(ConfigParser::Error, /Absolute paths are not allowed/)
           tf.unlink
           tf2.unlink
         end
+      end
+
+      it "rejects ERB partials which traverse out of the config directory" do
+        tf = Tempfile.new('unittest')
+        tf.puts "<%= render '../../../../etc/_passwd' %>"
+        tf.close
+
+        expect { @cp.parse_file(tf.path) }.to raise_error(ConfigParser::Error, /Path traversal is not allowed/)
+        tf.unlink
+      end
+
+      it "rejects read_file with an absolute path" do
+        expect { @cp.read_file('/etc/passwd') }.to raise_error(ConfigParser::Error, /Absolute paths are not allowed/)
+      end
+
+      it "rejects read_file with path traversal" do
+        expect { @cp.read_file('../../../../etc/passwd') }.to raise_error(ConfigParser::Error, /Path traversal is not allowed/)
       end
 
       it "supports ERB partials via render" do

--- a/openc3/spec/packets/packet_config_spec.rb
+++ b/openc3/spec/packets/packet_config_spec.rb
@@ -827,24 +827,48 @@ module OpenC3
 
       context "with TEMPLATE_FILE" do
         it "sets the template via file" do
-          data_file = Tempfile.new('unittest')
-          data_file.write("File data")
-          data_file.close
           tf = Tempfile.new('unittest')
           filename = "datafile2.txt"
           File.open(File.dirname(tf.path) + '/' + filename, 'wb') do |file|
             file.write("relative file")
           end
+          subdir = File.join(File.dirname(tf.path), 'templates')
+          FileUtils.mkdir_p(subdir)
+          File.open(File.join(subdir, 'datafile3.txt'), 'wb') do |file|
+            file.write("subdir file")
+          end
           tf.puts 'TELEMETRY tgt1 pkt1 LITTLE_ENDIAN "Description"'
-          tf.puts "TEMPLATE_FILE #{data_file.path}"
+          tf.puts "TEMPLATE_FILE templates/datafile3.txt"
           tf.puts 'COMMAND tgt2 pkt1 LITTLE_ENDIAN "Description"'
           tf.puts "TEMPLATE_FILE #{filename}"
           tf.close
           @pc.process_file(tf.path, "SYSTEM")
-          expect(@pc.telemetry["TGT1"]["PKT1"].template).to eq "File data"
+          expect(@pc.telemetry["TGT1"]["PKT1"].template).to eq "subdir file"
           expect(@pc.commands["TGT2"]["PKT1"].template).to eq "relative file"
           File.delete(File.dirname(tf.path) + '/' + filename)
+          FileUtils.rm_rf(subdir)
+          tf.unlink
+        end
+
+        it "rejects absolute template paths" do
+          data_file = Tempfile.new('unittest')
+          data_file.write("File data")
+          data_file.close
+          tf = Tempfile.new('unittest')
+          tf.puts 'TELEMETRY tgt1 pkt1 LITTLE_ENDIAN "Description"'
+          tf.puts "TEMPLATE_FILE #{data_file.path}"
+          tf.close
+          expect { @pc.process_file(tf.path, "SYSTEM") }.to raise_error(ConfigParser::Error, /Absolute paths are not allowed/)
           data_file.unlink
+          tf.unlink
+        end
+
+        it "rejects template paths which traverse out of the config directory" do
+          tf = Tempfile.new('unittest')
+          tf.puts 'TELEMETRY tgt1 pkt1 LITTLE_ENDIAN "Description"'
+          tf.puts "TEMPLATE_FILE ../../../../etc/passwd"
+          tf.close
+          expect { @pc.process_file(tf.path, "SYSTEM") }.to raise_error(ConfigParser::Error, /Path traversal is not allowed/)
           tf.unlink
         end
       end


### PR DESCRIPTION
### What changed

Both callers now resolve through resolve_config_path, which rejects absolute paths and '..' and verifies the result stays inside the parsed file's directory. Mirrored in the Python ConfigParser.

### Why it changed

ConfigParser#read_file resolved filenames from configuration files with no containment check, so a TEMPLATE_FILE or ERB render directive could read any file the process user could access via an absolute path or ../ traversal. 

### Testing strategy

Unit tests