### PR TITLE
fix(interface): call queue size methods in as_json

### DIFF
--- a/openc3/lib/openc3/interfaces/interface.rb
+++ b/openc3/lib/openc3/interfaces/interface.rb
@@ -433,8 +433,8 @@ module OpenC3
       config['name'] = @name
       config['state'] = @state
       config['clients'] = self.num_clients
-      config['txsize'] = @write_queue_size
-      config['rxsize'] = @read_queue_size
+      config['txsize'] = self.write_queue_size
+      config['rxsize'] = self.read_queue_size
       config['txbytes'] = @bytes_written
       config['rxbytes'] = @bytes_read
       config['txcnt'] = @write_count

--- a/openc3/spec/interfaces/interface_spec.rb
+++ b/openc3/spec/interfaces/interface_spec.rb
@@ -699,6 +699,35 @@ module OpenC3
       end
     end
 
+    describe "as_json" do
+      it "returns the interface status" do
+        i = Interface.new
+        i.name = "TEST_INT"
+        json = i.as_json
+        expect(json['name']).to eql "TEST_INT"
+        expect(json['state']).to eql "DISCONNECTED"
+        expect(json['clients']).to eql 0
+        expect(json['txsize']).to eql 0
+        expect(json['rxsize']).to eql 0
+        expect(json['txbytes']).to eql 0
+        expect(json['rxbytes']).to eql 0
+        expect(json['txcnt']).to eql 0
+        expect(json['rxcnt']).to eql 0
+      end
+
+      it "calls the queue size and client methods so subclasses can override" do
+        klass = Class.new(Interface) do
+          def num_clients; 3; end
+          def write_queue_size; 5; end
+          def read_queue_size; 7; end
+        end
+        json = klass.new.as_json
+        expect(json['clients']).to eql 3
+        expect(json['txsize']).to eql 5
+        expect(json['rxsize']).to eql 7
+      end
+    end
+
     describe "details" do
       it "returns detailed interface information" do
         i = Interface.new


### PR DESCRIPTION
### What changed

Call the `write_queue_size` and `read_queue_size` methods in interface.rb, matching `num_clients` and the Python library.

### Why it changed

as_json read the @write_queue_size/@read_queue_size instance variables, which are only ever set to 0, so subclass overrides such as TcpipServerInterface's were bypassed and txsize/rxsize always reported 0

Fixes #3773

### Testing strategy

Unit tests