### PR TITLE
Fix/python tcpip socket read timeout

### DIFF
--- a/openc3/python/openc3/interfaces/tcpip_server_interface.py
+++ b/openc3/python/openc3/interfaces/tcpip_server_interface.py
@@ -348,7 +348,7 @@ class TcpipServerInterface(StreamInterface):
                 + "wait 1 minute and try again."
             ) from e
 
-        listen_socket.setblocking(0)
+        listen_socket.setblocking(False)
         listen_socket.listen(5)
         self.listen_sockets.append(listen_socket)
 

--- a/openc3/python/openc3/streams/tcpip_socket_stream.py
+++ b/openc3/python/openc3/streams/tcpip_socket_stream.py
@@ -10,6 +10,7 @@
 # if purchased from OpenC3, Inc.
 
 import contextlib
+import errno
 import select
 import socket
 import threading
@@ -67,19 +68,37 @@ class TcpipSocketStream(Stream):
             # if there is no data available
             except OSError as error:
                 if error.errno == socket.EAGAIN or error.errno == socket.EWOULDBLOCK:
-                    # If select returns something it means the socket is now available for
-                    # reading so retry the read. If it returns empty list it means we timed out.
-                    # If the pipe is present that means we closed the socket
-                    readable, _, _ = select.select(
-                        [self.read_socket, self.pipe_reader],
-                        [],
-                        [],
-                        self.read_timeout,
-                    )
-                    if readable and self.pipe_reader in readable:
+                    # Wait for the socket to be ready for reading or for the timeout
+                    try:
+                        readable, _, _ = select.select(
+                            [self.read_socket, self.pipe_reader],
+                            [],
+                            [],
+                            self.read_timeout,
+                        )
+                    # These can happen with the socket being closed while waiting on
+                    # select. Python sets fileno() to -1 once closed, which raises
+                    # ValueError rather than OSError.
+                    except ValueError:
                         data = ""
+                        break
+                    except OSError as select_error:
+                        if select_error.errno in (errno.EBADF, errno.ENOTSOCK):
+                            data = ""
+                            break
+                        # Anything else is an unexpected system failure, not a
+                        # closed socket - don't hide it behind a clean EOF
+                        raise
+                    # If select returns something it means the socket is now available for
+                    # reading so retry the read. If it returns an empty list it means we
+                    # timed out. If the pipe is present that means we closed the socket.
+                    if readable:
+                        if self.pipe_reader in readable:
+                            data = ""
+                        else:
+                            continue
                     else:
-                        continue
+                        raise TimeoutError("Read Timeout") from error
             break
         return data
 

--- a/openc3/python/openc3/streams/tcpip_socket_stream.py
+++ b/openc3/python/openc3/streams/tcpip_socket_stream.py
@@ -76,12 +76,15 @@ class TcpipSocketStream(Stream):
                             [],
                             self.read_timeout,
                         )
-                    # These can happen with the socket being closed while waiting on
-                    # select. Python sets fileno() to -1 once closed, which raises
-                    # ValueError rather than OSError.
+                    # Python sets fileno() to -1 once a socket is closed and select
+                    # raises ValueError rather than OSError for a negative fd. Only
+                    # that case is a disconnect. Other ValueErrors (a negative
+                    # timeout, an fd over FD_SETSIZE) are real errors so re-raise.
                     except ValueError:
-                        data = ""
-                        break
+                        if self._any_socket_closed():
+                            data = ""
+                            break
+                        raise
                     except OSError as select_error:
                         if select_error.errno in (errno.EBADF, errno.ENOTSOCK):
                             data = ""
@@ -101,6 +104,17 @@ class TcpipSocketStream(Stream):
                         raise TimeoutError("Read Timeout") from error
             break
         return data
+
+    # self.return [Boolean] Whether either socket passed to select has been closed
+    def _any_socket_closed(self):
+        for sock in (self.read_socket, self.pipe_reader):
+            try:
+                if sock.fileno() < 0:
+                    return True
+            # fileno() raises on an already released socket object
+            except OSError:
+                return True
+        return False
 
     # self.param data [String] A binary string of data to write to the socket
     def write(self, data):

--- a/openc3/python/test/streams/test_tcpip_socket_stream.py
+++ b/openc3/python/test/streams/test_tcpip_socket_stream.py
@@ -61,10 +61,11 @@ class TestTcpipSocketStream(unittest.TestCase):
                 self.request.send(b"test")
                 self.request.close()
 
-        server = ReusableTCPServer(("localhost", 20000), MyTCPHandler)
+        # Bind to an ephemeral port so concurrent runs can't collide
+        server = ReusableTCPServer(("localhost", 0), MyTCPHandler)
         threading.Thread(target=server.handle_request).start()
         rs = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        rs.connect(("localhost", 20000))
+        rs.connect(server.server_address)
         ss = TcpipSocketStream(None, rs, 10.0, None)
         self.assertEqual(ss.read(), b"test")
         close_socket(rs)
@@ -127,9 +128,26 @@ class TestTcpipSocketStream(unittest.TestCase):
                 mock_select.side_effect = select_error
                 self.assertEqual(ss.read(), "")
         # Python sets fileno() to -1 once the socket is closed
+        read.fileno.return_value = -1
         with patch("openc3.streams.tcpip_socket_stream.select.select") as mock_select:
             mock_select.side_effect = ValueError("file descriptor cannot be a negative integer (-1)")
             self.assertEqual(ss.read(), "")
+        ss.disconnect()
+
+    def test_reraises_value_errors_unrelated_to_a_closed_socket(self):
+        # A ValueError from a bad timeout or an out of range fd is a real error
+        # and must not be reported as a clean EOF
+        read = Mock()
+        error = OSError()
+        error.errno = errno.EWOULDBLOCK
+        read.recv.side_effect = error
+        read.fileno.return_value = 5
+        ss = TcpipSocketStream(None, read, 10.0, -1.0)
+        ss.connect()
+        with patch("openc3.streams.tcpip_socket_stream.select.select") as mock_select:
+            mock_select.side_effect = ValueError("timeout must be non-negative")
+            with self.assertRaisesRegex(ValueError, "timeout must be non-negative"):
+                ss.read()
         ss.disconnect()
 
     def test_reraises_unexpected_select_errors(self):
@@ -155,10 +173,10 @@ class TestTcpipSocketStream(unittest.TestCase):
                 # Accept the connection and then send nothing, keeping it open
                 time.sleep(0.5)
 
-        server = ReusableTCPServer(("localhost", 20004), MyTCPHandler)
+        server = ReusableTCPServer(("localhost", 0), MyTCPHandler)
         threading.Thread(target=server.handle_request).start()
         rs = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        rs.connect(("localhost", 20004))
+        rs.connect(server.server_address)
         # Match how the interfaces create their sockets. MSG_DONTWAIT does not
         # exist on Windows so a blocking socket would sit in recv instead of
         # returning EWOULDBLOCK and reaching the select timeout.
@@ -177,10 +195,10 @@ class TestTcpipSocketStream(unittest.TestCase):
                 time.sleep(0.2)
                 self.request.close()
 
-        server = ReusableTCPServer(("localhost", 20002), MyTCPHandler)
+        server = ReusableTCPServer(("localhost", 0), MyTCPHandler)
         threading.Thread(target=server.handle_request).start()
         rs = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        rs.connect(("localhost", 20002))
+        rs.connect(server.server_address)
         ss = TcpipSocketStream(None, rs, 10.0, 5.0)
         time.sleep(0.1)  # allow the server thread to accept
         # close the socket before trying to read from it

--- a/openc3/python/test/streams/test_tcpip_socket_stream.py
+++ b/openc3/python/test/streams/test_tcpip_socket_stream.py
@@ -22,6 +22,11 @@ from openc3.top_level import close_socket
 from test.test_helper import capture_io, mock_redis
 
 
+class ReusableTCPServer(socketserver.TCPServer):
+    # Avoid "Address already in use" when a previous test left the port in TIME_WAIT
+    allow_reuse_address = True
+
+
 class TestTcpipSocketStream(unittest.TestCase):
     def setUp(self):
         mock_redis(self)
@@ -56,7 +61,7 @@ class TestTcpipSocketStream(unittest.TestCase):
                 self.request.send(b"test")
                 self.request.close()
 
-        server = socketserver.TCPServer(("localhost", 20000), MyTCPHandler)
+        server = ReusableTCPServer(("localhost", 20000), MyTCPHandler)
         threading.Thread(target=server.handle_request).start()
         rs = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         rs.connect(("localhost", 20000))
@@ -67,21 +72,104 @@ class TestTcpipSocketStream(unittest.TestCase):
         server.server_close()
         time.sleep(0.1)
 
-    #     def test_handles_socket_timeouts(self):
-    #         server = TCPServer(2000) # Server bound to port 2000
-    #         thread = Thread() do
-    #           client = server.accept # Wait for a client to connect
-    #           sleep 0.2
-    #           client.close
-    #         socket = TCPSocket('127.0.0.1', 2000)
-    #         ss = TcpipSocketStream(None, socket, 10.0, 0.1)
-    #         { ss.read }.to raise_error(Timeout='E'rror)
-    #         thread.join()
-    #         sleep 0.2
-    #         OpenC3.close_socket(socket)
-    #         OpenC3.close_socket(server)
-    #         ss.disconnect
-    #         sleep 0.1
+    def test_handles_socket_read_timeouts(self):
+        # Regression test for read_timeout being ignored on a socket which stays
+        # open but stops sending data. select returns ([], [], []) on timeout.
+        read = Mock()
+        error = OSError()
+        error.errno = errno.EWOULDBLOCK
+        read.recv.side_effect = error
+        ss = TcpipSocketStream(None, read, 10.0, 0.1)
+        ss.connect()
+        with patch("openc3.streams.tcpip_socket_stream.select.select") as mock_select:
+            mock_select.return_value = ([], [], [])
+            with self.assertRaisesRegex(TimeoutError, "Read Timeout"):
+                ss.read()
+        ss.disconnect()
+
+    def test_retries_the_read_when_the_socket_becomes_readable(self):
+        read = Mock()
+        error = OSError()
+        error.errno = errno.EWOULDBLOCK
+        # Raise EWOULDBLOCK on the first recv, return data on the second
+        read.recv.side_effect = [error, b"test"]
+        ss = TcpipSocketStream(None, read, 10.0, 0.1)
+        ss.connect()
+        with patch("openc3.streams.tcpip_socket_stream.select.select") as mock_select:
+            mock_select.return_value = ([read], [], [])
+            self.assertEqual(ss.read(), b"test")
+        self.assertEqual(read.recv.call_count, 2)
+        ss.disconnect()
+
+    def test_returns_empty_data_when_disconnected_while_reading(self):
+        read = Mock()
+        error = OSError()
+        error.errno = errno.EWOULDBLOCK
+        read.recv.side_effect = error
+        ss = TcpipSocketStream(None, read, 10.0, None)
+        ss.connect()
+        with patch("openc3.streams.tcpip_socket_stream.select.select") as mock_select:
+            mock_select.return_value = ([ss.pipe_reader], [], [])
+            self.assertEqual(ss.read(), "")
+        ss.disconnect()
+
+    def test_returns_empty_data_when_select_sees_a_closed_socket(self):
+        read = Mock()
+        error = OSError()
+        error.errno = errno.EWOULDBLOCK
+        read.recv.side_effect = error
+        ss = TcpipSocketStream(None, read, 10.0, None)
+        ss.connect()
+        for select_errno in (errno.EBADF, errno.ENOTSOCK):
+            select_error = OSError()
+            select_error.errno = select_errno
+            with patch("openc3.streams.tcpip_socket_stream.select.select") as mock_select:
+                mock_select.side_effect = select_error
+                self.assertEqual(ss.read(), "")
+        # Python sets fileno() to -1 once the socket is closed
+        with patch("openc3.streams.tcpip_socket_stream.select.select") as mock_select:
+            mock_select.side_effect = ValueError("file descriptor cannot be a negative integer (-1)")
+            self.assertEqual(ss.read(), "")
+        ss.disconnect()
+
+    def test_reraises_unexpected_select_errors(self):
+        # An unexpected system failure must not be hidden behind a clean EOF
+        read = Mock()
+        error = OSError()
+        error.errno = errno.EWOULDBLOCK
+        read.recv.side_effect = error
+        ss = TcpipSocketStream(None, read, 10.0, None)
+        ss.connect()
+        select_error = OSError()
+        select_error.errno = errno.ENOMEM
+        with patch("openc3.streams.tcpip_socket_stream.select.select") as mock_select:
+            mock_select.side_effect = select_error
+            with self.assertRaises(OSError) as context:
+                ss.read()
+            self.assertEqual(context.exception.errno, errno.ENOMEM)
+        ss.disconnect()
+
+    def test_times_out_reading_from_a_silent_socket(self):
+        class MyTCPHandler(socketserver.BaseRequestHandler):
+            def handle(self):
+                # Accept the connection and then send nothing, keeping it open
+                time.sleep(0.5)
+
+        server = ReusableTCPServer(("localhost", 20004), MyTCPHandler)
+        threading.Thread(target=server.handle_request).start()
+        rs = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+        rs.connect(("localhost", 20004))
+        # Match how the interfaces create their sockets. MSG_DONTWAIT does not
+        # exist on Windows so a blocking socket would sit in recv instead of
+        # returning EWOULDBLOCK and reaching the select timeout.
+        rs.setblocking(False)
+        ss = TcpipSocketStream(None, rs, 10.0, 0.1)
+        ss.connect()
+        with self.assertRaisesRegex(TimeoutError, "Read Timeout"):
+            ss.read()
+        ss.disconnect()
+        server.server_close()
+        time.sleep(0.1)
 
     def test_handles_socket_connection_reset_exceptions(self):
         class MyTCPHandler(socketserver.BaseRequestHandler):
@@ -89,7 +177,7 @@ class TestTcpipSocketStream(unittest.TestCase):
                 time.sleep(0.2)
                 self.request.close()
 
-        server = socketserver.TCPServer(("localhost", 20002), MyTCPHandler)
+        server = ReusableTCPServer(("localhost", 20002), MyTCPHandler)
         threading.Thread(target=server.handle_request).start()
         rs = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         rs.connect(("localhost", 20002))


### PR DESCRIPTION
### What changed

Python's select.select returns ([], [], []) on timeout, which fell into the retry branch and looped forever, so read_timeout never bounded an idle-but-open socket. Give the timeout its own branch matching the Ruby stream and write(), and treat only closed-socket errors from select as EOF.

### Why it changed

closes #3751

### Testing strategy

Unit tests


