### PR TITLE
fix(interface): make connect_interface a no-op when already connected

### DIFF
--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -5850,6 +5850,11 @@ interface_names = get_interface_names() # => ['INST_INT', 'INST2_INT', 'EXAMPLE_
 
 Connects to targets associated with a COSMOS interface.
 
+If the interface is already connected and no interface parameters are given, this
+method is a no-op and the existing connection is left untouched. To force a
+reconnect, call [disconnect_interface](#disconnect_interface) first, or pass
+interface parameters which always rebuild the interface.
+
 <Tabs groupId="script-language">
 <TabItem value="python" label="Python Syntax">
 
@@ -5897,7 +5902,10 @@ connect_interface("INT1", hostname, port)
 
 <span class="badge badge--secondary since-heading">Since 5.0.0</span>
 
-Disconnects from targets associated with a COSMOS interface.
+Disconnects from targets associated with a COSMOS interface. If the interface has
+already been disconnected this is a no-op. Otherwise the interface is asked to
+disconnect regardless of whether it reports being connected, so any resources it
+is still holding are released.
 
 <Tabs groupId="script-language">
 <TabItem value="python" label="Python Syntax">

--- a/openc3/lib/openc3/interfaces/mqtt_stream_interface.rb
+++ b/openc3/lib/openc3/interfaces/mqtt_stream_interface.rb
@@ -49,6 +49,8 @@ module OpenC3
 
     # Creates a new {SerialStream} using the parameters passed in the constructor
     def connect
+      # Cleanly close any existing stream rather than leaving it open
+      @stream.disconnect if @stream
       @stream = MqttStream.new(@hostname, @port, @ssl, @write_topic, @read_topic, @ack_timeout)
       @stream.username = @username if @username
       @stream.password = @password if @password

--- a/openc3/lib/openc3/interfaces/serial_interface.rb
+++ b/openc3/lib/openc3/interfaces/serial_interface.rb
@@ -77,6 +77,8 @@ module OpenC3
 
     # Creates a new {SerialStream} using the parameters passed in the constructor
     def connect
+      # Cleanly close any existing stream rather than leaving it open
+      @stream.disconnect if @stream
       @stream = SerialStream.new(
         @write_port_name,
         @read_port_name,

--- a/openc3/lib/openc3/interfaces/tcpip_client_interface.rb
+++ b/openc3/lib/openc3/interfaces/tcpip_client_interface.rb
@@ -76,6 +76,8 @@ module OpenC3
     # Connects the {TcpipClientStream} by passing the
     # initialization parameters to the {TcpipClientStream}.
     def connect
+      # Cleanly close any existing stream rather than leaving it open
+      @stream.disconnect if @stream
       @stream = TcpipClientStream.new(
         @hostname,
         @write_port,

--- a/openc3/lib/openc3/microservices/interface_microservice.rb
+++ b/openc3/lib/openc3/microservices/interface_microservice.rb
@@ -610,7 +610,26 @@ module OpenC3
     # Called to connect the interface/router. It takes optional parameters to
     # rebuilt the interface/router. Once we set the state to 'ATTEMPTING' the
     # run method handles the actual connection.
+    # Connecting an interface/router which is already CONNECTED is a no-op.
+    # Without this the existing (working) connection would be torn down and
+    # rebuilt which can take up to the read_timeout to detect. Callers who want
+    # to force a reconnect should disconnect first or pass new parameters.
     def attempting(*params)
+      if params.empty? and @interface.state == 'CONNECTED' and @interface.connected?
+        @logger.info "#{@interface.name}: Connect ignored, already connected"
+        return @interface
+      end
+
+      attempt_connection(*params)
+    end
+
+    # Sets the state to 'ATTEMPTING', first rebuilding the interface/router if
+    # parameters are given, so the run method performs the actual connection.
+    # Unlike attempting() this always transitions. The reconnect path in
+    # disconnect() requires that, since @interface.disconnect may have raised or
+    # left connected? true, which would make attempting() ignore the request and
+    # leave the interface stuck in 'CONNECTED' with no way back to a connection.
+    def attempt_connection(*params)
       unless params.empty?
         @interface.disconnect()
         # Build New Interface, this can fail if passed bad parameters
@@ -828,6 +847,13 @@ module OpenC3
 
     def connect
       @logger.info "#{@interface.name}: Connect #{@interface.connection_string}"
+      # Interface connect implementations typically overwrite their stream / socket
+      # so cleanly close any existing connection rather than leaking it
+      begin
+        @interface.disconnect if @interface.connected?
+      rescue => e
+        @logger.error "Disconnect: #{@interface.name}: #{e.formatted}"
+      end
       begin
         @interface.connect
         @interface.post_connect
@@ -849,38 +875,49 @@ module OpenC3
     end
 
     def disconnect(allow_reconnect = true)
-      return if @interface.state == 'DISCONNECTED' && !@interface.connected?
+      reconnect = false
 
-      # Synchronize the calls to @interface.disconnect since it takes an unknown
-      # amount of time. If two calls to disconnect stack up, the if statement
-      # should avoid multiple calls to disconnect.
+      # Two threads reach here for a single connection loss: the cmd handler
+      # thread servicing a disconnect directive, and the run thread coming back
+      # out of read (or out of the connection maintenance sleep). The redundant
+      # check below and the state change that records the disconnect must be in
+      # the same critical section, otherwise the second thread reads the state
+      # before the first has updated it and disconnects the interface twice.
       @mutex.synchronize do
+        # A disconnect has already been performed so there is nothing left to do
+        return if @interface.state == 'DISCONNECTED' && !@interface.connected?
+
+        # Call disconnect without consulting connected? so any resources the
+        # interface is still holding are cleaned up. It takes an unknown amount
+        # of time which is the other reason for the mutex.
         begin
-          @interface.disconnect if @interface.connected?
+          @interface.disconnect
         rescue => e
           @logger.error "Disconnect: #{@interface.name}: #{e.formatted}"
         end
-      end
 
-      # If the interface is set to auto_reconnect then delay so the thread
-      # can come back around and allow the interface a chance to reconnect.
-      # Skip reconnect if stop() has been called to avoid re-creating the status model
-      if allow_reconnect and @interface.auto_reconnect and @interface.state != 'DISCONNECTED' and !@cancel_thread
-        attempting()
-        if !@cancel_thread
-          # @logger.debug "reconnect delay: #{@interface.reconnect_delay}"
-          @interface_thread_sleeper.sleep(@interface.reconnect_delay)
-        end
-      else
-        @interface.state = 'DISCONNECTED'
-        unless @cancel_thread
-          if @interface_or_router == 'INTERFACE'
-            InterfaceStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
-          else
-            RouterStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+        # If the interface is set to auto_reconnect then delay so the thread
+        # can come back around and allow the interface a chance to reconnect.
+        # Skip reconnect if stop() has been called to avoid re-creating the status model
+        reconnect = allow_reconnect && @interface.auto_reconnect && @interface.state != 'DISCONNECTED' && !@cancel_thread
+        if reconnect
+          attempt_connection()
+        else
+          @interface.state = 'DISCONNECTED'
+          unless @cancel_thread
+            if @interface_or_router == 'INTERFACE'
+              InterfaceStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+            else
+              RouterStatusModel.set(@interface.as_json(), queued: true, scope: @scope)
+            end
           end
         end
       end
+
+      # Sleep outside the mutex so stop() and connect() are not blocked for the
+      # whole reconnect delay
+      # @logger.debug "reconnect delay: #{@interface.reconnect_delay}"
+      @interface_thread_sleeper.sleep(@interface.reconnect_delay) if reconnect && !@cancel_thread
     end
 
     # Disconnect from the interface and stop the thread

--- a/openc3/lib/openc3/tools/cmd_tlm_server/interface_thread.rb
+++ b/openc3/lib/openc3/tools/cmd_tlm_server/interface_thread.rb
@@ -253,6 +253,9 @@ module OpenC3
 
     def connect
       Logger.info "Connecting to #{@interface.name}..."
+      # Interface connect implementations typically overwrite their stream / socket
+      # so cleanly close any existing connection rather than leaking it
+      @interface.disconnect if @interface.connected?
       @interface.connect
       if @connection_success_callback
         @connection_success_callback.call

--- a/openc3/lib/openc3/tools/cmd_tlm_server/interface_thread.rb
+++ b/openc3/lib/openc3/tools/cmd_tlm_server/interface_thread.rb
@@ -255,7 +255,11 @@ module OpenC3
       Logger.info "Connecting to #{@interface.name}..."
       # Interface connect implementations typically overwrite their stream / socket
       # so cleanly close any existing connection rather than leaking it
-      @interface.disconnect if @interface.connected?
+      begin
+        @interface.disconnect if @interface.connected?
+      rescue => err
+        Logger.error "Disconnect: #{@interface.name}: #{err.formatted}"
+      end
       @interface.connect
       if @connection_success_callback
         @connection_success_callback.call

--- a/openc3/python/openc3/interfaces/mqtt_stream_interface.py
+++ b/openc3/python/openc3/interfaces/mqtt_stream_interface.py
@@ -60,6 +60,9 @@ class MqttStreamInterface(StreamInterface):
 
     # Creates a new {SerialStream} using the parameters passed in the constructor
     def connect(self):
+        # Cleanly close any existing stream rather than leaving it open
+        if self.stream:
+            self.stream.disconnect()
         self.stream = MqttStream(
             self.hostname,
             self.port,

--- a/openc3/python/openc3/interfaces/serial_interface.py
+++ b/openc3/python/openc3/interfaces/serial_interface.py
@@ -85,6 +85,9 @@ class SerialInterface(StreamInterface):
 
     def connect(self):
         """Creates a new SerialStream using the parameters passed in the constructor"""
+        # Cleanly close any existing stream rather than leaving it open
+        if self.stream:
+            self.stream.disconnect()
         self.stream = SerialStream(
             write_port_name=self.write_port_name,
             read_port_name=self.read_port_name,

--- a/openc3/python/openc3/interfaces/tcpip_client_interface.py
+++ b/openc3/python/openc3/interfaces/tcpip_client_interface.py
@@ -73,6 +73,9 @@ class TcpipClientInterface(StreamInterface):
     # Connects the {TcpipClientStream} by passing the
     # initialization parameters to the {TcpipClientStream}.
     def connect(self):
+        # Cleanly close any existing stream rather than leaving it open
+        if self.stream:
+            self.stream.disconnect()
         self.stream = TcpipClientStream(
             self.hostname,
             self.write_port,

--- a/openc3/python/openc3/microservices/interface_microservice.py
+++ b/openc3/python/openc3/microservices/interface_microservice.py
@@ -685,6 +685,23 @@ class InterfaceMicroservice(Microservice):
     # rebuilt the interface/router. Once we set the state to 'ATTEMPTING' the
     # run method handles the actual connection.
     def attempting(self, *params):
+        # Connecting an interface/router which is already CONNECTED is a no-op.
+        # Without this the existing (working) connection would be torn down and
+        # rebuilt which can take up to the read_timeout to detect. Callers who want
+        # to force a reconnect should disconnect first or pass new parameters.
+        if len(params) == 0 and self.interface.state == "CONNECTED" and self.interface.connected():
+            self.logger.info(f"{self.interface.name}: Connect ignored, already connected")
+            return self.interface
+
+        return self.attempt_connection(*params)
+
+    # Sets the state to 'ATTEMPTING', first rebuilding the interface/router if
+    # parameters are given, so the run method performs the actual connection.
+    # Unlike attempting() this always transitions. The reconnect path in
+    # disconnect() requires that, since interface.disconnect() may have raised or
+    # left connected() True, which would make attempting() ignore the request and
+    # leave the interface stuck in 'CONNECTED' with no way back to a connection.
+    def attempt_connection(self, *params):
         try:
             if len(params) != 0:
                 self.interface.disconnect()
@@ -900,6 +917,14 @@ class InterfaceMicroservice(Microservice):
     def connect(self):
         self.logger.info(f"{self.interface.name}: Connect {self.interface.connection_string()}")
 
+        # Interface connect implementations typically overwrite their stream / socket
+        # so cleanly close any existing connection rather than leaking it
+        if self.interface.connected():
+            try:
+                self.interface.disconnect()
+            except Exception:
+                self.logger.error(f"Disconnect: {self.interface.name}: {traceback.format_exc()}")
+
         try:
             self.interface.connect()
             self.interface.post_connect()
@@ -917,38 +942,50 @@ class InterfaceMicroservice(Microservice):
         self.logger.info(f"{self.interface.name}: Connection Success")
 
     def disconnect(self, allow_reconnect=True):
-        if self.interface.state == "DISCONNECTED" and self.interface.connected() is False:
-            return
+        reconnect = False
 
-        # Synchronize the calls to @interface.disconnect since it takes an unknown
-        # amount of time. If two calls to disconnect stack up, the if statement
-        # should avoid multiple calls to disconnect.
+        # Two threads reach here for a single connection loss: the cmd handler
+        # thread servicing a disconnect directive, and the run thread coming back
+        # out of read (or out of the connection maintenance sleep). The redundant
+        # check below and the state change that records the disconnect must be in
+        # the same critical section, otherwise the second thread reads the state
+        # before the first has updated it and disconnects the interface twice.
         with self.mutex:
+            # A disconnect has already been performed so there is nothing left to do
+            if self.interface.state == "DISCONNECTED" and self.interface.connected() is False:
+                return
+
+            # Call disconnect without consulting connected() so any resources the
+            # interface is still holding are cleaned up. It takes an unknown amount
+            # of time which is the other reason for the mutex.
             try:
-                if self.interface.connected():
-                    self.interface.disconnect()
+                self.interface.disconnect()
             except Exception:
                 self.logger.error(f"Disconnect: {self.interface.name}: {traceback.format_exc()}")
 
-        # If the interface is set to auto_reconnect then delay so the thread
-        # can come back around and allow the interface a chance to reconnect.
-        # Skip reconnect if stop() has been called to avoid re-creating the status model
-        if (
-            allow_reconnect
-            and self.interface.auto_reconnect
-            and self.interface.state != "DISCONNECTED"
-            and not self.cancel_thread
-        ):
-            self.attempting()
-            if not self.cancel_thread:
-                self.interface_thread_sleeper.sleep(self.interface.reconnect_delay)
-        else:
-            self.interface.state = "DISCONNECTED"
-            if not self.cancel_thread:
-                if self.interface_or_router == "INTERFACE":
-                    InterfaceStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
-                else:
-                    RouterStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
+            # If the interface is set to auto_reconnect then delay so the thread
+            # can come back around and allow the interface a chance to reconnect.
+            # Skip reconnect if stop() has been called to avoid re-creating the status model
+            reconnect = (
+                allow_reconnect
+                and self.interface.auto_reconnect
+                and self.interface.state != "DISCONNECTED"
+                and not self.cancel_thread
+            )
+            if reconnect:
+                self.attempt_connection()
+            else:
+                self.interface.state = "DISCONNECTED"
+                if not self.cancel_thread:
+                    if self.interface_or_router == "INTERFACE":
+                        InterfaceStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
+                    else:
+                        RouterStatusModel.set(self.interface.as_json(), queued=True, scope=self.scope)
+
+        # Sleep outside the mutex so stop() and connect() are not blocked for the
+        # whole reconnect delay
+        if reconnect and not self.cancel_thread:
+            self.interface_thread_sleeper.sleep(self.interface.reconnect_delay)
 
     # Disconnect from the interface and stop the thread
     def stop(self):

--- a/openc3/python/test/microservices/test_interface_microservice.py
+++ b/openc3/python/test/microservices/test_interface_microservice.py
@@ -283,6 +283,85 @@ class TestInterfaceMicroservice(unittest.TestCase):
 
             self.assertEqual(im.interface.port, 54321)
 
+    def test_ignores_connect_interface_on_a_connected_interface(self):
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        im.interface.reconnect_delay = 0.1  # Override the reconnect delay to be quick
+
+        for stdout in capture_io():
+            self.start_microservice(im)
+            all_interfaces = self.wait_for_state("CONNECTED")
+            self.assertEqual(all_interfaces["INST_INT"]["state"], "CONNECTED")
+            self.assertEqual(im.interface.connect_count, 1)
+
+            InterfaceTopic.connect_interface("INST_INT", scope="DEFAULT")
+            self.wait_for_output(stdout, "Connect ignored, already connected")
+            time.sleep(0.1)
+            # The existing connection is left alone
+            self.assertNotIn("Connection Lost", stdout.getvalue())
+            self.assertEqual(im.interface.disconnect_count, 0)
+            self.assertEqual(im.interface.connect_count, 1)
+            all_interfaces = InterfaceStatusModel.all(scope="DEFAULT")
+            self.assertEqual(all_interfaces["INST_INT"]["state"], "CONNECTED")
+
+    def test_connects_if_the_state_is_connected_but_the_interface_is_not(self):
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        self.addCleanup(im.shutdown)
+        im.interface.state = "CONNECTED"
+        im.interface._connected = False
+        im.attempting()
+        self.assertEqual(im.interface.state, "ATTEMPTING")
+
+    def test_cleanly_disconnects_an_existing_connection_before_connecting(self):
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        self.addCleanup(im.shutdown)
+        im.interface.state = "ATTEMPTING"
+        im.interface._connected = True
+        im.connect()
+        # The old connection was closed rather than being abandoned
+        self.assertEqual(im.interface.disconnect_count, 1)
+        self.assertEqual(im.interface.state, "CONNECTED")
+
+    def test_disconnects_even_if_the_interface_reports_it_is_not_connected(self):
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        self.addCleanup(im.shutdown)
+        im.interface.state = "CONNECTED"
+        im.interface._connected = False
+        im.disconnect(False)
+        self.assertEqual(im.interface.disconnect_count, 1)
+        self.assertEqual(im.interface.state, "DISCONNECTED")
+
+    # The no-op check in attempting() must not block the reconnect path in
+    # disconnect() or a failed cleanup leaves the interface stuck in CONNECTED
+    def test_still_reconnects_if_the_interface_disconnect_raises(self):
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        self.addCleanup(im.shutdown)
+        im.interface.reconnect_delay = 0.01  # Override the reconnect delay to be quick
+        im.interface.state = "CONNECTED"
+        im.interface._connected = True
+
+        for stdout in capture_io():
+            with patch.object(im.interface, "disconnect", side_effect=RuntimeError("test-error")):
+                im.disconnect()
+            self.assertIn("Disconnect: INST_INT", stdout.getvalue())
+            self.assertNotIn("Connect ignored, already connected", stdout.getvalue())
+        self.assertEqual(im.interface.state, "ATTEMPTING")
+
+    def test_still_reconnects_if_the_interface_disconnect_leaves_it_connected(self):
+        im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
+        self.addCleanup(im.shutdown)
+        im.interface.reconnect_delay = 0.01  # Override the reconnect delay to be quick
+        im.interface.state = "CONNECTED"
+        im.interface._connected = True
+
+        for stdout in capture_io():
+            # Disconnect does nothing so connected() still reports True afterwards
+            with patch.object(im.interface, "disconnect") as mock_disconnect:
+                im.disconnect()
+                mock_disconnect.assert_called_once()
+            self.assertNotIn("Connect ignored, already connected", stdout.getvalue())
+        self.assertTrue(im.interface.connected())
+        self.assertEqual(im.interface.state, "ATTEMPTING")
+
     # def test_handles_exceptions_in_monitor_thread(self):
     #     im = InterfaceMicroservice("DEFAULT__INTERFACE__INST_INT")
     #     all_interfaces = InterfaceStatusModel.all(scope="DEFAULT")

--- a/openc3/spec/microservices/interface_microservice_spec.rb
+++ b/openc3/spec/microservices/interface_microservice_spec.rb
@@ -352,6 +352,108 @@ module OpenC3
       end
     end
 
+    describe "already connected" do
+      it "ignores connect_interface on a CONNECTED interface" do
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        sleep 0.01
+        interface = im.instance_variable_get(:@interface)
+        interface.reconnect_delay = 0.01 # Override the reconnect delay to be quick
+
+        capture_io do |stdout|
+          Thread.new { im.run }
+          sleep 0.01 # Allow to start
+          all = InterfaceStatusModel.all(scope: "DEFAULT")
+          expect(all["INST_INT"]["state"]).to eql "CONNECTED"
+
+          @api.connect_interface("INST_INT")
+          sleep 0.2 # Allow the connect request to be processed
+          expect(stdout.string).to include("Connect ignored, already connected")
+          # The existing connection is left alone
+          expect(stdout.string).not_to include("Connection Lost")
+          expect($disconnect_count).to eql 0
+          all = InterfaceStatusModel.all(scope: "DEFAULT")
+          expect(all["INST_INT"]["state"]).to eql "CONNECTED"
+
+          im.shutdown
+        end
+      end
+
+      it "connects if the state is CONNECTED but the interface is not" do
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        interface = im.instance_variable_get(:@interface)
+        interface.state = 'CONNECTED'
+        interface.instance_variable_set(:@connected, false)
+        im.attempting()
+        expect(interface.state).to eql 'ATTEMPTING'
+        im.shutdown
+      end
+
+      it "cleanly disconnects an existing connection before connecting" do
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        interface = im.instance_variable_get(:@interface)
+        interface.state = 'ATTEMPTING'
+        interface.instance_variable_set(:@connected, true)
+        im.connect()
+        # The old connection was closed rather than being abandoned
+        expect($disconnect_count).to eql 1
+        expect(interface.state).to eql 'CONNECTED'
+        im.shutdown
+      end
+
+      it "disconnects even if the interface reports it is not connected" do
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        interface = im.instance_variable_get(:@interface)
+        interface.state = 'CONNECTED'
+        interface.instance_variable_set(:@connected, false)
+        im.disconnect(false)
+        expect($disconnect_count).to eql 1
+        expect(interface.state).to eql 'DISCONNECTED'
+        im.shutdown
+      end
+
+      # The no-op check in attempting() must not block the reconnect path in
+      # disconnect() or a failed cleanup leaves the interface stuck in CONNECTED
+      it "still reconnects if the interface disconnect raises" do
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        interface = im.instance_variable_get(:@interface)
+        interface.reconnect_delay = 0.01 # Override the reconnect delay to be quick
+        interface.state = 'CONNECTED'
+        interface.instance_variable_set(:@connected, true)
+        allow(interface).to receive(:disconnect).and_raise('test-error')
+
+        capture_io do |stdout|
+          im.disconnect()
+          expect(stdout.string).to include("Disconnect: INST_INT")
+          expect(stdout.string).not_to include("Connect ignored, already connected")
+        end
+        expect(interface.state).to eql 'ATTEMPTING'
+
+        allow(interface).to receive(:disconnect).and_call_original # Allow a clean shutdown
+        im.shutdown
+      end
+
+      it "still reconnects if the interface disconnect leaves it connected" do
+        im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")
+        interface = im.instance_variable_get(:@interface)
+        interface.reconnect_delay = 0.01 # Override the reconnect delay to be quick
+        interface.state = 'CONNECTED'
+        interface.instance_variable_set(:@connected, true)
+        # Disconnect does nothing so connected? still reports true afterwards
+        allow(interface).to receive(:disconnect)
+
+        capture_io do |stdout|
+          im.disconnect()
+          expect(stdout.string).not_to include("Connect ignored, already connected")
+        end
+        expect(interface).to have_received(:disconnect)
+        expect(interface.connected?).to be true
+        expect(interface.state).to eql 'ATTEMPTING'
+
+        allow(interface).to receive(:disconnect).and_call_original # Allow a clean shutdown
+        im.shutdown
+      end
+    end
+
     it "handles exceptions in monitor thread" do
       $read_allowed_raise = true
       im = InterfaceMicroservice.new("DEFAULT__INTERFACE__INST_INT")


### PR DESCRIPTION
### What changed

The redundant-disconnect check and the state change that records it now share one critical section; splitting them let a second thread disconnect the interface twice. attempting() gained the already-connected guard, so the reconnect path calls attempt_connection() directly to avoid being ignored when interface cleanup raises or leaves connected? true.

### Why it changed

Connecting a CONNECTED interface set state to ATTEMPTING without touching the socket, so a working connection was torn down and rebuilt only once the blocking read returned, costing a full read_timeout. Interface connect now closes any existing stream instead of abandoning it to the GC, and disconnect no longer skips cleanup based on connected?.

Fixes #3798

### Testing strategy

Mostly unit tests. Also ran the demo and connected and disconnect. Ran script to test multiple connect / disconnect:
```python
for interface in ["INST_INT", "INST2_INT"]:
  disconnect_interface(interface)
  wait(3)
  disconnect_interface(interface)
  wait(3)
  connect_interface(interface)
  wait(3)
  connect_interface(interface)
  wait(3)
```
while watching the CmdTlmServer. Observed `Connect ignored, already connected` messages. Finally connected EXAMPLE_INT and TEMPLATE_INT and then restarted their backend interfaces to observe reconnect.