### PR TITLE
fix: honor custom RUBYGEMS_URL for build and runtime plugin gem installs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source ENV['RUBYGEMS_URL']
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'dotenv'

--- a/compose.yaml
+++ b/compose.yaml
@@ -190,10 +190,12 @@ services:
     environment:
       - RAILS_ENV=production
       - GEM_HOME=/gems
-      # Seeds the per-scope rubygems_url setting (scope_model) so plugin gem
-      # installs (gem_model) fetch dependencies from the configured mirror. The
-      # api Gemfiles pin a constant source, so this never rewrites Gemfile.lock.
+      # Seed the per-scope rubygems_url/pypi_url settings (scope_model) so plugin
+      # gem installs (gem_model) and python package installs (python_package_model)
+      # fetch dependencies from the configured mirrors. The api Gemfiles pin a
+      # constant source, so RUBYGEMS_URL never rewrites Gemfile.lock.
       - RUBYGEMS_URL=${RUBYGEMS_URL}
+      - PYPI_URL=${PYPI_URL}
       - PYTHONUSERBASE=/gems/python_packages
       - ANYCABLE_REDIS_URL=redis://${OPENC3_REDIS_USERNAME}:${OPENC3_REDIS_PASSWORD}@${OPENC3_REDIS_HOSTNAME}:${OPENC3_REDIS_PORT}
       - SECRET_KEY_BASE=${SECRET_KEY_BASE}
@@ -259,10 +261,12 @@ services:
     environment:
       - RAILS_ENV=production
       - GEM_HOME=/gems
-      # Seeds the per-scope rubygems_url setting (scope_model) so plugin gem
-      # installs (gem_model) fetch dependencies from the configured mirror. The
-      # api Gemfiles pin a constant source, so this never rewrites Gemfile.lock.
+      # Seed the per-scope rubygems_url/pypi_url settings (scope_model) so plugin
+      # gem installs (gem_model) and python package installs (python_package_model)
+      # fetch dependencies from the configured mirrors. The api Gemfiles pin a
+      # constant source, so RUBYGEMS_URL never rewrites Gemfile.lock.
       - RUBYGEMS_URL=${RUBYGEMS_URL}
+      - PYPI_URL=${PYPI_URL}
       - PYTHONUSERBASE=/gems/python_packages
       - OPENC3_USE_UV=true
       - ANYCABLE_REDIS_URL=redis://${OPENC3_REDIS_USERNAME}:${OPENC3_REDIS_PASSWORD}@${OPENC3_REDIS_HOSTNAME}:${OPENC3_REDIS_PORT}
@@ -344,10 +348,12 @@ services:
       # List syntax passes through host CI only if set, omits it otherwise
       - CI
       - GEM_HOME=/gems
-      # Seeds the per-scope rubygems_url setting (scope_model) so plugin gem
-      # installs (gem_model) fetch dependencies from the configured mirror. The
-      # api Gemfiles pin a constant source, so this never rewrites Gemfile.lock.
+      # Seed the per-scope rubygems_url/pypi_url settings (scope_model) so plugin
+      # gem installs (gem_model) and python package installs (python_package_model)
+      # fetch dependencies from the configured mirrors. The api Gemfiles pin a
+      # constant source, so RUBYGEMS_URL never rewrites Gemfile.lock.
       - RUBYGEMS_URL=${RUBYGEMS_URL}
+      - PYPI_URL=${PYPI_URL}
       - PYTHONUSERBASE=/gems/python_packages
       - OPENC3_USE_UV=true
       # If your microservices do heavy BLAS / linear algebra work,
@@ -457,10 +463,12 @@ services:
       # List syntax passes through host CI only if set, omits it otherwise
       - CI
       - GEM_HOME=/gems
-      # Seeds the per-scope rubygems_url setting (scope_model) so plugin gem
-      # installs (gem_model) fetch dependencies from the configured mirror. The
-      # api Gemfiles pin a constant source, so this never rewrites Gemfile.lock.
+      # Seed the per-scope rubygems_url/pypi_url settings (scope_model) so plugin
+      # gem installs (gem_model) and python package installs (python_package_model)
+      # fetch dependencies from the configured mirrors. The api Gemfiles pin a
+      # constant source, so RUBYGEMS_URL never rewrites Gemfile.lock.
       - RUBYGEMS_URL=${RUBYGEMS_URL}
+      - PYPI_URL=${PYPI_URL}
       - PYTHONUSERBASE=/gems/python_packages
       - OPENC3_USE_UV=true
       # Redis

--- a/compose.yaml
+++ b/compose.yaml
@@ -190,6 +190,10 @@ services:
     environment:
       - RAILS_ENV=production
       - GEM_HOME=/gems
+      # Seeds the per-scope rubygems_url setting (scope_model) so plugin gem
+      # installs (gem_model) fetch dependencies from the configured mirror. The
+      # api Gemfiles pin a constant source, so this never rewrites Gemfile.lock.
+      - RUBYGEMS_URL=${RUBYGEMS_URL}
       - PYTHONUSERBASE=/gems/python_packages
       - ANYCABLE_REDIS_URL=redis://${OPENC3_REDIS_USERNAME}:${OPENC3_REDIS_PASSWORD}@${OPENC3_REDIS_HOSTNAME}:${OPENC3_REDIS_PORT}
       - SECRET_KEY_BASE=${SECRET_KEY_BASE}
@@ -255,6 +259,10 @@ services:
     environment:
       - RAILS_ENV=production
       - GEM_HOME=/gems
+      # Seeds the per-scope rubygems_url setting (scope_model) so plugin gem
+      # installs (gem_model) fetch dependencies from the configured mirror. The
+      # api Gemfiles pin a constant source, so this never rewrites Gemfile.lock.
+      - RUBYGEMS_URL=${RUBYGEMS_URL}
       - PYTHONUSERBASE=/gems/python_packages
       - OPENC3_USE_UV=true
       - ANYCABLE_REDIS_URL=redis://${OPENC3_REDIS_USERNAME}:${OPENC3_REDIS_PASSWORD}@${OPENC3_REDIS_HOSTNAME}:${OPENC3_REDIS_PORT}
@@ -336,6 +344,10 @@ services:
       # List syntax passes through host CI only if set, omits it otherwise
       - CI
       - GEM_HOME=/gems
+      # Seeds the per-scope rubygems_url setting (scope_model) so plugin gem
+      # installs (gem_model) fetch dependencies from the configured mirror. The
+      # api Gemfiles pin a constant source, so this never rewrites Gemfile.lock.
+      - RUBYGEMS_URL=${RUBYGEMS_URL}
       - PYTHONUSERBASE=/gems/python_packages
       - OPENC3_USE_UV=true
       # If your microservices do heavy BLAS / linear algebra work,
@@ -445,6 +457,10 @@ services:
       # List syntax passes through host CI only if set, omits it otherwise
       - CI
       - GEM_HOME=/gems
+      # Seeds the per-scope rubygems_url setting (scope_model) so plugin gem
+      # installs (gem_model) fetch dependencies from the configured mirror. The
+      # api Gemfiles pin a constant source, so this never rewrites Gemfile.lock.
+      - RUBYGEMS_URL=${RUBYGEMS_URL}
       - PYTHONUSERBASE=/gems/python_packages
       - OPENC3_USE_UV=true
       # Redis

--- a/openc3-cosmos-cmd-tlm-api/Gemfile
+++ b/openc3-cosmos-cmd-tlm-api/Gemfile
@@ -1,4 +1,4 @@
-source ENV['RUBYGEMS_URL'] || "https://rubygems.org"
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Ultimately we want to deploy on 3.x but we don't want to mandate it here

--- a/openc3-cosmos-script-runner-api/Gemfile
+++ b/openc3-cosmos-script-runner-api/Gemfile
@@ -1,4 +1,4 @@
-source ENV['RUBYGEMS_URL'] || "https://rubygems.org"
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Ultimately we want to deploy on 3.x but we don't want to mandate it here

--- a/openc3-ruby/Dockerfile
+++ b/openc3-ruby/Dockerfile
@@ -56,6 +56,11 @@ RUN sed -i "s|RUBYGEMS_URL|${RUBYGEMS_URL}|g" /root/.gemrc && \
     cp /root/.gemrc /etc/gemrc
 ENV GEMRC=/etc/gemrc
 
+# Pin bundler's global config to a fixed path so it stays effective in
+# downstream images that change HOME. The mirror entry itself is configured in
+# the apt step below (once bundler is installed).
+ENV BUNDLE_USER_CONFIG=/etc/bundle/config
+
 COPY anycable* /usr/bin/
 RUN /usr/bin/anycable_install.sh
 
@@ -101,6 +106,13 @@ RUN apt-get update && \
     gem cleanup && \
     bundle config build.nokogiri --use-system-libraries && \
     bundle config git.allow_insecure true && \
+    # Route bundler through the same RUBYGEMS_URL mirror that .gemrc uses for the
+    # gem command, so a custom mirror supplies gems while the Gemfile 'source'
+    # (and thus Gemfile.lock's remote) stays the constant https://rubygems.org.
+    if [ "${RUBYGEMS_URL}" != "https://rubygems.org" ]; then \
+      bundle config set --global mirror.https://rubygems.org "${RUBYGEMS_URL}"; \
+    fi && \
+    chmod -R a+rX /etc/bundle && \
     python3 -m pip install --break-system-packages "uv==${UV_VERSION}" && \
     rm -rf /var/lib/apt/lists/*
 

--- a/openc3-ruby/Dockerfile
+++ b/openc3-ruby/Dockerfile
@@ -120,6 +120,10 @@ RUN apt-get update && \
 ENV UV_LINK_MODE=copy
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_PYTHON_DOWNLOADS=never
+# Route uv at the configured PyPI mirror (no-op at the default pypi.org). Matches
+# the runtime pip -i <pypi_url>/simple convention so air-gapped builds resolve
+# Python deps from the same mirror the runtime plugin installs use.
+ENV UV_DEFAULT_INDEX=${PYPI_URL}/simple
 # Use the Debian system Python instead of the project's .python-version pin
 # (which targets 3.12 for host development) since UV_PYTHON_DOWNLOADS is never.
 ENV UV_PYTHON=python${PYTHON_VERSION}

--- a/openc3-ruby/Dockerfile-ubi
+++ b/openc3-ruby/Dockerfile-ubi
@@ -93,6 +93,10 @@ RUN gem update --system 3.7.2 && \
 ENV UV_LINK_MODE=copy
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_PYTHON_DOWNLOADS=never
+# Route uv at the configured PyPI mirror (no-op at the default pypi.org). Matches
+# the runtime pip -i <pypi_url>/simple convention so air-gapped builds resolve
+# Python deps from the same mirror the runtime plugin installs use.
+ENV UV_DEFAULT_INDEX=${PYPI_URL}/simple
 
 # Set Python executable path for microservices (uses venv to support editable installs)
 ENV OPENC3_PYTHON_BIN=/openc3/python/.venv/bin/python

--- a/openc3/Gemfile
+++ b/openc3/Gemfile
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 
-source ENV['RUBYGEMS_URL'] || "https://rubygems.org"
+source "https://rubygems.org"
 
 gemspec :name => 'openc3'
 


### PR DESCRIPTION
## Context
1. Running `openc3.sh start` from `cosmos-enterprise-project` on 7.2 crash-loops several containers, including cmd-tlm-api, with a readonly filesystem error due to an attempt to rewrite the Gemfile.lock that was built into the image using a different source (RUBGEMS_URL) that was passed in at runtime
2. This issue is not present in the same way in 7.3 due to removing `env_file: .env`, which meant that runtime no longer receives RUBYGEMS_URL. The crash-loop no longer happens, which would suggest the problem has been resolved, but plugin installs with packages that aren't present would always use rubygems.org, even if a custom URL was provided. This may not have been noticed unless in an air gapped environment

## Problem

Deployments that build and/or run against private package mirrors (`RUBYGEMS_URL`, `PYPI_URL`, e.g. air-gapped Nexus/Artifactory) hit these issues:

1. **Read-only `Gemfile.lock` rewrite crash.** The api Gemfiles used a dynamic `source ENV['RUBYGEMS_URL'] || "https://rubygems.org"`, re-evaluated at *runtime*. Whenever the runtime `RUBYGEMS_URL` differed from the value baked into `Gemfile.lock` at build, bundler tried to rewrite the lockfile on the read-only container rootfs and crashed.

3. **Plugin package installs ignore the mirror.** Plugins that need extra Ruby gems / Python packages install them at runtime into the writable `/gems` volume (`GemModel`, `PythonPackageModel`), using the per-scope `rubygems_url` / `pypi_url` settings that `ScopeModel` seeds from `ENV`. With the env vars absent, the settings default to public rubygems.org / pypi.org and installs fail in air-gapped/custom-mirror environments.

4. **Air-gapped build of Python deps.** `PYPI_URL` was baked as an env var but nothing consumed it at build — `uv sync --frozen` always resolved against public pypi.org, so air-gapped image builds failed on the Python side.

`da88510ae` on main fixed (1) for the **default-URL build** by removing `env_file: .env` so the runtime container no longer receives `RUBYGEMS_URL`. But a **custom-mirror build** still records the mirror in `Gemfile.lock` while runtime falls back to `rubygems.org` (mismatch/crash returns), and it starves the runtime plugin-install path (2). Air-gapped image builds against a custom source are a supported requirement, so all of the above must work.

## Approach

Decouple the mirror from the Gemfile `source` so the lockfile is stable regardless of build mirror, then hand the mirror URLs to build and runtime consistently.

1. **Constant Gemfile `source`.** All Gemfiles pin `source "https://rubygems.org"`. `Gemfile.lock`'s `remote:` is therefore always `https://rubygems.org/`, so the runtime source always matches the lock and bundler never rewrites it.

2. **Build-time bundler mirror.** `openc3-ruby/Dockerfile` sets a bundler *mirror* (`bundle config set --global mirror.https://rubygems.org "$RUBYGEMS_URL"`) alongside the existing `.gemrc` redirect, pinned via `BUNDLE_USER_CONFIG=/etc/bundle/config` so it survives downstream `HOME` changes. `source` stays the canonical identity (and lock `remote:`) while gem *downloads* are transparently rerouted to the mirror — custom/air-gapped builds work without leaking the mirror into the lock.

3. **Runtime `RUBYGEMS_URL` + `PYPI_URL`.** Re-add both to the four Ruby services (cmd-tlm-api, script-runner-api, operator, cosmos-init). They seed the `rubygems_url` / `pypi_url` settings so `GemModel` and `PythonPackageModel` plugin installs use the configured mirrors. Safe for `RUBYGEMS_URL` because piece 1 means it no longer feeds the Gemfile source. Undoes only the runtime-env slice of `da88510ae` for these two vars.

5. **Build-time PyPI mirror.** Set `UV_DEFAULT_INDEX=${PYPI_URL}/simple` in the base Dockerfiles (Debian + UBI) so `uv sync` resolves Python deps from the configured mirror, matching the runtime `pip -i <pypi_url>/simple` convention. No-op at the default pypi.org; enterprise inherits via the base.

## PyPI vs RubyGems

PyPI needs the runtime pass-through (3) and build index (4), but **not** the constant-source/mirror-redirect machinery (1+2): the build uses `uv sync --frozen` (never rewrites `uv.lock`) and runtime uses `pip install -i` (reads the setting), so there is no source-in-lock / read-only-rewrite problem like the Gemfile one.

**NPM_URL / APT_URL need nothing here** — both are build-time only (frontend registry config via `pnpm/npm config set registry`; base-image apt mirror via sources.list) with no runtime model consumer, per-scope setting, or plugin install path.

## Mirror coverage after this PR

| var | build | runtime plugin installs |
| --- | --- | --- |
| RUBYGEMS_URL | .gemrc + bundler mirror | env -> rubygems_url setting -> GemModel |
| PYPI_URL | UV_DEFAULT_INDEX | env -> pypi_url setting -> PythonPackageModel |
| APT_URL | sources.list | n/a |
| NPM_URL | npm/pnpm registry | n/a |

## Verified

- Full image chain built against an nginx reverse-proxy mirror (`RUBYGEMS_URL` != rubygems.org): all gems fetched through the proxy, while `Gemfile.lock` still recorded `remote: https://rubygems.org/`.
- Read-only container with a mismatched runtime `RUBYGEMS_URL`: `bundle exec` runs with no lockfile-rewrite attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)