### PR TITLE
Fix/env local not sourced

### DIFF
--- a/openc3.bat
+++ b/openc3.bat
@@ -63,6 +63,20 @@ if exist "%~dp0compose.override.yaml" (
   set COMPOSE_OVERRIDE=-f "%~dp0compose.override.yaml"
 )
 
+REM Env files: .env ships the upstream defaults (tracked). .env.local (if
+REM present) is loaded last so its values override .env. .env.local is
+REM gitignored, so it is the place to put SECRET overrides (passwords, keys)
+REM that must NOT be checked in. Compose interpolation precedence is:
+REM   shell env  >  last --env-file  >  earlier --env-file
+REM so a value in .env.local wins over the same value in .env. Once we pass
+REM --env-file explicitly, Compose stops auto-loading .env from the cwd,
+REM which is why .env must be listed explicitly here.
+REM See https://github.com/OpenC3/cosmos/issues/3710
+set COMPOSE_ENV_FILES=--env-file "%~dp0.env"
+if exist "%~dp0.env.local" (
+  set COMPOSE_ENV_FILES=!COMPOSE_ENV_FILES! --env-file "%~dp0.env.local"
+)
+
 if "%1" == "" (
   GOTO usage
 )
@@ -73,9 +87,7 @@ if "%1" == "-h" (
   GOTO usage
 )
 if "%1" == "cli" (
-  REM tokens=* means process the full line
-  REM findstr /V = print lines that don't match, /B beginning of line, /L literal search string, /C:# match #
-  FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# %~dp0.env') do SET %%i
+  CALL :load_env
   set params=%*
   call set params=%%params:*%1=%%
   REM Start (and remove when done --rm) the cmd-tlm-api container with the current working directory
@@ -85,22 +97,22 @@ if "%1" == "cli" (
   REM Note: The service name is always openc3-cosmos-cmd-tlm-api; compose.yaml pulls the correct image
   REM (enterprise or non-enterprise) based on environment variables.
   if "%OPENC3_ENTERPRISE%" == "1" (
-    !CONTAINER_COMPOSE_CMD! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! run -it --rm -v %cd%:/openc3/local -w /openc3/local -e OPENC3_API_USER=!OPENC3_API_USER! -e OPENC3_API_PASSWORD=!OPENC3_API_PASSWORD! --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli !params!
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! run -it --rm -v %cd%:/openc3/local -w /openc3/local -e OPENC3_API_USER=!OPENC3_API_USER! -e OPENC3_API_PASSWORD=!OPENC3_API_PASSWORD! --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli !params!
   ) else (
-    !CONTAINER_COMPOSE_CMD! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! run -it --rm -v %cd%:/openc3/local -w /openc3/local -e OPENC3_API_PASSWORD=!OPENC3_API_PASSWORD! --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli !params!
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! run -it --rm -v %cd%:/openc3/local -w /openc3/local -e OPENC3_API_PASSWORD=!OPENC3_API_PASSWORD! --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli !params!
   )
   GOTO :EOF
 )
 if "%1" == "cliroot" (
-  FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# %~dp0.env') do SET %%i
+  CALL :load_env
   set params=%*
   call set params=%%params:*%1=%%
   REM Note: The service name is always openc3-cosmos-cmd-tlm-api; compose.yaml pulls the correct image
   REM (enterprise or non-enterprise) based on environment variables.
   if "%OPENC3_ENTERPRISE%" == "1" (
-    !CONTAINER_COMPOSE_CMD! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! run -it --rm --user=root -v %cd%:/openc3/local -w /openc3/local -e OPENC3_API_USER=!OPENC3_API_USER! -e OPENC3_API_PASSWORD=!OPENC3_API_PASSWORD! --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli !params!
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! run -it --rm --user=root -v %cd%:/openc3/local -w /openc3/local -e OPENC3_API_USER=!OPENC3_API_USER! -e OPENC3_API_PASSWORD=!OPENC3_API_PASSWORD! --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli !params!
   ) else (
-    !CONTAINER_COMPOSE_CMD! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! run -it --rm --user=root -v %cd%:/openc3/local -w /openc3/local -e OPENC3_API_PASSWORD=!OPENC3_API_PASSWORD! --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli !params!
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! run -it --rm --user=root -v %cd%:/openc3/local -w /openc3/local -e OPENC3_API_PASSWORD=!OPENC3_API_PASSWORD! --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli !params!
   )
   GOTO :EOF
 )
@@ -135,7 +147,7 @@ if "%1" == "upgrade" (
   GOTO upgrade
 )
 if "%1" == "util" (
-  FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# %~dp0.env') do SET %%i
+  CALL :load_env
   GOTO util
 )
 
@@ -144,22 +156,22 @@ GOTO usage
 :startup
   if "%OPENC3_DEVEL%" == "1" (
     CALL openc3 build || exit /b
-    !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! up -d
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! up -d
   ) else (
-    !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! up -d
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! up -d
   )
   @echo off
 GOTO :EOF
 
 :stop
-  !CONTAINER_COMPOSE_CMD! stop openc3-operator
-  !CONTAINER_COMPOSE_CMD! stop openc3-cosmos-script-runner-api
-  !CONTAINER_COMPOSE_CMD! stop openc3-cosmos-cmd-tlm-api
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! stop openc3-operator
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! stop openc3-cosmos-script-runner-api
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! stop openc3-cosmos-cmd-tlm-api
   if "%OPENC3_ENTERPRISE%" == "1" (
-    !CONTAINER_COMPOSE_CMD! stop openc3-metrics
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! stop openc3-metrics
   )
   timeout /t 5 /nobreak
-  !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! down -t 30
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! down -t 30
   @echo off
 GOTO :EOF
 
@@ -212,7 +224,7 @@ GOTO :EOF
 goto :try_cleanup
 
 :cleanup_y
-  !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! down -t 30 -v
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! down -t 30 -v
 
   if "%2" == "local" (
     FOR /d %%a IN (%~dp0plugins\DEFAULT\*) DO RD /S /Q "%%a"
@@ -231,30 +243,30 @@ GOTO :EOF
   if "%OPENC3_ENTERPRISE%" == "1" (
     REM Enterprise: build core images first when OPENC3_TAG=latest, then enterprise
     CALL :build_core_images
-    !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build openc3-enterprise-gem || GOTO :pull_failed
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build openc3-enterprise-gem || GOTO :pull_failed
   ) else (
-    !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build openc3-ruby || GOTO :pull_failed
-    !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build openc3-base || GOTO :pull_failed
-    !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build openc3-node || GOTO :pull_failed
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build openc3-ruby || GOTO :pull_failed
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build openc3-base || GOTO :pull_failed
+    !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build openc3-node || GOTO :pull_failed
   )
-  !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build || GOTO :pull_failed
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build || GOTO :pull_failed
   @echo off
 GOTO :EOF
 
 :run
-  !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! up -d || GOTO :pull_failed
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! up -d || GOTO :pull_failed
   @echo off
 GOTO :EOF
 
 :dev
-  !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-dev.yaml up -d
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-dev.yaml up -d
   @echo off
 GOTO :EOF
 
 :test
   REM Building COSMOS
   CALL scripts\windows\openc3_setup || exit /b
-  !CONTAINER_COMPOSE_CMD! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f compose.yaml !COMPOSE_OVERRIDE! -f compose-build.yaml build
   set args=%*
   call set args=%%args:*%1=%%
   REM Running tests
@@ -283,7 +295,9 @@ GOTO :EOF
 GOTO :EOF
 
 :resolve_openc3_tag
-  REM Resolve OPENC3_TAG from the env file if not already set.
+  REM Resolve OPENC3_TAG from the env files if not already set.
+  REM .env.local is checked first so its override wins over the .env default.
+  if not defined OPENC3_TAG if exist "%~dp0.env.local" FOR /F "tokens=1,* delims==" %%a in ('findstr /B /C:"OPENC3_TAG=" "%~dp0.env.local" 2^>nul') do set "OPENC3_TAG=%%b"
   if not defined OPENC3_TAG FOR /F "tokens=1,* delims==" %%a in ('findstr /B /C:"OPENC3_TAG=" "%~dp0.env" 2^>nul') do set "OPENC3_TAG=%%b"
   if not defined OPENC3_TAG set "OPENC3_TAG=latest"
   exit /b 0
@@ -308,8 +322,18 @@ REM docker.io) and break air-gapped builds. Instead suggest logging in.
   CALL :suggest_registry_login
   exit /b 1
 
+REM Load the env files into the environment, .env first then .env.local so
+REM .env.local overrides .env. findstr /V = print lines that don't match,
+REM /B beginning of line, /L literal search string, /C:# match #
+:load_env
+  FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# "%~dp0.env"') do SET %%i
+  if exist "%~dp0.env.local" (
+    FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# "%~dp0.env.local"') do SET %%i
+  )
+  GOTO :EOF
+
 :suggest_registry_login
-  FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# %~dp0.env') do SET %%i
+  CALL :load_env
   @echo. 1>&2
   @echo The command failed. If this was a registry authentication error (403), 1>&2
   @echo login to the registry and retry the command: 1>&2

--- a/openc3.bat
+++ b/openc3.bat
@@ -77,6 +77,16 @@ if exist "%~dp0.env.local" (
   set COMPOSE_ENV_FILES=!COMPOSE_ENV_FILES! --env-file "%~dp0.env.local"
 )
 
+REM Load the env files now, with delayed expansion DISABLED, so values that
+REM contain '!' (common in the passwords .env.local is meant to hold) are
+REM stored literally instead of being eaten by delayed expansion. Delayed
+REM expansion is re-enabled immediately afterwards for the rest of the script;
+REM variables set in the outer scope are inherited by the inner one and both
+REM scopes are popped when the script exits.
+setlocal DisableDelayedExpansion
+CALL :load_env
+setlocal EnableDelayedExpansion
+
 if "%1" == "" (
   GOTO usage
 )
@@ -87,7 +97,6 @@ if "%1" == "-h" (
   GOTO usage
 )
 if "%1" == "cli" (
-  CALL :load_env
   set params=%*
   call set params=%%params:*%1=%%
   REM Start (and remove when done --rm) the cmd-tlm-api container with the current working directory
@@ -104,7 +113,6 @@ if "%1" == "cli" (
   GOTO :EOF
 )
 if "%1" == "cliroot" (
-  CALL :load_env
   set params=%*
   call set params=%%params:*%1=%%
   REM Note: The service name is always openc3-cosmos-cmd-tlm-api; compose.yaml pulls the correct image
@@ -147,7 +155,6 @@ if "%1" == "upgrade" (
   GOTO upgrade
 )
 if "%1" == "util" (
-  CALL :load_env
   GOTO util
 )
 
@@ -186,13 +193,13 @@ GOTO :EOF
   REM Get image repositories from compose config
   REM Strip docker.io/ prefix and :tag suffix so we match all tags per repository
   set "FILTER_ARGS="
-  for /f "delims=" %%i in ('docker compose !COMPOSE_FILES! config --images 2^>nul') do (
+  for /f "delims=" %%i in ('!CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! !COMPOSE_FILES! config --images 2^>nul') do (
     set "IMG=%%i"
     set "IMG=!IMG:docker.io/=!"
     REM Strip :tag suffix by splitting on colon
     for /f "tokens=1 delims=:" %%r in ("!IMG!") do set "REPO=%%r"
     REM Check if any local images exist for this repository
-    for /f %%q in ('docker images -q "!REPO!" 2^>nul') do (
+    for /f %%q in ('!CONTAINER_CMD! images -q "!REPO!" 2^>nul') do (
       set "FILTER_ARGS=!FILTER_ARGS! --filter reference=!REPO!"
     )
   )
@@ -200,12 +207,12 @@ GOTO :EOF
     @echo No %COSMOS_NAME% images found locally.
     GOTO :EOF
   )
-  docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}" !FILTER_ARGS!
+  !CONTAINER_CMD! images --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}" !FILTER_ARGS!
   @echo off
 GOTO :EOF
 
 :status
-  docker compose -f %~dp0compose.yaml ps
+  !CONTAINER_COMPOSE_CMD! !COMPOSE_ENV_FILES! -f %~dp0compose.yaml !COMPOSE_OVERRIDE! ps
   @echo off
 GOTO :EOF
 
@@ -326,14 +333,15 @@ REM Load the env files into the environment, .env first then .env.local so
 REM .env.local overrides .env. findstr /V = print lines that don't match,
 REM /B beginning of line, /L literal search string, /C:# match #
 :load_env
-  FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# "%~dp0.env"') do SET %%i
+  if exist "%~dp0.env" (
+    FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# "%~dp0.env"') do SET %%i
+  )
   if exist "%~dp0.env.local" (
     FOR /F "tokens=*" %%i in ('findstr /V /B /L /C:# "%~dp0.env.local"') do SET %%i
   )
   GOTO :EOF
 
 :suggest_registry_login
-  CALL :load_env
   @echo. 1>&2
   @echo The command failed. If this was a registry authentication error (403), 1>&2
   @echo login to the registry and retry the command: 1>&2

--- a/openc3.sh
+++ b/openc3.sh
@@ -148,11 +148,11 @@ detect_compose_cmd
 # without editing it. See:
 # https://github.com/OpenC3/cosmos/issues/3024
 # https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/
-COMPOSE_FILE_ARGS=(--env-file "$(dirname -- "$0")/${ENV_FILE:-.env}")
+COMPOSE_ENV_FILE_ARGS=(--env-file "$(dirname -- "$0")/${ENV_FILE:-.env}")
 if [[ -f "$(dirname -- "$0")/.env.local" ]]; then
-  COMPOSE_FILE_ARGS+=(--env-file "$(dirname -- "$0")/.env.local")
+  COMPOSE_ENV_FILE_ARGS+=(--env-file "$(dirname -- "$0")/.env.local")
 fi
-COMPOSE_FILE_ARGS+=(-f "$(dirname -- "$0")/compose.yaml")
+COMPOSE_FILE_ARGS=("${COMPOSE_ENV_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose.yaml")
 if [[ -f "$(dirname -- "$0")/compose.override.yaml" ]]; then
   COMPOSE_FILE_ARGS+=(-f "$(dirname -- "$0")/compose.override.yaml")
 fi
@@ -673,7 +673,7 @@ case $1 in
     # Get the list of image repositories defined in the compose configuration
     # Strip the docker.io/ prefix that compose adds (docker CLI doesn't recognize it)
     # and strip the :tag suffix so we match all tags for each repository
-    REPOS=$(${DOCKER_COMPOSE_COMMAND} $COMPOSE_FILES config --images 2>/dev/null | sed 's|^docker\.io/||; s|:.*||' | sort -u)
+    REPOS=$(${DOCKER_COMPOSE_COMMAND} "${COMPOSE_ENV_FILE_ARGS[@]}" $COMPOSE_FILES config --images 2>/dev/null | sed 's|^docker\.io/||; s|:.*||' | sort -u)
     if [[ -z "$REPOS" ]]; then
       echo "No $COSMOS_NAME images found in compose configuration."
       exit 0
@@ -681,7 +681,7 @@ case $1 in
     # Build filter args for each repository that has at least one local image
     FILTER_ARGS=""
     for repo in $REPOS; do
-      if docker images -q "$repo" 2>/dev/null | grep -q .; then
+      if $CONTAINER_CMD images -q "$repo" 2>/dev/null | grep -q .; then
         FILTER_ARGS="$FILTER_ARGS --filter reference=$repo"
       fi
     done
@@ -689,7 +689,7 @@ case $1 in
       echo "No $COSMOS_NAME images found locally."
       exit 0
     fi
-    docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}" $FILTER_ARGS
+    $CONTAINER_CMD images --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}" $FILTER_ARGS
     ;;
   status )
     if [[ "$2" == "--help" ]] || [[ "$2" == "-h" ]]; then
@@ -704,7 +704,7 @@ case $1 in
       echo "  -h, --help    Show this help message"
       exit 0
     fi
-    ${DOCKER_COMPOSE_COMMAND} -f "$(dirname -- "$0")/compose.yaml" ps
+    ${DOCKER_COMPOSE_COMMAND} "${COMPOSE_FILE_ARGS[@]}" ps
     ;;
   destroy )
     if [[ "$2" == "--help" ]] || [[ "$2" == "-h" ]]; then
@@ -737,7 +737,7 @@ case $1 in
     fi
     # Get the list of images defined in the compose configuration
     # Strip the docker.io/ prefix that compose adds, since docker CLI doesn't recognize it
-    IMAGES=$(${DOCKER_COMPOSE_COMMAND} $COMPOSE_FILES config --images 2>/dev/null | sed 's|^docker\.io/||' | sort -u)
+    IMAGES=$(${DOCKER_COMPOSE_COMMAND} "${COMPOSE_ENV_FILE_ARGS[@]}" $COMPOSE_FILES config --images 2>/dev/null | sed 's|^docker\.io/||' | sort -u)
     if [[ -z "$IMAGES" ]]; then
       echo "No $COSMOS_NAME images found in compose configuration."
       exit 0
@@ -745,7 +745,7 @@ case $1 in
     # Filter to only images that actually exist locally
     EXISTING_IMAGES=""
     for img in $IMAGES; do
-      if docker image inspect "$img" &>/dev/null; then
+      if $CONTAINER_CMD image inspect "$img" &>/dev/null; then
         EXISTING_IMAGES="$EXISTING_IMAGES $img"
       fi
     done
@@ -761,12 +761,12 @@ case $1 in
     done
     echo ""
     if [[ "$2" == "force" ]]; then
-      docker rmi $EXISTING_IMAGES
+      $CONTAINER_CMD rmi $EXISTING_IMAGES
     else
       echo "Are you sure you want to remove these $COSMOS_NAME images? (1-Yes / 2-No)"
       select yn in "Yes" "No"; do
         case $yn in
-          Yes ) docker rmi $EXISTING_IMAGES; break;;
+          Yes ) $CONTAINER_CMD rmi $EXISTING_IMAGES; break;;
           No ) exit;;
           * ) echo "Please select 1 for Yes or 2 for No.";;
         esac
@@ -774,7 +774,7 @@ case $1 in
     fi
     echo ""
     echo "Pruning dangling images..."
-    docker image prune -f
+    $CONTAINER_CMD image prune -f
     ;;
   build )
     if [[ "$OPENC3_DEVEL" -eq 0 ]]; then

--- a/openc3.sh
+++ b/openc3.sh
@@ -45,12 +45,7 @@ detect_compose_cmd() {
 # We intentionally do NOT login automatically: forcing a login would require
 # credentials for public registries (e.g. docker.io) and break air-gapped builds.
 suggest_registry_login() {
-  local env_file="$(dirname -- "$0")/${ENV_FILE:-.env}"
-  if [[ -f "$env_file" ]]; then
-    set -a
-    . "$env_file"
-    set +a
-  fi
+  source_env_files
 
   echo "" >&2
   echo "A container image pull was denied (403 / authentication required)." >&2
@@ -78,6 +73,48 @@ run_with_registry_check() {
   fi
   rm -f "$tmp"
   return $status
+}
+
+# Source the env files into the shell environment, exporting every value.
+# .env ships the upstream defaults (tracked); .env.local (if present) is
+# sourced last so its values override .env. This mirrors the --env-file
+# ordering in COMPOSE_FILE_ARGS below. Sourcing only .env would export its
+# values as real shell variables, which outrank Compose's --env-file
+# interpolation and silently discard .env.local overrides.
+# See https://github.com/OpenC3/cosmos/issues/3710
+#
+# Variables already present in the shell environment win over both files, to
+# match the documented precedence (shell env > .env.local > .env). Sourcing
+# alone would clobber them, so their values are saved first and restored
+# afterwards.
+source_env_files() {
+  local dir="$(dirname -- "$0")"
+  local -a env_files=()
+  local file key
+  if [[ -f "$dir/${ENV_FILE:-.env}" ]]; then
+    env_files+=("$dir/${ENV_FILE:-.env}")
+  fi
+  if [[ -f "$dir/.env.local" ]]; then
+    env_files+=("$dir/.env.local")
+  fi
+
+  local -a preset=()
+  for file in "${env_files[@]}"; do
+    while IFS= read -r key; do
+      if [[ -n "${!key+x}" ]]; then
+        preset+=("$key=${!key}")
+      fi
+    done < <(sed -nE 's/^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)=.*/\2/p' "$file")
+  done
+
+  set -a
+  for file in "${env_files[@]}"; do
+    . "$file"
+  done
+  for key in "${preset[@]}"; do
+    export "$key"
+  done
+  set +a
 }
 
 # Helper function to find script - checks PATH first, then falls back to script location
@@ -333,15 +370,22 @@ check_root() {
   fi
 }
 
-# Resolve OPENC3_TAG, reading from the env file if not already set.
+# Resolve OPENC3_TAG, reading from the env files if not already set.
+# .env.local is checked first so its override wins over the .env default.
 resolve_openc3_tag() {
   if [[ -n "$OPENC3_TAG" ]]; then
     return
   fi
-  local env_file="$(dirname -- "$0")/${ENV_FILE:-.env}"
-  if [[ -f "$env_file" ]]; then
-    OPENC3_TAG=$(grep -E '^OPENC3_TAG=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2)
-  fi
+  local dir="$(dirname -- "$0")"
+  local env_file
+  for env_file in "$dir/.env.local" "$dir/${ENV_FILE:-.env}"; do
+    if [[ -f "$env_file" ]]; then
+      OPENC3_TAG=$(grep -E '^OPENC3_TAG=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2)
+      if [[ -n "$OPENC3_TAG" ]]; then
+        break
+      fi
+    fi
+  done
   OPENC3_TAG="${OPENC3_TAG:-latest}"
 }
 
@@ -402,10 +446,9 @@ case $1 in
       echo "  --wrapper-help    (same as --help)"
       exit 0
     fi
-    # Source the environment file to setup environment variables
-    # Use ENV_FILE if set, otherwise default to .env
-    set -a
-    . "$(dirname -- "$0")/${ENV_FILE:-.env}"
+    # Source the environment files (.env then .env.local) to setup
+    # environment variables. Use ENV_FILE if set, otherwise default to .env
+    source_env_files
     # Start (and remove when done --rm) the cmd-tlm-api container with the current working directory
     # mapped as volume (-v) /openc3/local and container working directory (-w) also set to /openc3/local.
     # This allows tools running in the container to have a consistent path to the current working directory.
@@ -417,7 +460,6 @@ case $1 in
     else
       ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm -v $(pwd):/openc3/local:z -w /openc3/local -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli "$@"
     fi
-    set +a
     ;;
   cliroot )
     if [[ "$2" == "--wrapper-help" ]] || [[ "$2" == "--help" ]] || [[ "$2" == "-h" ]]; then
@@ -454,10 +496,9 @@ case $1 in
       echo "  --wrapper-help    (same as --help)"
       exit 0
     fi
-    # Source the environment file to setup environment variables
-    # Use ENV_FILE if set, otherwise default to .env
-    set -a
-    . "$(dirname -- "$0")/${ENV_FILE:-.env}"
+    # Source the environment files (.env then .env.local) to setup
+    # environment variables. Use ENV_FILE if set, otherwise default to .env
+    source_env_files
     # Same as cli but run as root user
     # Note: The service name is always openc3-cosmos-cmd-tlm-api; compose.yaml pulls the correct image
     # (enterprise or non-enterprise) based on environment variables.
@@ -468,7 +509,6 @@ case $1 in
     else
       ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm --user=root -v $(pwd):/openc3/local:z -w /openc3/local -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli "$@"
     fi
-    set +a
     ;;
   start )
     if [[ "$2" == "--help" ]] || [[ "$2" == "-h" ]]; then
@@ -843,8 +883,7 @@ case $1 in
     fi
     # Change to cosmos directory since scripts use relative paths
     cd "$(dirname -- "$0")"
-    set -a
-    . "$(dirname -- "$0")/${ENV_FILE:-.env}"
+    source_env_files
     if [[ -f /etc/ssl/certs/ca-bundle.crt ]]
     then
       cp /etc/ssl/certs/ca-bundle.crt "$(dirname -- "$0")/cacert.pem"
@@ -852,7 +891,6 @@ case $1 in
     "$(find_script openc3_setup.sh)"
     # Pass through any additional arguments (image names) to openc3_build_ubi.sh
     "$(find_script openc3_build_ubi.sh)" "${@:2}"
-    set +a
     ;;
   run )
     if [[ "$2" == "--help" ]] || [[ "$2" == "-h" ]]; then
@@ -995,10 +1033,8 @@ case $1 in
       echo "  -h, --help                  Show this help message"
       exit 0
     fi
-    set -a
-    . "$(dirname -- "$0")/${ENV_FILE:-.env}"
+    source_env_files
     "$(find_script openc3_util.sh)" "${@:2}"
-    set +a
     ;;
   * )
     usage $0


### PR DESCRIPTION
### What changed

Source the .env, then the .env.local, then the environment variables when running openc3.sh commands.

### Why it changed

Our new .env.local changes were not being applied when using openc3.sh cli for example.

closes #3710

### Testing strategy

Create a .env.local. Add the following line `OPENC3_REGISTRY=nope.io`. Try running `openc3.sh cli help`. Observe:
```
Image nope.io/openc3inc/openc3-cosmos-cmd-tlm-api:latest Pulling
Image nope.io/openc3inc/openc3-cosmos-cmd-tlm-api:latest Error failed to resolve reference "nope.io/openc3inc/openc3-cosmos-cmd-tlm-api:latest": failed to do request: Head "https://nope.io/v2/openc3inc/openc3-cosmos-cmd-tlm-api/manifests/latest": dialing nope.io:443 container via direct connection because Docker Desktop has no HTTPS proxy: connecting to nope.io:443: dial tcp: lookup nope.io: no such host
```

I wasn't able to test the Windows batch file changes and note that the Windows side still does not honor environment variable settings over .env and .env.local. This is an existing behavior.