### PR TITLE
fix(script): align check, wait and wait_check comparison parsing

### DIFF
--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -2684,8 +2684,16 @@ check("<Target Name> <Packet Name> <Item Name> <Comparison - optional>")
 | Item Name   | Name of the telemetry item.                                                                                                                        |
 | Comparison  | A comparison to perform against the telemetry item. If a comparison is not given then the telemetry item will just be printed into the script log. |
 
+:::note[Supported Comparisons]
+A comparison is a single operator followed by a literal value. The supported operators are
+`==`, `!=`, `>`, `>=`, `<`, `<=` and `in`. `in` requires a list operand, e.g. `in [1, 2, 3]`,
+whose elements follow the same rules as any other value, e.g. `in ['ON', 'OFF']`.
+Compound expressions, e.g. `TIMEUS & 0x0001 == 0x0000`, are not supported - use
+[check_expression](#check_expression) instead.
+:::
+
 :::note[String Comparisons]
-When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). Unquoted values are interpreted as variable names.
+When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself, e.g. `check("INST HEALTH_STATUS TYPE == '#{expected}'")`.
 :::
 
 <Tabs groupId="script-language">
@@ -4143,8 +4151,16 @@ success = wait(
 | type         | Named parameter specifying the type. RAW, CONVERTED (default) or FORMATTED (Ruby symbol, Python string).       |
 | quiet        | Named parameter indicating whether to log the result. Defaults to false which means log the wait.              |
 
+:::note[Supported Comparisons]
+A comparison is a single operator followed by a literal value. The supported operators are
+`==`, `!=`, `>`, `>=`, `<`, `<=` and `in`. `in` requires a list operand, e.g. `in [1, 2, 3]`,
+whose elements follow the same rules as any other value, e.g. `in ['ON', 'OFF']`.
+Compound expressions, e.g. `TIMEUS & 0x0001 == 0x0000`, are not supported - use
+[wait_expression](#wait_expression) instead.
+:::
+
 :::note[String Comparisons]
-When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). Unquoted values are interpreted as variable names.
+When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself, e.g. `check("INST HEALTH_STATUS TYPE == '#{expected}'")`.
 :::
 
 <Tabs groupId="script-language">
@@ -4424,8 +4440,16 @@ elapsed = wait_check(
 | Polling Rate | How often the comparison is evaluated in seconds. Defaults to 0.25 if not specified.                        |
 | type         | Named parameter specifying the type. RAW, CONVERTED (default) or FORMATTED (Ruby symbol, Python string).    |
 
+:::note[Supported Comparisons]
+A comparison is a single operator followed by a literal value. The supported operators are
+`==`, `!=`, `>`, `>=`, `<`, `<=` and `in`. `in` requires a list operand, e.g. `in [1, 2, 3]`,
+whose elements follow the same rules as any other value, e.g. `in ['ON', 'OFF']`.
+Compound expressions, e.g. `TIMEUS & 0x0001 == 0x0000`, are not supported - use
+[wait_check_expression](#wait_check_expression) instead.
+:::
+
 :::note String Comparisons
-When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). Unquoted values are interpreted as variable names.
+When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself, e.g. `check("INST HEALTH_STATUS TYPE == '#{expected}'")`.
 :::
 
 <Tabs groupId="script-language">

--- a/docs.openc3.com/docs/guides/scripting-api.md
+++ b/docs.openc3.com/docs/guides/scripting-api.md
@@ -2693,7 +2693,7 @@ Compound expressions, e.g. `TIMEUS & 0x0001 == 0x0000`, are not supported - use
 :::
 
 :::note[String Comparisons]
-When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself, e.g. `check("INST HEALTH_STATUS TYPE == '#{expected}'")`.
+When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself instead: Ruby `check("INST HEALTH_STATUS TYPE == '#{expected}'")` or Python `check(f"INST HEALTH_STATUS TYPE == '{expected}'")`.
 :::
 
 <Tabs groupId="script-language">
@@ -4160,7 +4160,7 @@ Compound expressions, e.g. `TIMEUS & 0x0001 == 0x0000`, are not supported - use
 :::
 
 :::note[String Comparisons]
-When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself, e.g. `check("INST HEALTH_STATUS TYPE == '#{expected}'")`.
+When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself instead: Ruby `wait("INST HEALTH_STATUS TYPE == '#{expected}'", 10)` or Python `wait(f"INST HEALTH_STATUS TYPE == '{expected}'", 10)`.
 :::
 
 <Tabs groupId="script-language">
@@ -4448,8 +4448,8 @@ Compound expressions, e.g. `TIMEUS & 0x0001 == 0x0000`, are not supported - use
 [wait_check_expression](#wait_check_expression) instead.
 :::
 
-:::note String Comparisons
-When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself, e.g. `check("INST HEALTH_STATUS TYPE == '#{expected}'")`.
+:::note[String Comparisons]
+When comparing against string or state values, the value must be quoted (e.g., `== 'ON'`). An unquoted value is rejected with `Uninitialized constant ON. Did you mean 'ON' as a string?`. Quoted values follow the string literal rules of the script language, so escape sequences are processed in Ruby double quoted strings and in all Python strings. The Ruby control and meta escapes `\c`, `\C-` and `\M-` are rejected rather than silently changed, as is string interpolation (Ruby `"#{...}"`, Python f-strings) because the comparison is not evaluated as code. Interpolate in the script itself instead: Ruby `wait_check("INST HEALTH_STATUS TYPE == '#{expected}'", 10)` or Python `wait_check(f"INST HEALTH_STATUS TYPE == '{expected}'", 10)`.
 :::
 
 <Tabs groupId="script-language">

--- a/openc3/lib/openc3/script/api_shared.rb
+++ b/openc3/lib/openc3/script/api_shared.rb
@@ -530,7 +530,7 @@ module OpenC3
 
       value = yield(target_name, packet_name, item_name)
       if comparison_to_eval
-        _check_eval(target_name, packet_name, item_name, comparison_to_eval, value)
+        _check_comparison(target_name, packet_name, item_name, comparison_to_eval, value)
       else
         puts "CHECK: #{_upcase(target_name, packet_name, item_name)} == #{value.nil? ? 'nil' : value.inspect}"
       end
@@ -733,28 +733,17 @@ module OpenC3
       return [target_name, packet_name, item_name, comparison_to_eval, timeout, polling_rate]
     end
 
-    def _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, exp_to_eval, scope: $openc3_scope, token: $openc3_token, &block)
+    # Waits for the comparison to be true or the timeout to expire.
+    # The comparison is a callable which takes the telemetry value and returns true or false.
+    # A block passed by the user takes precedence over the comparison.
+    def _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, comparison, scope: $openc3_scope, token: $openc3_token, &block)
+      comparison = block if block
       end_time = Time.now.sys + timeout
-      if exp_to_eval and !exp_to_eval.is_printable?
-        raise "ERROR: Invalid comparison to non-ascii value"
-      end
+      value = nil
       while true
         work_start = Time.now.sys
         value = tlm(target_name, packet_name, item_name, type: value_type, scope: scope, token: token)
-        if not block.nil?
-          if block.call(value)
-            return true, value
-          end
-        else
-          begin
-            if eval(exp_to_eval)
-              return true, value
-            end
-          # NoMethodError is raised when the tlm() returns nil and we try to eval the expression
-          # In this case we just continue and see if eventually we get a good value from tlm()
-          rescue NoMethodError
-          end
-        end
+        return true, value if comparison and comparison.call(value)
         break if Time.now.sys >= end_time
 
         delta = Time.now.sys - work_start
@@ -766,58 +755,62 @@ module OpenC3
 
         if canceled
           value = tlm(target_name, packet_name, item_name, type: value_type, scope: scope, token: token)
-          if not block.nil?
-            if block.call(value)
-              return true, value
-            else
-              return false, value
-            end
+          if comparison and comparison.call(value)
+            return true, value
           else
-            begin
-              if eval(exp_to_eval)
-                return true, value
-              else
-                return false, value
-              end
-            # NoMethodError is raised when the tlm() returns nil and we try to eval the expression
-            rescue NoMethodError
-              return false, value
-            end
+            return false, value
           end
         end
       end
 
       return false, value
-    rescue NameError => e
-      if e.message =~ /uninitialized constant OpenC3::ApiShared::(\w+)/
-        new_error = NameError.new("Uninitialized constant #{$1}. Did you mean '#{$1}' as a string?")
-        new_error.set_backtrace(e.backtrace)
-        raise new_error
-      else
-        raise e
-      end
+    end
+
+    # Builds a callable which compares a telemetry value against the given comparison string,
+    # e.g. "> 1". Returns nil if there is no comparison, e.g. a block based wait_check().
+    # Raises if the comparison is invalid, e.g. an unsupported operator or unparsable operand.
+    def _comparison_implementation(comparison_to_eval)
+      return nil unless comparison_to_eval
+
+      operator, operand = extract_operator_and_operand_from_comparison(comparison_to_eval)
+      return nil unless operator
+      lambda { |value| compare_values(value, operator, operand) }
     end
 
     # Wait for a converted telemetry item to pass a comparison
     def _openc3_script_wait_implementation_comparison(target_name, packet_name, item_name, value_type, comparison_to_eval, timeout, polling_rate = DEFAULT_TLM_POLLING_RATE, scope: $openc3_scope, token: $openc3_token, &block)
-      if comparison_to_eval
-        exp_to_eval = "value " + comparison_to_eval
-      else
-        exp_to_eval = nil
+      # The comparison text is logged whether or not it is parsed so it is always validated
+      if comparison_to_eval and !comparison_to_eval.is_printable?
+        raise "ERROR: Invalid comparison to non-ascii value"
       end
-      _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, exp_to_eval, scope: scope, token: token, &block)
+      # A user supplied block is the condition so the comparison text is never parsed
+      comparison = block ? nil : _comparison_implementation(comparison_to_eval)
+      _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, comparison, scope: scope, token: token, &block)
     end
 
     def _openc3_script_wait_implementation_tolerance(target_name, packet_name, item_name, value_type, expected_value, tolerance, timeout, polling_rate = DEFAULT_TLM_POLLING_RATE, scope: $openc3_scope, token: $openc3_token, &block)
-      exp_to_eval = "((#{expected_value} - #{tolerance})..(#{expected_value} + #{tolerance})).include? value"
-      _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, exp_to_eval, scope: scope, token: token, &block)
+      comparison = lambda do |value|
+        begin
+          value >= (expected_value - tolerance) and value <= (expected_value + tolerance)
+        rescue ArgumentError, NoMethodError, TypeError
+          false
+        end
+      end
+      _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, comparison, scope: scope, token: token, &block)
     end
 
     def _openc3_script_wait_implementation_array_tolerance(array_size, target_name, packet_name, item_name, value_type, expected_value, tolerance, timeout, polling_rate = DEFAULT_TLM_POLLING_RATE, scope: $openc3_scope, token: $openc3_token, &block)
-      statements = []
-      array_size.times { |i| statements << "(((#{expected_value[i]} - #{tolerance[i]})..(#{expected_value[i]} + #{tolerance[i]})).include? value[#{i}])" }
-      exp_to_eval = statements.join(" && ")
-      _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, exp_to_eval, scope: scope, token: token, &block)
+      comparison = lambda do |values|
+        begin
+          next false unless values.is_a?(Array) and values.length == array_size
+          array_size.times.all? do |i|
+            values[i] >= (expected_value[i] - tolerance[i]) and values[i] <= (expected_value[i] + tolerance[i])
+          end
+        rescue ArgumentError, NoMethodError, TypeError
+          false
+        end
+      end
+      _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, comparison, scope: scope, token: token, &block)
     end
 
     # Wait on an expression to be true.
@@ -859,17 +852,15 @@ module OpenC3
       end
     end
 
-    def _check_eval(target_name, packet_name, item_name, comparison_to_eval, value)
-      string = "value " + comparison_to_eval
+    def _check_comparison(target_name, packet_name, item_name, comparison_to_eval, value)
       check_str = "CHECK: #{_upcase(target_name, packet_name, item_name)} #{comparison_to_eval}"
       # Show user the check against a quoted string
-      # Note: We have to preserve the original 'value' variable because we're going to eval against it
       value_str = value.is_a?(String) ? "'#{value}'" : value
       value_str = 'nil' if value.nil? # Show user nil value as 'nil'
       with_value = "with value == #{value_str}"
 
-      eval_is_valid = _check_eval_validity(value, comparison_to_eval)
-      unless eval_is_valid
+      operator, operand = extract_operator_and_operand_from_comparison(comparison_to_eval)
+      unless _valid_comparison?(value, operator, operand)
         message = "Invalid comparison for types"
         if $disconnect
           puts "ERROR: #{message}"
@@ -878,7 +869,7 @@ module OpenC3
         end
       end
 
-      if eval_is_valid && eval(string)
+      if compare_values(value, operator, operand)
         puts "#{check_str} success #{with_value}"
       else
         message = "#{check_str} failed #{with_value}"
@@ -888,35 +879,19 @@ module OpenC3
           raise CheckError, message
         end
       end
-    rescue NameError => e
-      if e.message =~ /uninitialized constant OpenC3::ApiShared::(\w+)/
-        new_error = NameError.new("Uninitialized constant #{$1}. Did you mean '#{$1}' as a string?")
-        new_error.set_backtrace(e.backtrace)
-        raise new_error
-      else
-        raise e
-      end
     end
 
-    def _check_eval_validity(value, comparison)
-      return true if comparison.nil? || comparison.empty?
-
-      begin
-        operator, operand = extract_operator_and_operand_from_comparison(comparison)
-      rescue RuntimeError => e
-        if e.message.include?("Unable to parse operand")
-          # If we can't parse the operand, let the eval happen anyway
-          # It will raise an appropriate error (like NameError for undefined constants)
-          return true
-        end
-        raise # Re-raise invalid operator errors
-      rescue JSON::ParserError
-        return true
-      end
+    # Returns whether the value and operand can be meaningfully compared with the operator.
+    # Note this is only used by check() because wait() polls until the value changes.
+    def _valid_comparison?(value, operator, operand)
+      return true if operator.nil?
 
       if [">=", "<=", ">", "<"].include?(operator)
-        return false if value.nil? || operand.nil? || value.is_a?(Array) || operand.is_a?(Array)
+        return false if value.nil? or operand.nil?
+        return false if value.is_a?(Array) or operand.is_a?(Array)
+        return false if value.is_a?(String) != operand.is_a?(String)
       end
+      # Note 'in' does not need a check here because the parser already requires a list operand
 
       return true
     end

--- a/openc3/lib/openc3/script/api_shared.rb
+++ b/openc3/lib/openc3/script/api_shared.rb
@@ -737,13 +737,12 @@ module OpenC3
     # The comparison is a callable which takes the telemetry value and returns true or false.
     # A block passed by the user takes precedence over the comparison.
     def _openc3_script_wait_implementation(target_name, packet_name, item_name, value_type, timeout, polling_rate, comparison, scope: $openc3_scope, token: $openc3_token, &block)
-      comparison = block if block
+      condition = block || comparison
       end_time = Time.now.sys + timeout
-      value = nil
       while true
         work_start = Time.now.sys
         value = tlm(target_name, packet_name, item_name, type: value_type, scope: scope, token: token)
-        return true, value if comparison and comparison.call(value)
+        return true, value if condition and condition.call(value)
         break if Time.now.sys >= end_time
 
         delta = Time.now.sys - work_start
@@ -755,7 +754,7 @@ module OpenC3
 
         if canceled
           value = tlm(target_name, packet_name, item_name, type: value_type, scope: scope, token: token)
-          if comparison and comparison.call(value)
+          if condition and condition.call(value)
             return true, value
           else
             return false, value

--- a/openc3/lib/openc3/script/extract.rb
+++ b/openc3/lib/openc3/script/extract.rb
@@ -26,6 +26,30 @@ module OpenC3
     # whitespace around them is optional.
     SCANNING_REGULAR_EXPRESSION = %r{ (?:"(?:[^\\"]|\\.)*") | (?:'(?:[^\\']|\\.)*') | (?:\[(?:[^\\\[\]]|\\.|\[(?:[^\\\[\]]|\\.)*\])*\]) | , | [^\s,]+ }x # "
 
+    # Operators supported by check(), wait() and wait_check() comparisons
+    COMPARISON_OPERATORS = ["==", "!=", ">=", "<=", ">", "<", "in"]
+
+    # Single character escape sequences processed inside a double quoted comparison operand.
+    # The numeric (\nnn, \xHH, \uHHHH, \u{...}) forms are handled by unescape_double_quoted().
+    DOUBLE_QUOTE_ESCAPES = {
+      '\\' => "\\", '"' => '"', "'" => "'", '#' => '#', 'n' => "\n", 't' => "\t",
+      'r' => "\r", 'a' => "\a", 'b' => "\b", 'e' => "\e", 'f' => "\f", 'v' => "\v", 's' => ' '
+    }
+
+    # Tokenizes a double quoted operand into escape sequences, interpolation markers and runs
+    # of plain characters. The alternatives are ordered longest first so \u{1F600} is not read
+    # as \u, and the escape alternatives precede the markers so \#{ is a literal '#{'.
+    DOUBLE_QUOTE_TOKEN_REGEX =
+      /\\u\{[\h\s]*\}|\\u\h{4}|\\x\h{1,2}|\\[0-7]{1,3}|\\M-\\C-.|\\M-.|\\C-.|\\c.|\\.|\#[{@$]|[^\\\#]+|\#/m
+
+    # Escape sequences which have a meaning we deliberately do not implement. Dropping the
+    # backslash would silently change the value so they are rejected instead.
+    UNSUPPORTED_ESCAPE_REGEX = /\A\\(?:c|C-|M-)/
+
+    # The Ruby string interpolation markers. Interpolation would be code execution so it is
+    # rejected rather than silently compared against the uninterpolated text.
+    INTERPOLATION_REGEX = /\A\#[{@$]/
+
     private
 
     # Pulls all string keyword arguments into the args array. Raises on any symbol keyword arguments.
@@ -165,8 +189,6 @@ module OpenC3
 
     # Splits `check()` comparison expressions, e.g. "== 'foo bar'" becomes ["==", "foo bar"]
     def extract_operator_and_operand_from_comparison(comparison)
-      valid_operators = ["==", "!=", ">=", "<=", ">", "<", "in"]
-
       operator, operand = comparison.split(nil, 2) # Ruby: second split arg is max number of resultant elements
 
       if operand.nil?
@@ -175,29 +197,180 @@ module OpenC3
         return [nil, nil]
       end
 
-      raise "ERROR: Invalid operator: '#{operator}'" unless valid_operators.include?(operator)
+      raise "ERROR: Invalid operator: '#{operator}'" unless COMPARISON_OPERATORS.include?(operator)
 
-      # Handle string operand: remove surrounding double/single quotes
-      if operand.match?(/^(['"])(.*)\1$/m) # Starts with single or double quote, and ends with matching quote
-        operand = operand[1..-2]
-        return [operator, operand]
+      operand = extract_operand(operand)
+      # 'in' is containment against a list of values in both Ruby and Python.
+      # Enforced here so check(), wait() and wait_check() all reject the same thing.
+      if operator == "in" and !operand.is_a?(Array)
+        raise "ERROR: The 'in' operator requires a list operand: #{operand.inspect}"
       end
 
-      # Handle other operand types
-      if operand == "nil"
-        operand = nil
-      elsif operand == "false"
-        operand = false
-      elsif operand == "true"
-        operand = true
-      else
-        begin
-          operand = JSON.parse(operand)
-        rescue JSON::ParserError
-          raise "ERROR: Unable to parse operand: #{operand}"
-        end
-      end
       return [operator, operand]
+    end
+
+    # Converts the operand of a `check()` comparison expression into a Ruby value.
+    # Note this deliberately does not eval the operand so only literal values are supported.
+    def extract_operand(operand)
+      # A quoted operand must be a single complete string literal. Anything trailing the
+      # closing quote, e.g. "== 'a' garbage 'b'", is a syntax error rather than a string.
+      if (match = operand.match(/\A'((?:[^'\\]|\\.)*)'\z/m))
+        # Ruby single quoted strings only escape the backslash and the single quote
+        return match[1].gsub(/\\([\\'])/) { $1 }
+      end
+      if (match = operand.match(/\A"((?:[^"\\]|\\.)*)"\z/m))
+        return unescape_double_quoted(match[1])
+      end
+      return nil if operand == "nil"
+      return false if operand == "false"
+      return true if operand == "true"
+
+      # Ruby's Float() rejects these but Python's float() accepts them
+      case operand.upcase
+      when 'INFINITY', '+INFINITY', 'INF', '+INF'
+        return Float::INFINITY
+      when '-INFINITY', '-INF'
+        return -Float::INFINITY
+      when 'NAN', '+NAN', '-NAN'
+        return Float::NAN
+      end
+
+      # Arrays are parsed recursively so their elements follow exactly the same rules as a
+      # bare operand. JSON alone would reject ['ON', 'OFF'], [0xA, 0xB] and [true, nil].
+      if operand.start_with?('[') and operand.end_with?(']')
+        return split_operand_list(operand[1..-2]).map { |element| extract_operand(element) }
+      end
+      # JSON handles decimal numbers and hashes
+      begin
+        return JSON.parse(operand)
+      rescue JSON::ParserError
+        # Fall through to the number formats JSON does not accept
+      end
+      # Number formats JSON does not accept
+      begin
+        # Explicit base prefix: hex (0x), octal (0o) or binary (0b)
+        return Integer(operand) if operand.match?(/\A[+-]?0[xXoObB][0-9a-fA-F_]+\z/)
+        # Integers with underscore separators, e.g. 1_000. A leading zero is deliberately
+        # rejected because it is ambiguous: Ruby reads 010 as octal 8 while Python rejects it.
+        # Write 0o10 for octal 8 or 10 for decimal 10.
+        return Integer(operand, 10) if operand.match?(/\A[+-]?[1-9][0-9_]*\z/)
+        # Floats with underscore separators, e.g. 1_000.5. A leading zero is unambiguous here.
+        return Float(operand) if operand.match?(/\A[+-]?[0-9][0-9_]*(?:\.[0-9_]+(?:[eE][+-]?[0-9_]+)?|[eE][+-]?[0-9_]+)\z/)
+      rescue ArgumentError
+        # Fall through to the error cases
+      end
+
+      # A bare word is almost always a string the user forgot to quote
+      if operand.match?(/\A[A-Za-z_][A-Za-z0-9_]*\z/)
+        raise NameError, "Uninitialized constant #{operand}. Did you mean '#{operand}' as a string?"
+      end
+      raise "ERROR: Unable to parse operand: #{operand}"
+    end
+
+    # Processes the escape sequences in the contents of a double quoted operand
+    def unescape_double_quoted(string)
+      # A \xHH or octal escape can produce a byte which is not valid UTF-8 so build the result
+      # in binary. Otherwise preserve the encoding of the comparison the user passed in.
+      binary = string.match?(/\\(?:x\h|[0-7])/)
+      result = binary ? ''.b : String.new(encoding: string.encoding)
+      string.scan(DOUBLE_QUOTE_TOKEN_REGEX).each do |token|
+        replacement =
+          if token.match?(INTERPOLATION_REGEX)
+            raise "ERROR: String interpolation is not supported in an operand: #{token}. " +
+                  'Interpolate in the script itself or escape it as \#' + token[1] +
+                  ' to compare against the literal text'
+          elsif !token.start_with?('\\')
+            token
+          elsif token.start_with?('\u{')
+            # \u{1F600} or \u{48 49} which is one or more whitespace separated codepoints
+            token[3..-2].split.map { |codepoint| [codepoint.hex].pack('U') }.join
+          elsif token.length == 6 and token.start_with?('\u')
+            [token[2..-1].hex].pack('U')
+          elsif token.length > 2 and token.start_with?('\x')
+            [token[2..-1].hex].pack('C')
+          elsif token.match?(/\A\\[0-7]/)
+            [token[1..-1].to_i(8) & 0xFF].pack('C')
+          elsif token.match?(UNSUPPORTED_ESCAPE_REGEX)
+            raise "ERROR: Unsupported escape sequence in operand: #{token}"
+          elsif token == '\u' or token == '\x'
+            raise "ERROR: Invalid escape sequence in operand: #{token}"
+          else
+            # Ruby drops the backslash of an escape which has no special meaning, e.g. "\q"
+            DOUBLE_QUOTE_ESCAPES.fetch(token[1], token[1])
+          end
+        result << (binary ? replacement.b : replacement)
+      end
+      return result
+    end
+
+    # Splits the contents of a bracketed operand list on the top level commas.
+    # Quotes and nesting are tracked so "['a,b', [1, 2]]" is two elements, not four.
+    def split_operand_list(text)
+      elements = []
+      current = String.new(encoding: text.encoding)
+      depth = 0
+      quote = nil
+      escaped = false
+      text.each_char do |char|
+        if escaped
+          escaped = false
+        elsif quote
+          if char == '\\'
+            escaped = true
+          elsif char == quote
+            quote = nil
+          end
+        elsif char == "'" or char == '"'
+          quote = char
+        elsif char == '[' or char == '{'
+          depth += 1
+        elsif char == ']' or char == '}'
+          depth -= 1
+          raise "ERROR: Unable to parse operand: [#{text}]" if depth < 0
+        elsif char == ',' and depth == 0
+          elements << current.strip
+          current = String.new(encoding: text.encoding)
+          next
+        end
+        current << char
+      end
+      raise "ERROR: Unable to parse operand: [#{text}]" if depth != 0 or quote
+
+      elements << current.strip
+      # A single empty element is an empty list, e.g. []
+      return [] if elements.length == 1 and elements[0].empty?
+      # A trailing comma is allowed, e.g. [1,], matching both Ruby and Python list literals
+      elements.pop if elements[-1].empty?
+      raise "ERROR: Unable to parse operand: [#{text}]" if elements.empty? or elements.any?(&:empty?)
+
+      return elements
+    end
+
+    # Compares a telemetry value against an operand using the given operator.
+    # Returns false rather than raising if the two values can not be compared.
+    def compare_values(value, operator, operand)
+      case operator
+      when "=="
+        value == operand
+      when "!="
+        value != operand
+      when ">"
+        value > operand
+      when ">="
+        value >= operand
+      when "<"
+        value < operand
+      when "<="
+        value <= operand
+      when "in"
+        # 'in' is containment against a list of values, matching Python
+        operand.is_a?(Array) && operand.include?(value)
+      else
+        raise "ERROR: Invalid operator: '#{operator}'"
+      end
+    rescue ArgumentError, NoMethodError, TypeError
+      # Comparing incompatible types, e.g. nil > 1, is simply not a match
+      false
     end
   end
 end

--- a/openc3/lib/openc3/script/extract.rb
+++ b/openc3/lib/openc3/script/extract.rb
@@ -50,6 +50,13 @@ module OpenC3
     # rejected rather than silently compared against the uninterpolated text.
     INTERPOLATION_REGEX = /\A\#[{@$]/
 
+    # Limits Ruby enforces on a \u escape. A codepoint is written with at most six hex digits,
+    # the largest character Unicode defines is 0x10FFFF, and the surrogate range is reserved
+    # for UTF-16 pairs so it is not a character on its own.
+    MAX_UNICODE_DIGITS = 6
+    MAX_UNICODE_CODEPOINT = 0x10FFFF
+    UNICODE_SURROGATE_RANGE = (0xD800..0xDFFF)
+
     private
 
     # Pulls all string keyword arguments into the args array. Raises on any symbol keyword arguments.
@@ -233,6 +240,8 @@ module OpenC3
         return -Float::INFINITY
       when 'NAN', '+NAN', '-NAN'
         return Float::NAN
+      else
+        # Not an infinity or NaN keyword so fall through to the formats below
       end
 
       # Arrays are parsed recursively so their elements follow exactly the same rules as a
@@ -283,9 +292,9 @@ module OpenC3
             token
           elsif token.start_with?('\u{')
             # \u{1F600} or \u{48 49} which is one or more whitespace separated codepoints
-            token[3..-2].split.map { |codepoint| [codepoint.hex].pack('U') }.join
+            token[3..-2].split.map { |codepoint| pack_unicode_codepoint(codepoint, token) }.join
           elsif token.length == 6 and token.start_with?('\u')
-            [token[2..-1].hex].pack('U')
+            pack_unicode_codepoint(token[2..-1], token)
           elsif token.length > 2 and token.start_with?('\x')
             [token[2..-1].hex].pack('C')
           elsif token.match?(/\A\\[0-7]/)
@@ -301,6 +310,18 @@ module OpenC3
         result << (binary ? replacement.b : replacement)
       end
       return result
+    end
+
+    # Packs a single codepoint of a \u escape into a UTF-8 character. Ruby rejects a codepoint
+    # which is too long, above the largest Unicode character or in the UTF-16 surrogate range,
+    # so those raise here rather than silently packing into an invalid UTF-8 string.
+    def pack_unicode_codepoint(codepoint, token)
+      value = codepoint.hex
+      if codepoint.length > MAX_UNICODE_DIGITS or value > MAX_UNICODE_CODEPOINT or
+         UNICODE_SURROGATE_RANGE.include?(value)
+        raise "ERROR: Invalid Unicode codepoint in operand: #{token}"
+      end
+      return [value].pack('U')
     end
 
     # Splits the contents of a bracketed operand list on the top level commas.

--- a/openc3/python/openc3/api/api_shared.py
+++ b/openc3/python/openc3/api/api_shared.py
@@ -844,19 +844,19 @@ def _comparison_implementation(comparison_to_eval):
 def _tolerance_implementation(expected_value, tolerance):
     """Builds a callable which checks a telemetry value is within the given tolerance"""
 
-    def comparison(value):
+    def _comparison(value):
         try:
             return (expected_value - abs(tolerance)) <= value <= (expected_value + abs(tolerance))
         except TypeError:
             return False
 
-    return comparison
+    return _comparison
 
 
 def _array_tolerance_implementation(array_size, expected_value, tolerance):
     """Builds a callable which checks every telemetry value is within the given tolerance"""
 
-    def comparison(values):
+    def _comparison(values):
         try:
             if not isinstance(values, list) or len(values) != array_size:
                 return False
@@ -867,7 +867,7 @@ def _array_tolerance_implementation(array_size, expected_value, tolerance):
         except TypeError:
             return False
 
-    return comparison
+    return _comparison
 
 
 # Wait for a converted telemetry item to pass a comparison

--- a/openc3/python/openc3/api/api_shared.py
+++ b/openc3/python/openc3/api/api_shared.py
@@ -9,7 +9,6 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
-import json
 import sys
 import time
 import traceback
@@ -18,6 +17,7 @@ from openc3.api.tlm_api import tlm
 from openc3.environment import OPENC3_SCOPE
 from openc3.script.exceptions import CheckError
 from openc3.utilities.extract import (
+    compare_values,
     extract_fields_from_check_text,
     extract_fields_from_tlm_text,
     extract_operator_and_operand_from_comparison,
@@ -546,7 +546,7 @@ def _check(*args, type="CONVERTED", scope=OPENC3_SCOPE):
     target_name, packet_name, item_name, comparison_to_eval = _check_process_args(args, "check")
     value = tlm(target_name, packet_name, item_name, type=type, scope=scope)
     if comparison_to_eval:
-        return _check_eval(target_name, packet_name, item_name, comparison_to_eval, value)
+        return _check_comparison(target_name, packet_name, item_name, comparison_to_eval, value)
     else:
         print(f"CHECK: {_upcase(target_name, packet_name, item_name)} == {value}")
 
@@ -790,54 +790,84 @@ def _openc3_script_wait(
     value_type,
     timeout,
     polling_rate,
-    exp_to_eval,
+    comparison,
     scope,
 ):
+    """Waits for the comparison to be true or the timeout to expire.
+    The comparison is a callable which takes the telemetry value and returns True or False.
+    """
     value = None
     end_time = time.time() + timeout
-    if exp_to_eval and not exp_to_eval.isascii():
-        raise RuntimeError("ERROR: Invalid comparison to non-ascii value")
+    while True:
+        work_start = time.time()
+        value = tlm(target_name, packet_name, item_name, type=value_type, scope=scope)
+        if comparison and comparison(value):
+            return True, value
+        if time.time() >= end_time:
+            break
 
-    try:
-        while True:
-            work_start = time.time()
+        delta = time.time() - work_start
+        sleep_time = polling_rate - delta
+        end_delta = end_time - time.time()
+        if end_delta < sleep_time:
+            sleep_time = end_delta
+        if sleep_time < 0:
+            sleep_time = 0
+        canceled = openc3_script_sleep(sleep_time)
+
+        if canceled:
             value = tlm(target_name, packet_name, item_name, type=value_type, scope=scope)
-            try:
-                if eval(exp_to_eval):
-                    return True, value
-            # We get TypeError when trying to eval None >= 0 (for example)
-            # In this case we just continue and see if eventually we get a good value from tlm()
-            except TypeError:
-                pass
-            if time.time() >= end_time:
-                break
-
-            delta = time.time() - work_start
-            sleep_time = polling_rate - delta
-            end_delta = end_time - time.time()
-            if end_delta < sleep_time:
-                sleep_time = end_delta
-            if sleep_time < 0:
-                sleep_time = 0
-            canceled = openc3_script_sleep(sleep_time)
-
-            if canceled:
-                value = tlm(target_name, packet_name, item_name, type=value_type, scope=scope)
-                try:
-                    if eval(exp_to_eval):
-                        return True, value
-                    else:
-                        return False, value
-                # We get TypeError when trying to eval None >= 0 (for example)
-                except TypeError:
-                    return False, value
-
-    except NameError as error:
-        parts = error.args[0].split("'")
-        new_error = NameError(f"Uninitialized constant {parts[1]}. Did you mean '{parts[1]}' as a string?")
-        raise new_error from error
+            if comparison and comparison(value):
+                return True, value
+            else:
+                return False, value
 
     return False, value
+
+
+def _comparison_implementation(comparison_to_eval):
+    """Builds a callable which compares a telemetry value against the given comparison string,
+    e.g. "> 1". Returns None if there is no comparison, e.g. a check with no comparison.
+    Raises if the comparison is invalid, e.g. an unsupported operator or unparsable operand.
+    """
+    if not comparison_to_eval:
+        return None
+    if not comparison_to_eval.isascii():
+        raise RuntimeError("ERROR: Invalid comparison to non-ascii value")
+
+    operator, operand = extract_operator_and_operand_from_comparison(comparison_to_eval)
+    if operator is None:
+        return None
+    return lambda value: compare_values(value, operator, operand)
+
+
+def _tolerance_implementation(expected_value, tolerance):
+    """Builds a callable which checks a telemetry value is within the given tolerance"""
+
+    def comparison(value):
+        try:
+            return (expected_value - abs(tolerance)) <= value <= (expected_value + abs(tolerance))
+        except TypeError:
+            return False
+
+    return comparison
+
+
+def _array_tolerance_implementation(array_size, expected_value, tolerance):
+    """Builds a callable which checks every telemetry value is within the given tolerance"""
+
+    def comparison(values):
+        try:
+            if not isinstance(values, list) or len(values) != array_size:
+                return False
+            return all(
+                (expected_value[i] - abs(tolerance[i])) <= values[i] <= (expected_value[i] + abs(tolerance[i]))
+                for i in range(array_size)
+            )
+        except TypeError:
+            return False
+
+    return comparison
 
 
 # Wait for a converted telemetry item to pass a comparison
@@ -851,10 +881,6 @@ def _openc3_script_wait_value(
     polling_rate=DEFAULT_TLM_POLLING_RATE,
     scope=OPENC3_SCOPE,
 ):
-    if comparison_to_eval:
-        exp_to_eval = "value " + comparison_to_eval
-    else:
-        exp_to_eval = None
     return _openc3_script_wait(
         target_name,
         packet_name,
@@ -862,7 +888,7 @@ def _openc3_script_wait_value(
         value_type,
         timeout,
         polling_rate,
-        exp_to_eval,
+        _comparison_implementation(comparison_to_eval),
         scope,
     )
 
@@ -878,7 +904,6 @@ def _openc3_script_wait_tolerance(
     polling_rate=DEFAULT_TLM_POLLING_RATE,
     scope=OPENC3_SCOPE,
 ):
-    exp_to_eval = f"(value >= ({expected_value} - {abs(tolerance)}) and value <= ({expected_value} + {abs(tolerance)}))"
     return _openc3_script_wait(
         target_name,
         packet_name,
@@ -886,7 +911,7 @@ def _openc3_script_wait_tolerance(
         value_type,
         timeout,
         polling_rate,
-        exp_to_eval,
+        _tolerance_implementation(expected_value, tolerance),
         scope,
     )
 
@@ -903,12 +928,6 @@ def _openc3_script_wait_array_tolerance(
     polling_rate=DEFAULT_TLM_POLLING_RATE,
     scope=OPENC3_SCOPE,
 ):
-    statements = []
-    for i in range(array_size):
-        statements.append(
-            f"(value[{i}] >= ({expected_value[i]} - {abs(tolerance[i])}) and value[{i}] <= ({expected_value[i]} + {abs(tolerance[i])}))"
-        )
-    exp_to_eval = " and ".join(statements)
     return _openc3_script_wait(
         target_name,
         packet_name,
@@ -916,7 +935,7 @@ def _openc3_script_wait_array_tolerance(
         value_type,
         timeout,
         polling_rate,
-        exp_to_eval,
+        _array_tolerance_implementation(array_size, expected_value, tolerance),
         scope,
     )
 
@@ -957,31 +976,25 @@ def _openc3_script_wait_expression(exp_to_eval, timeout, polling_rate, globals=N
     return None
 
 
-def _check_eval(target_name, packet_name, item_name, comparison_to_eval, value):
-    string = "value " + comparison_to_eval
+def _check_comparison(target_name, packet_name, item_name, comparison_to_eval, value):
     check_str = f"CHECK: {_upcase(target_name, packet_name, item_name)} {comparison_to_eval}"
     # Show user the check against a quoted string
-    # Note: We have to preserve the original 'value' variable because we're going to eval against it
     if isinstance(value, str):
         value_str = f"'{value}'"
     else:
         value_str = value
     with_value = f"with value == {value_str}"
 
-    try:
-        eval_is_valid = _check_eval_validity(value, comparison_to_eval)
-        if eval_is_valid and eval(string):
-            print(f"{check_str} success {with_value}")
-        else:
-            message = f"{check_str} failed {with_value}"
-            raise CheckError(message)
-    except (NameError, json.JSONDecodeError) as error:
-        if isinstance(error, NameError):
-            parts = error.args[0].split("'")
-            new_error = NameError(f"Uninitialized constant {parts[1]}. Did you mean '{parts[1]}' as a string?")
-            raise new_error from error
-        else:
-            raise
+    operator, operand = extract_operator_and_operand_from_comparison(comparison_to_eval)
+    if not _valid_comparison(value, operator, operand):
+        message = "Invalid comparison for types"
+        raise CheckError(message)
+
+    if compare_values(value, operator, operand):
+        print(f"{check_str} success {with_value}")
+    else:
+        message = f"{check_str} failed {with_value}"
+        raise CheckError(message)
 
 
 def _frange(value):
@@ -993,30 +1006,22 @@ def _frange(value):
         return value
 
 
-def _check_eval_validity(value, comparison):
-    if not comparison:
+def _valid_comparison(value, operator, operand):
+    """Returns whether the value and operand can be meaningfully compared with the operator.
+    Note this is only used by check() because wait() polls until the value changes.
+    """
+    if operator is None:
         return True
 
-    try:
-        operator, operand = extract_operator_and_operand_from_comparison(comparison)
-    except RuntimeError as e:
-        if "Unable to parse operand" in str(e):
-            # If we can't parse the operand, let the eval happen anyway
-            # It will raise an appropriate error (like NameError for undefined constants)
-            return True
-        raise  # Re-raise invalid operator errors
-    except json.JSONDecodeError:
-        return True
-
-    if operator in [">=", "<=", ">", "<"] and (
-        value is None or operand is None or isinstance(value, list) or isinstance(operand, list)
-    ):
-        return False
-
-    # Ruby doesn't have the "in" operator
-    return not (
-        operator == "in" and (isinstance(operand, str) and not isinstance(value, str) or not isinstance(operand, list))
-    )
+    if operator in [">=", "<=", ">", "<"]:
+        if value is None or operand is None:
+            return False
+        if isinstance(value, list) or isinstance(operand, list):
+            return False
+        if isinstance(value, str) != isinstance(operand, str):
+            return False
+    # Note 'in' does not need a check here because the parser already requires a list operand
+    return True
 
 
 # Interesting formatter to a specific number of significant digits:

--- a/openc3/python/openc3/script/api_shared.py
+++ b/openc3/python/openc3/script/api_shared.py
@@ -9,7 +9,6 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
-import json
 import sys
 import time
 import traceback
@@ -18,6 +17,7 @@ from contextlib import contextmanager
 import openc3.script
 from openc3.environment import OPENC3_SCOPE
 from openc3.utilities.extract import (
+    compare_values,
     extract_fields_from_check_text,
     extract_fields_from_tlm_text,
     extract_operator_and_operand_from_comparison,
@@ -624,7 +624,7 @@ def _check(*args, type="CONVERTED", scope=OPENC3_SCOPE):
     target_name, packet_name, item_name, comparison_to_eval = _check_process_args(args, "check")
     value = openc3.script.API_SERVER.tlm(target_name, packet_name, item_name, type=type, scope=scope)
     if comparison_to_eval:
-        return _check_eval(target_name, packet_name, item_name, comparison_to_eval, value)
+        return _check_comparison(target_name, packet_name, item_name, comparison_to_eval, value)
     else:
         print(f"CHECK: {_upcase(target_name, packet_name, item_name)} == {value}")
 
@@ -871,54 +871,84 @@ def _openc3_script_wait(
     value_type,
     timeout,
     polling_rate,
-    exp_to_eval,
+    comparison,
     scope,
 ):
+    """Waits for the comparison to be true or the timeout to expire.
+    The comparison is a callable which takes the telemetry value and returns True or False.
+    """
     value = None
     end_time = time.time() + timeout
-    if exp_to_eval and not exp_to_eval.isascii():
-        raise RuntimeError("ERROR: Invalid comparison to non-ascii value")
+    while True:
+        work_start = time.time()
+        value = openc3.script.API_SERVER.tlm(target_name, packet_name, item_name, type=value_type, scope=scope)
+        if comparison and comparison(value):
+            return True, value
+        if time.time() >= end_time:
+            break
 
-    try:
-        while True:
-            work_start = time.time()
+        delta = time.time() - work_start
+        sleep_time = polling_rate - delta
+        end_delta = end_time - time.time()
+        if end_delta < sleep_time:
+            sleep_time = end_delta
+        if sleep_time < 0:
+            sleep_time = 0
+        canceled = openc3_script_sleep(sleep_time)
+
+        if canceled:
             value = openc3.script.API_SERVER.tlm(target_name, packet_name, item_name, type=value_type, scope=scope)
-            try:
-                if eval(exp_to_eval):
-                    return True, value
-            # We get TypeError when trying to eval None >= 0 (for example)
-            # In this case we just continue and see if eventually we get a good value from tlm()
-            except TypeError:
-                pass
-            if time.time() >= end_time:
-                break
-
-            delta = time.time() - work_start
-            sleep_time = polling_rate - delta
-            end_delta = end_time - time.time()
-            if end_delta < sleep_time:
-                sleep_time = end_delta
-            if sleep_time < 0:
-                sleep_time = 0
-            canceled = openc3_script_sleep(sleep_time)
-
-            if canceled:
-                value = openc3.script.API_SERVER.tlm(target_name, packet_name, item_name, type=value_type, scope=scope)
-                try:
-                    if eval(exp_to_eval):
-                        return True, value
-                    else:
-                        return False, value
-                # We get TypeError when trying to eval None >= 0 (for example)
-                except TypeError:
-                    return False, value
-
-    except NameError as error:
-        parts = error.args[0].split("'")
-        new_error = NameError(f"Uninitialized constant {parts[1]}. Did you mean '{parts[1]}' as a string?")
-        raise new_error from error
+            if comparison and comparison(value):
+                return True, value
+            else:
+                return False, value
 
     return False, value
+
+
+def _comparison_implementation(comparison_to_eval):
+    """Builds a callable which compares a telemetry value against the given comparison string,
+    e.g. "> 1". Returns None if there is no comparison, e.g. a check with no comparison.
+    Raises if the comparison is invalid, e.g. an unsupported operator or unparsable operand.
+    """
+    if not comparison_to_eval:
+        return None
+    if not comparison_to_eval.isascii():
+        raise RuntimeError("ERROR: Invalid comparison to non-ascii value")
+
+    operator, operand = extract_operator_and_operand_from_comparison(comparison_to_eval)
+    if operator is None:
+        return None
+    return lambda value: compare_values(value, operator, operand)
+
+
+def _tolerance_implementation(expected_value, tolerance):
+    """Builds a callable which checks a telemetry value is within the given tolerance"""
+
+    def comparison(value):
+        try:
+            return (expected_value - abs(tolerance)) <= value <= (expected_value + abs(tolerance))
+        except TypeError:
+            return False
+
+    return comparison
+
+
+def _array_tolerance_implementation(array_size, expected_value, tolerance):
+    """Builds a callable which checks every telemetry value is within the given tolerance"""
+
+    def comparison(values):
+        try:
+            if not isinstance(values, list) or len(values) != array_size:
+                return False
+            return all(
+                (expected_value[i] - abs(tolerance[i])) <= values[i] <= (expected_value[i] + abs(tolerance[i]))
+                for i in range(array_size)
+            )
+        except TypeError:
+            return False
+
+    return comparison
 
 
 # Wait for a converted telemetry item to pass a comparison
@@ -932,10 +962,6 @@ def _openc3_script_wait_value(
     polling_rate=DEFAULT_TLM_POLLING_RATE,
     scope=OPENC3_SCOPE,
 ):
-    if comparison_to_eval:
-        exp_to_eval = "value " + comparison_to_eval
-    else:
-        exp_to_eval = None
     return _openc3_script_wait(
         target_name,
         packet_name,
@@ -943,7 +969,7 @@ def _openc3_script_wait_value(
         value_type,
         timeout,
         polling_rate,
-        exp_to_eval,
+        _comparison_implementation(comparison_to_eval),
         scope,
     )
 
@@ -959,7 +985,6 @@ def _openc3_script_wait_tolerance(
     polling_rate=DEFAULT_TLM_POLLING_RATE,
     scope=OPENC3_SCOPE,
 ):
-    exp_to_eval = f"(value >= ({expected_value} - {abs(tolerance)}) and value <= ({expected_value} + {abs(tolerance)}))"
     return _openc3_script_wait(
         target_name,
         packet_name,
@@ -967,7 +992,7 @@ def _openc3_script_wait_tolerance(
         value_type,
         timeout,
         polling_rate,
-        exp_to_eval,
+        _tolerance_implementation(expected_value, tolerance),
         scope,
     )
 
@@ -984,12 +1009,6 @@ def _openc3_script_wait_array_tolerance(
     polling_rate=DEFAULT_TLM_POLLING_RATE,
     scope=OPENC3_SCOPE,
 ):
-    statements = []
-    for i in range(array_size):
-        statements.append(
-            f"(value[{i}] >= ({expected_value[i]} - {abs(tolerance[i])}) and value[{i}] <= ({expected_value[i]} + {abs(tolerance[i])}))"
-        )
-    exp_to_eval = " and ".join(statements)
     return _openc3_script_wait(
         target_name,
         packet_name,
@@ -997,7 +1016,7 @@ def _openc3_script_wait_array_tolerance(
         value_type,
         timeout,
         polling_rate,
-        exp_to_eval,
+        _array_tolerance_implementation(array_size, expected_value, tolerance),
         scope,
     )
 
@@ -1038,37 +1057,31 @@ def _openc3_script_wait_expression(exp_to_eval, timeout, polling_rate, globals, 
     return None
 
 
-def _check_eval(target_name, packet_name, item_name, comparison_to_eval, value):
-    string = "value " + comparison_to_eval
+def _check_comparison(target_name, packet_name, item_name, comparison_to_eval, value):
     check_str = f"CHECK: {_upcase(target_name, packet_name, item_name)} {comparison_to_eval}"
     # Show user the check against a quoted string
-    # Note: We have to preserve the original 'value' variable because we're going to eval against it
     if isinstance(value, str):
         value_str = f"'{value}'"
     else:
         value_str = value
     with_value = f"with value == {value_str}"
 
-    eval_is_valid = _check_eval_validity(value, comparison_to_eval)
-    if not eval_is_valid:
+    operator, operand = extract_operator_and_operand_from_comparison(comparison_to_eval)
+    if not _valid_comparison(value, operator, operand):
         message = "Invalid comparison for types"
         if openc3.script.DISCONNECT:
             print(f"ERROR: {message}")
         else:
             raise CheckError(message)
-    try:
-        if eval_is_valid and eval(string):
-            print(f"{check_str} success {with_value}")
+
+    if compare_values(value, operator, operand):
+        print(f"{check_str} success {with_value}")
+    else:
+        message = f"{check_str} failed {with_value}"
+        if openc3.script.DISCONNECT:
+            print(f"ERROR: {message}")
         else:
-            message = f"{check_str} failed {with_value}"
-            if openc3.script.DISCONNECT:
-                print(f"ERROR: {message}")
-            else:
-                raise CheckError(message)
-    except NameError as error:
-        parts = error.args[0].split("'")
-        new_error = NameError(f"Uninitialized constant {parts[1]}. Did you mean '{parts[1]}' as a string?")
-        raise new_error from error
+            raise CheckError(message)
 
 
 def _frange(value):
@@ -1080,30 +1093,22 @@ def _frange(value):
         return value
 
 
-def _check_eval_validity(value, comparison):
-    if not comparison:
+def _valid_comparison(value, operator, operand):
+    """Returns whether the value and operand can be meaningfully compared with the operator.
+    Note this is only used by check() because wait() polls until the value changes.
+    """
+    if operator is None:
         return True
 
-    try:
-        operator, operand = extract_operator_and_operand_from_comparison(comparison)
-    except RuntimeError as e:
-        if "Unable to parse operand" in str(e):
-            # If we can't parse the operand, let the eval happen anyway
-            # It will raise an appropriate error (like NameError for undefined constants)
-            return True
-        raise  # Re-raise invalid operator errors
-    except json.JSONDecodeError:
-        return True
-
-    if operator in [">=", "<=", ">", "<"] and (
-        value is None or operand is None or isinstance(value, list) or isinstance(operand, list)
-    ):
-        return False
-
-    # Ruby doesn't have the "in" operator
-    return not (
-        operator == "in" and (isinstance(operand, str) and not isinstance(value, str) or not isinstance(operand, list))
-    )
+    if operator in [">=", "<=", ">", "<"]:
+        if value is None or operand is None:
+            return False
+        if isinstance(value, list) or isinstance(operand, list):
+            return False
+        if isinstance(value, str) != isinstance(operand, str):
+            return False
+    # Note 'in' does not need a check here because the parser already requires a list operand
+    return True
 
 
 # Interesting formatter to a specific number of significant digits:

--- a/openc3/python/openc3/script/api_shared.py
+++ b/openc3/python/openc3/script/api_shared.py
@@ -925,19 +925,19 @@ def _comparison_implementation(comparison_to_eval):
 def _tolerance_implementation(expected_value, tolerance):
     """Builds a callable which checks a telemetry value is within the given tolerance"""
 
-    def comparison(value):
+    def _comparison(value):
         try:
             return (expected_value - abs(tolerance)) <= value <= (expected_value + abs(tolerance))
         except TypeError:
             return False
 
-    return comparison
+    return _comparison
 
 
 def _array_tolerance_implementation(array_size, expected_value, tolerance):
     """Builds a callable which checks every telemetry value is within the given tolerance"""
 
-    def comparison(values):
+    def _comparison(values):
         try:
             if not isinstance(values, list) or len(values) != array_size:
                 return False
@@ -948,7 +948,7 @@ def _array_tolerance_implementation(array_size, expected_value, tolerance):
         except TypeError:
             return False
 
-    return comparison
+    return _comparison
 
 
 # Wait for a converted telemetry item to pass a comparison

--- a/openc3/python/openc3/utilities/extract.py
+++ b/openc3/python/openc3/utilities/extract.py
@@ -14,7 +14,6 @@
 # if purchased from OpenC3, Inc.
 
 import ast
-import json
 import re
 
 
@@ -30,6 +29,20 @@ SCANNING_REGULAR_EXPRESSION = re.compile(
     """,
     re.VERBOSE,
 )
+
+# Operators supported by check(), wait() and wait_check() comparisons
+COMPARISON_OPERATORS = ["==", "!=", ">=", "<=", ">", "<", "in"]
+
+# Matches Infinity and NaN which literal_eval rejects but float() accepts
+INFINITY_NAN_REGEX = re.compile(r"^[+-]?(inf(inity)?|nan)$", re.IGNORECASE)
+
+# Matches an f-string prefix. Interpolation would be code execution so it is rejected.
+INTERPOLATION_REGEX = re.compile(r"^(?:[fF][rRbB]?|[rRbB][fF])['\"]")
+
+# Matches repr() of a bytearray, e.g. bytearray(b'\\x00'). tlm() returns BLOCK items as a
+# bytearray so this is the natural way to write the operand, but it is a constructor call
+# rather than a literal so literal_eval rejects it.
+BYTEARRAY_REGEX = re.compile(r"^bytearray\((.*)\)$", re.DOTALL)
 
 SPLIT_WITH_REGEX = re.compile(r"\s+with\s+", re.IGNORECASE)
 SPLIT_WITH_OPTIONAL_WHITESPACE_REGEX = re.compile(r"\s*with\s*", re.IGNORECASE)
@@ -250,8 +263,6 @@ def extract_fields_from_check_text(text):
 
 # Splits `check()` comparison expressions, e.g. "== 'foo bar'" becomes ["==", "foo bar"]
 def extract_operator_and_operand_from_comparison(comparison):
-    valid_operators = ["==", "!=", ">=", "<=", ">", "<", "in"]
-
     parts = comparison.split(None, 1)  # Python: second split arg is max number of splits
     operator = parts[0] if len(parts) >= 1 else None
     operand = parts[1] if len(parts) >= 2 else None
@@ -261,27 +272,76 @@ def extract_operator_and_operand_from_comparison(comparison):
             raise RuntimeError(f"ERROR: Invalid comparison, must specify an operand: {comparison}")
         return [None, None]
 
-    if operator not in valid_operators:
+    if operator not in COMPARISON_OPERATORS:
         raise RuntimeError(f"ERROR: Invalid operator: '{operator}'")
 
-    # Handle string operand: remove surrounding double/single quotes
-    quote_match = re.match(
-        r"^(['\"])(.*)\1$", operand, re.DOTALL
-    )  # Starts with single or double quote, and ends with matching quote
-    if quote_match:
-        operand = quote_match.group(2)
-        return operator, operand
+    operand = extract_operand(operand)
+    # 'in' is containment against a list of values in both Ruby and Python.
+    # Enforced here so check(), wait() and wait_check() all reject the same thing.
+    if operator == "in" and not isinstance(operand, list):
+        raise RuntimeError(f"ERROR: The 'in' operator requires a list operand: {operand!r}")
 
-    # Handle other operand types
-    if operand == "None":
-        operand = None
-    elif operand == "False":
-        operand = False
-    elif operand == "True":
-        operand = True
-    else:
-        try:
-            operand = json.loads(operand)
-        except json.JSONDecodeError as err:
-            raise RuntimeError(f"ERROR: Unable to parse operand: {operand}") from err
     return operator, operand
+
+
+# Converts the operand of a `check()` comparison expression into a Python value.
+# Note this deliberately does not eval the operand so only literal values are supported.
+def extract_operand(operand):
+    # A bytearray is spelled as a constructor call around a literal. Only this one wrapper is
+    # recognized and its contents still go through extract_operand, so nothing is executed.
+    bytearray_match = BYTEARRAY_REGEX.match(operand)
+    if bytearray_match:
+        contents = bytearray_match.group(1).strip()
+        if not contents:
+            return bytearray()
+        value = extract_operand(contents)
+        if not isinstance(value, bytes | bytearray | list):
+            raise RuntimeError(f"ERROR: Unable to parse operand: {operand}")
+        return bytearray(value)
+
+    # literal_eval only parses Python literals, e.g. numbers, strings, bytes, lists and dicts,
+    # so unlike eval it can not execute arbitrary code. It processes string escape sequences
+    # and requires a single complete literal, so "== 'a' garbage 'b'" is a syntax error.
+    try:
+        return ast.literal_eval(operand)
+    except (ValueError, SyntaxError, MemoryError, RecursionError):
+        pass  # Fall through to the formats literal_eval does not support
+    if INFINITY_NAN_REGEX.match(operand):
+        return float(operand)
+
+    # An f-string is interpolation which would be code execution. literal_eval already rejects
+    # it but the generic error does not say why.
+    if INTERPOLATION_REGEX.match(operand):
+        raise RuntimeError(
+            f"ERROR: String interpolation is not supported in an operand: {operand}. Interpolate in the script itself"
+        )
+    # A bare word is almost always a string the user forgot to quote
+    if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", operand):
+        raise NameError(f"Uninitialized constant {operand}. Did you mean '{operand}' as a string?")
+    raise RuntimeError(f"ERROR: Unable to parse operand: {operand}")
+
+
+# Compares a telemetry value against an operand using the given operator.
+# Returns False rather than raising if the two values can not be compared.
+def compare_values(value, operator, operand):
+    try:
+        if operator == "==":
+            return value == operand
+        elif operator == "!=":
+            return value != operand
+        elif operator == ">":
+            return value > operand
+        elif operator == ">=":
+            return value >= operand
+        elif operator == "<":
+            return value < operand
+        elif operator == "<=":
+            return value <= operand
+        elif operator == "in":
+            # 'in' is containment against a list of values, matching Ruby
+            return isinstance(operand, list) and value in operand
+        else:
+            raise RuntimeError(f"ERROR: Invalid operator: '{operator}'")
+    except TypeError:
+        # Comparing incompatible types, e.g. None > 1, is simply not a match
+        return False

--- a/openc3/python/openc3/utilities/extract.py
+++ b/openc3/python/openc3/utilities/extract.py
@@ -315,8 +315,9 @@ def extract_operand(operand):
         raise RuntimeError(
             f"ERROR: String interpolation is not supported in an operand: {operand}. Interpolate in the script itself"
         )
-    # A bare word is almost always a string the user forgot to quote
-    if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", operand):
+    # A bare word is almost always a string the user forgot to quote. re.ASCII keeps \w to
+    # [A-Za-z0-9_] so this matches the same words as the Ruby implementation.
+    if re.match(r"^[A-Za-z_]\w*$", operand, re.ASCII):
         raise NameError(f"Uninitialized constant {operand}. Did you mean '{operand}' as a string?")
     raise RuntimeError(f"ERROR: Unable to parse operand: {operand}")
 

--- a/openc3/python/test/api/test_api_shared.py
+++ b/openc3/python/test/api/test_api_shared.py
@@ -9,6 +9,7 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
+import re
 import unittest
 from unittest.mock import patch
 
@@ -63,7 +64,8 @@ def tlm(target_name, packet_name, item_name, type="CONVERTED", scope="DEFAULT"):
         case "CCSDSSHF":
             return "FALSE"
         case "BLOCKTEST":
-            return b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+            # tlm() returns BLOCK items as a bytearray, not bytes
+            return bytearray(b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
         case "ARY":
             return [2, 3, 4]
         case "RECEIVED_COUNT":
@@ -557,7 +559,8 @@ class TestApiShared(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid comparison to non-ascii value"):
             wait_check(f"INST HEALTH_STATUS BLOCKTEST == '{data}'", 0.01)
         data = b"\xff" * 10
-        with self.assertRaises(SyntaxError):
+        # Quoting the bytes repr does not produce a single complete literal
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand"):
             wait_check(f"INST HEALTH_STATUS BLOCKTEST == '{data}'", 0.01)
 
     def test_warns_when_checking_a_state_against_a_constant(self):
@@ -573,6 +576,92 @@ class TestApiShared(unittest.TestCase):
             "Uninitialized constant FALSE. Did you mean 'FALSE' as a string?",
         ):
             wait_check("INST HEALTH_STATUS CCSDSSHF == FALSE", 0.01)
+
+    # check(), wait() and wait_check() all parse the same comparison syntax
+    # so they must all accept and reject exactly the same expressions
+    def test_consistency_rejects_operators_which_are_not_supported(self):
+        # Bitwise and boolean operators are not part of the comparison syntax
+        for operator in ["&", "|", "^", "and", "or", "==="]:
+            for call in [
+                lambda op: check(f"INST HEALTH_STATUS TEMP1 {op} 1"),
+                lambda op: wait(f"INST HEALTH_STATUS TEMP1 {op} 1", 0.01),
+                lambda op: wait_check(f"INST HEALTH_STATUS TEMP1 {op} 1", 0.01),
+            ]:
+                with self.assertRaisesRegex(RuntimeError, f"ERROR: Invalid operator: '{re.escape(operator)}'"):
+                    call(operator)
+
+    def test_consistency_rejects_compound_expressions(self):
+        # https://github.com/OpenC3/cosmos/issues/3802
+        expression = "INST HEALTH_STATUS TIMEUS & 0x0001 == 0x0000"
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid operator: '&'"):
+            check(expression)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid operator: '&'"):
+            wait(expression, 0.01)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid operator: '&'"):
+            wait_check(expression, 0.01)
+
+    def test_consistency_rejects_operators_without_an_operand(self):
+        with self.assertRaisesRegex(RuntimeError, "must specify an operand"):
+            check("INST HEALTH_STATUS TEMP1 >")
+        with self.assertRaisesRegex(RuntimeError, "must specify an operand"):
+            wait("INST HEALTH_STATUS TEMP1 >", 0.01)
+        with self.assertRaisesRegex(RuntimeError, "must specify an operand"):
+            wait_check("INST HEALTH_STATUS TEMP1 >", 0.01)
+
+    def test_consistency_suggests_a_string_when_comparing_against_a_bare_word(self):
+        error = "Uninitialized constant FALSE. Did you mean 'FALSE' as a string?"
+        with self.assertRaisesRegex(NameError, re.escape(error)):
+            check("INST HEALTH_STATUS CCSDSSHF == FALSE")
+        with self.assertRaisesRegex(NameError, re.escape(error)):
+            wait("INST HEALTH_STATUS CCSDSSHF == FALSE", 0.01)
+        with self.assertRaisesRegex(NameError, re.escape(error)):
+            wait_check("INST HEALTH_STATUS CCSDSSHF == FALSE", 0.01)
+
+    def test_consistency_accepts_hex_operands(self):
+        for stdout in capture_io():
+            check("INST HEALTH_STATUS TEMP1 == 0x0A")  # TEMP1 is 10
+            self.assertIn(
+                "CHECK: INST HEALTH_STATUS TEMP1 == 0x0A success with value == 10",
+                stdout.getvalue(),
+            )
+            self.assertTrue(wait("INST HEALTH_STATUS TEMP1 == 0x0A", 0.01))
+            self.assertIsInstance(wait_check("INST HEALTH_STATUS TEMP1 == 0x0A", 0.01), float)
+
+    def test_consistency_rejects_ambiguous_leading_zero_integers(self):
+        # Ruby reads 010 as octal 8 while Python rejects it outright so require 0o10 or 10
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand: 010"):
+            check("INST HEALTH_STATUS TEMP1 == 010")
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand: 010"):
+            wait("INST HEALTH_STATUS TEMP1 == 010", 0.01)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand: 010"):
+            wait_check("INST HEALTH_STATUS TEMP1 == 010", 0.01)
+
+    def test_consistency_rejects_a_comparison_which_is_not_a_single_quoted_literal(self):
+        comparison = "INST HEALTH_STATUS CCSDSSHF == 'a' garbage 'b'"
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand"):
+            check(comparison)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand"):
+            wait(comparison, 0.01)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand"):
+            wait_check(comparison, 0.01)
+
+    def test_consistency_requires_a_list_operand_for_the_in_operator(self):
+        error = "ERROR: The 'in' operator requires a list operand"
+        with self.assertRaisesRegex(RuntimeError, error):
+            check("INST HEALTH_STATUS TEMP1 in 'abc'")
+        with self.assertRaisesRegex(RuntimeError, error):
+            wait("INST HEALTH_STATUS TEMP1 in 'abc'", 0.01)
+        with self.assertRaisesRegex(RuntimeError, error):
+            wait_check("INST HEALTH_STATUS TEMP1 in 'abc'", 0.01)
+
+        for stdout in capture_io():
+            check("INST HEALTH_STATUS TEMP1 in [1, 10]")  # TEMP1 is 10
+            self.assertIn(
+                "CHECK: INST HEALTH_STATUS TEMP1 in [1, 10] success with value == 10",
+                stdout.getvalue(),
+            )
+            self.assertTrue(wait("INST HEALTH_STATUS TEMP1 in [1, 10]", 0.01))
+            self.assertIsInstance(wait_check("INST HEALTH_STATUS TEMP1 in [1, 10]", 0.01), float)
 
     def test_wait_check_tolerance_raises_with_formatted_or_with_units(self):
         with self.assertRaisesRegex(RuntimeError, r"Invalid type 'FORMATTED' for wait_check_tolerance"):

--- a/openc3/python/test/script/test_api_shared.py
+++ b/openc3/python/test/script/test_api_shared.py
@@ -10,6 +10,7 @@
 # if purchased from OpenC3, Inc.
 
 import os
+import re
 import unittest
 from unittest.mock import *
 
@@ -48,7 +49,8 @@ class Proxy:
             case "CCSDSSHF":
                 return "FALSE"
             case "BLOCKTEST":
-                return b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+                # tlm() returns BLOCK items as a bytearray, not bytes
+                return bytearray(b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")
             case "ARY":
                 return [2, 3, 4]
             case "RECEIVED_COUNT":
@@ -317,11 +319,10 @@ class TestApiShared(unittest.TestCase):
             self.assertIn("is TRUE", stdout.getvalue())
         cancel = False
 
-    def test_check_eval_validity_returns_true_for_no_comparison(self):
-        from openc3.script.api_shared import _check_eval_validity
+    def test_valid_comparison_returns_true_for_no_comparison(self):
+        from openc3.script.api_shared import _valid_comparison
 
-        self.assertTrue(_check_eval_validity(10, None))
-        self.assertTrue(_check_eval_validity(10, ""))
+        self.assertTrue(_valid_comparison(10, None, None))
 
     def test_checks_against_the_specified_type(self):
         for stdout in capture_io():
@@ -783,20 +784,21 @@ class TestApiShared(unittest.TestCase):
         data = "\xff" * 10
         with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid comparison to non-ascii value"):
             wait_check(f"INST HEALTH_STATUS BLOCKTEST == {data}", 0.01)
-        data = b"\xff" * 10
+        data = bytearray(b"\xff" * 10)
         for stdout in capture_io():
             result = wait_check(f"INST HEALTH_STATUS BLOCKTEST == {data}", 0.01)
             self.assertTrue(isinstance(result, float))
             output = stdout.getvalue()
             self.assertIn(
-                "CHECK: INST HEALTH_STATUS BLOCKTEST == b'\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff' success with value ==",
+                "CHECK: INST HEALTH_STATUS BLOCKTEST == bytearray(b'\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff') success with value ==",
                 output,
             )
         data = "\xff" * 10
         with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid comparison to non-ascii value"):
             wait_check(f"INST HEALTH_STATUS BLOCKTEST == '{data}'", 0.01)
-        data = b"\xff" * 10
-        with self.assertRaises(SyntaxError):
+        data = bytearray(b"\xff" * 10)
+        # Quoting the bytearray repr does not produce a single complete literal
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand"):
             wait_check(f"INST HEALTH_STATUS BLOCKTEST == '{data}'", 0.01)
 
     def test_warns_when_checking_a_state_against_a_constant(self):
@@ -812,6 +814,92 @@ class TestApiShared(unittest.TestCase):
             "Uninitialized constant FALSE. Did you mean 'FALSE' as a string?",
         ):
             wait_check("INST HEALTH_STATUS CCSDSSHF == FALSE", 0.01)
+
+    # check(), wait() and wait_check() all parse the same comparison syntax
+    # so they must all accept and reject exactly the same expressions
+    def test_consistency_rejects_operators_which_are_not_supported(self):
+        # Bitwise and boolean operators are not part of the comparison syntax
+        for operator in ["&", "|", "^", "and", "or", "==="]:
+            for call in [
+                lambda op: check(f"INST HEALTH_STATUS TEMP1 {op} 1"),
+                lambda op: wait(f"INST HEALTH_STATUS TEMP1 {op} 1", 0.01),
+                lambda op: wait_check(f"INST HEALTH_STATUS TEMP1 {op} 1", 0.01),
+            ]:
+                with self.assertRaisesRegex(RuntimeError, f"ERROR: Invalid operator: '{re.escape(operator)}'"):
+                    call(operator)
+
+    def test_consistency_rejects_compound_expressions(self):
+        # https://github.com/OpenC3/cosmos/issues/3802
+        expression = "INST HEALTH_STATUS TIMEUS & 0x0001 == 0x0000"
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid operator: '&'"):
+            check(expression)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid operator: '&'"):
+            wait(expression, 0.01)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Invalid operator: '&'"):
+            wait_check(expression, 0.01)
+
+    def test_consistency_rejects_operators_without_an_operand(self):
+        with self.assertRaisesRegex(RuntimeError, "must specify an operand"):
+            check("INST HEALTH_STATUS TEMP1 >")
+        with self.assertRaisesRegex(RuntimeError, "must specify an operand"):
+            wait("INST HEALTH_STATUS TEMP1 >", 0.01)
+        with self.assertRaisesRegex(RuntimeError, "must specify an operand"):
+            wait_check("INST HEALTH_STATUS TEMP1 >", 0.01)
+
+    def test_consistency_suggests_a_string_when_comparing_against_a_bare_word(self):
+        error = "Uninitialized constant FALSE. Did you mean 'FALSE' as a string?"
+        with self.assertRaisesRegex(NameError, re.escape(error)):
+            check("INST HEALTH_STATUS CCSDSSHF == FALSE")
+        with self.assertRaisesRegex(NameError, re.escape(error)):
+            wait("INST HEALTH_STATUS CCSDSSHF == FALSE", 0.01)
+        with self.assertRaisesRegex(NameError, re.escape(error)):
+            wait_check("INST HEALTH_STATUS CCSDSSHF == FALSE", 0.01)
+
+    def test_consistency_accepts_hex_operands(self):
+        for stdout in capture_io():
+            check("INST HEALTH_STATUS TEMP1 == 0x0A")  # TEMP1 is 10
+            self.assertIn(
+                "CHECK: INST HEALTH_STATUS TEMP1 == 0x0A success with value == 10",
+                stdout.getvalue(),
+            )
+            self.assertTrue(wait("INST HEALTH_STATUS TEMP1 == 0x0A", 0.01))
+            self.assertIsInstance(wait_check("INST HEALTH_STATUS TEMP1 == 0x0A", 0.01), float)
+
+    def test_consistency_rejects_ambiguous_leading_zero_integers(self):
+        # Ruby reads 010 as octal 8 while Python rejects it outright so require 0o10 or 10
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand: 010"):
+            check("INST HEALTH_STATUS TEMP1 == 010")
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand: 010"):
+            wait("INST HEALTH_STATUS TEMP1 == 010", 0.01)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand: 010"):
+            wait_check("INST HEALTH_STATUS TEMP1 == 010", 0.01)
+
+    def test_consistency_rejects_a_comparison_which_is_not_a_single_quoted_literal(self):
+        comparison = "INST HEALTH_STATUS CCSDSSHF == 'a' garbage 'b'"
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand"):
+            check(comparison)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand"):
+            wait(comparison, 0.01)
+        with self.assertRaisesRegex(RuntimeError, "ERROR: Unable to parse operand"):
+            wait_check(comparison, 0.01)
+
+    def test_consistency_requires_a_list_operand_for_the_in_operator(self):
+        error = "ERROR: The 'in' operator requires a list operand"
+        with self.assertRaisesRegex(RuntimeError, error):
+            check("INST HEALTH_STATUS TEMP1 in 'abc'")
+        with self.assertRaisesRegex(RuntimeError, error):
+            wait("INST HEALTH_STATUS TEMP1 in 'abc'", 0.01)
+        with self.assertRaisesRegex(RuntimeError, error):
+            wait_check("INST HEALTH_STATUS TEMP1 in 'abc'", 0.01)
+
+        for stdout in capture_io():
+            check("INST HEALTH_STATUS TEMP1 in [1, 10]")  # TEMP1 is 10
+            self.assertIn(
+                "CHECK: INST HEALTH_STATUS TEMP1 in [1, 10] success with value == 10",
+                stdout.getvalue(),
+            )
+            self.assertTrue(wait("INST HEALTH_STATUS TEMP1 in [1, 10]", 0.01))
+            self.assertIsInstance(wait_check("INST HEALTH_STATUS TEMP1 in [1, 10]", 0.01), float)
 
     def test_wait_check_tolerance_raises_with_formatted_or_with_units(self):
         with self.assertRaisesRegex(RuntimeError, r"Invalid type 'FORMATTED' for wait_check_tolerance"):

--- a/openc3/python/test/utilities/test_extract.py
+++ b/openc3/python/test/utilities/test_extract.py
@@ -13,6 +13,7 @@ import pytest
 
 from openc3.utilities.extract import (
     add_cmd_parameter,
+    compare_values,
     extract_fields_from_check_text,
     extract_fields_from_cmd_text,
     extract_fields_from_set_tlm_text,
@@ -240,6 +241,126 @@ class TestExtractOperatorAndOperandFromComparison:
         with pytest.raises(RuntimeError, match="ERROR: Invalid"):
             extract_operator_and_operand_from_comparison("^ 'foo'")
 
+    def test_parses_hex_octal_and_binary_operands(self):
+        assert extract_operator_and_operand_from_comparison("== 0x0001") == ("==", 1)
+        assert extract_operator_and_operand_from_comparison("== 0o17") == ("==", 15)
+        assert extract_operator_and_operand_from_comparison("== 0b1010") == ("==", 10)
+
+    def test_parses_float_operands(self):
+        assert extract_operator_and_operand_from_comparison("> 1.5") == (">", 1.5)
+        assert extract_operator_and_operand_from_comparison("> 1e5") == (">", 100000.0)
+
+    def test_parses_bytes_operands(self):
+        assert extract_operator_and_operand_from_comparison("== b'\\xff'") == ("==", b"\xff")
+
     def test_complains_about_unparsable_operands(self):
         with pytest.raises(RuntimeError, match="ERROR: Unable"):
+            extract_operator_and_operand_from_comparison("== 1.2.3")
+
+    def test_suggests_a_string_for_bare_word_operands(self):
+        with pytest.raises(NameError, match="Uninitialized constant foo. Did you mean 'foo' as a string"):
             extract_operator_and_operand_from_comparison("== foo")
+
+    def test_processes_escape_sequences_using_python_string_literal_rules(self):
+        assert extract_operator_and_operand_from_comparison(r'== "line\nnext"') == ("==", "line\nnext")
+        assert extract_operator_and_operand_from_comparison(r"== 'line\nnext'") == ("==", "line\nnext")
+        assert extract_operator_and_operand_from_comparison(r"== 'tab\there'") == ("==", "tab\there")
+        assert extract_operator_and_operand_from_comparison(r"== 'it\'s'") == ("==", "it's")
+
+    def test_requires_a_single_complete_quoted_literal(self):
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand"):
+            extract_operator_and_operand_from_comparison("== 'a' garbage 'b'")
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand"):
+            extract_operator_and_operand_from_comparison("== 'unterminated")
+
+    def test_rejects_ambiguous_leading_zero_integers(self):
+        # Ruby reads 010 as octal 8 while Python rejects it outright so require 0o10 or 10
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand: 010"):
+            extract_operator_and_operand_from_comparison("== 010")
+        assert extract_operator_and_operand_from_comparison("== 0o10") == ("==", 8)
+        assert extract_operator_and_operand_from_comparison("== 10") == ("==", 10)
+        # A leading zero is not ambiguous for a float
+        assert extract_operator_and_operand_from_comparison("== 010.5") == ("==", 10.5)
+
+    def test_parses_numbers_with_underscore_separators(self):
+        assert extract_operator_and_operand_from_comparison("== 1_000") == ("==", 1000)
+        assert extract_operator_and_operand_from_comparison("== 1_000.5") == ("==", 1000.5)
+
+    def test_parses_a_bytearray_repr(self):
+        # tlm() returns BLOCK items as a bytearray so f"... == {data}" produces this form
+        data = bytearray(b"\x00\xff")
+        assert extract_operator_and_operand_from_comparison(f"== {data}") == ("==", data)
+        assert extract_operator_and_operand_from_comparison("== bytearray()") == ("==", bytearray())
+        assert extract_operator_and_operand_from_comparison("== bytearray([1, 2])") == ("==", bytearray(b"\x01\x02"))
+
+    def test_rejects_a_bytearray_wrapping_anything_but_a_literal(self):
+        # Only the one wrapper is recognized and its contents still go through extract_operand
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand"):
+            extract_operator_and_operand_from_comparison("== bytearray(open('/etc/passwd').read())")
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand"):
+            extract_operator_and_operand_from_comparison("== bytearray(5)")
+
+    def test_rejects_f_string_interpolation(self):
+        # The eval based implementation interpolated this. Interpolating is code execution so
+        # it is now an error rather than a silent comparison against the uninterpolated text.
+        with pytest.raises(RuntimeError, match="String interpolation is not supported in an operand"):
+            extract_operator_and_operand_from_comparison("== f'{1 + 1}'")
+        with pytest.raises(RuntimeError, match="String interpolation is not supported in an operand"):
+            extract_operator_and_operand_from_comparison('== f"{x}"')
+        # A brace in a plain string is literal text
+        assert extract_operator_and_operand_from_comparison("== '{1 + 1}'") == ("==", "{1 + 1}")
+
+    def test_parses_list_elements_with_the_same_rules_as_a_bare_operand(self):
+        assert extract_operator_and_operand_from_comparison("in ['ON', 'OFF']") == ("in", ["ON", "OFF"])
+        assert extract_operator_and_operand_from_comparison("in [0xA, 0o17, 1_000]") == ("in", [10, 15, 1000])
+        assert extract_operator_and_operand_from_comparison("in [True, None]") == ("in", [True, None])
+        assert extract_operator_and_operand_from_comparison("in []") == ("in", [])
+        assert extract_operator_and_operand_from_comparison("in [[1, 2], [3]]") == ("in", [[1, 2], [3]])
+        # Commas and brackets inside a quoted element do not split it
+        assert extract_operator_and_operand_from_comparison("in ['a,b', '[c]']") == ("in", ["a,b", "[c]"])
+
+    def test_allows_a_trailing_comma_like_a_ruby_or_python_list_literal(self):
+        assert extract_operator_and_operand_from_comparison("in [1,]") == ("in", [1])
+
+    def test_rejects_malformed_lists(self):
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand"):
+            extract_operator_and_operand_from_comparison("in [1,,2]")
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand"):
+            extract_operator_and_operand_from_comparison("in [,1]")
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand"):
+            extract_operator_and_operand_from_comparison("in [1, 2]]")
+        with pytest.raises(RuntimeError, match="ERROR: Unable to parse operand"):
+            extract_operator_and_operand_from_comparison("in ['unterminated]")
+
+    def test_allows_underscore_separators_in_an_exponent(self):
+        assert extract_operator_and_operand_from_comparison("== 1e1_0") == ("==", 1e10)
+
+    def test_requires_a_list_operand_for_the_in_operator(self):
+        with pytest.raises(RuntimeError, match="ERROR: The 'in' operator requires a list operand"):
+            extract_operator_and_operand_from_comparison("in 'abc'")
+        with pytest.raises(RuntimeError, match="ERROR: The 'in' operator requires a list operand"):
+            extract_operator_and_operand_from_comparison("in 5")
+
+
+class TestCompareValues:
+    def test_compares_with_all_the_supported_operators(self):
+        assert compare_values(1, "==", 1) is True
+        assert compare_values(1, "!=", 1) is False
+        assert compare_values(2, ">", 1) is True
+        assert compare_values(1, ">=", 1) is True
+        assert compare_values(1, "<", 2) is True
+        assert compare_values(1, "<=", 1) is True
+        assert compare_values(2, "in", [1, 2, 3]) is True
+        assert compare_values(4, "in", [1, 2, 3]) is False
+
+    def test_returns_false_when_the_types_can_not_be_compared(self):
+        assert compare_values(None, ">", 1) is False
+        assert compare_values(1, ">", None) is False
+        assert compare_values("STRING", ">", 1) is False
+        # 'in' is containment against a list, matching Ruby, so a str operand is not a match
+        assert compare_values(1, "in", 1) is False
+        assert compare_values("a", "in", "abc") is False
+
+    def test_complains_about_invalid_operators(self):
+        with pytest.raises(RuntimeError, match="ERROR: Invalid operator: '&'"):
+            compare_values(1, "&", 1)

--- a/openc3/spec/script/api_shared_spec.rb
+++ b/openc3/spec/script/api_shared_spec.rb
@@ -664,6 +664,96 @@ module OpenC3
       end
     end
 
+    # check(), wait() and wait_check() all parse the same comparison syntax
+    # so they must all accept and reject exactly the same expressions
+    describe "check, wait, wait_check consistency" do
+      it "rejects operators which are not supported" do
+        # Bitwise and boolean operators are not part of the comparison syntax
+        ["&", "|", "^", "and", "or", "==="].each do |operator|
+          expect { check("INST HEALTH_STATUS TEMP1 #{operator} 1") }.to raise_error(RuntimeError, /ERROR: Invalid operator: '#{Regexp.escape(operator)}'/)
+          expect { wait("INST HEALTH_STATUS TEMP1 #{operator} 1", 0.01) }.to raise_error(RuntimeError, /ERROR: Invalid operator: '#{Regexp.escape(operator)}'/)
+          expect { wait_check("INST HEALTH_STATUS TEMP1 #{operator} 1", 0.01) }.to raise_error(RuntimeError, /ERROR: Invalid operator: '#{Regexp.escape(operator)}'/)
+        end
+      end
+
+      it "rejects compound expressions" do
+        # https://github.com/OpenC3/cosmos/issues/3802
+        expression = "INST HEALTH_STATUS TIMEUS & 0x0001 == 0x0000"
+        expect { check(expression) }.to raise_error(RuntimeError, /ERROR: Invalid operator: '&'/)
+        expect { wait(expression, 0.01) }.to raise_error(RuntimeError, /ERROR: Invalid operator: '&'/)
+        expect { wait_check(expression, 0.01) }.to raise_error(RuntimeError, /ERROR: Invalid operator: '&'/)
+      end
+
+      it "rejects operators without an operand" do
+        expect { check("INST HEALTH_STATUS TEMP1 >") }.to raise_error(RuntimeError, /must specify an operand/)
+        expect { wait("INST HEALTH_STATUS TEMP1 >", 0.01) }.to raise_error(RuntimeError, /must specify an operand/)
+        expect { wait_check("INST HEALTH_STATUS TEMP1 >", 0.01) }.to raise_error(RuntimeError, /must specify an operand/)
+      end
+
+      it "suggests a string when comparing against a bare word" do
+        error = "Uninitialized constant FALSE. Did you mean 'FALSE' as a string?"
+        expect { check("INST HEALTH_STATUS CCSDSSHF == FALSE") }.to raise_error(NameError, error)
+        expect { wait("INST HEALTH_STATUS CCSDSSHF == FALSE", 0.01) }.to raise_error(NameError, error)
+        expect { wait_check("INST HEALTH_STATUS CCSDSSHF == FALSE", 0.01) }.to raise_error(NameError, error)
+      end
+
+      it "accepts hex operands" do
+        capture_io do |stdout|
+          check("INST HEALTH_STATUS TEMP1 == 0x0A") # TEMP1 is 10
+          expect(stdout.string).to include('CHECK: INST HEALTH_STATUS TEMP1 == 0x0A success with value == 10')
+          expect(wait("INST HEALTH_STATUS TEMP1 == 0x0A", 0.01)).to be true
+          expect(wait_check("INST HEALTH_STATUS TEMP1 == 0x0A", 0.01)).to be_a Float
+        end
+      end
+
+      it "rejects ambiguous leading zero integers" do
+        # Ruby reads 010 as octal 8 while Python rejects it outright so require 0o10 or 10
+        expect { check("INST HEALTH_STATUS TEMP1 == 010") }.to raise_error(/ERROR: Unable to parse operand: 010/)
+        expect { wait("INST HEALTH_STATUS TEMP1 == 010", 0.01) }.to raise_error(/ERROR: Unable to parse operand: 010/)
+        expect { wait_check("INST HEALTH_STATUS TEMP1 == 010", 0.01) }.to raise_error(/ERROR: Unable to parse operand: 010/)
+      end
+
+      it "rejects a comparison which is not a single complete quoted literal" do
+        comparison = "INST HEALTH_STATUS CCSDSSHF == 'a' garbage 'b'"
+        expect { check(comparison) }.to raise_error(/ERROR: Unable to parse operand/)
+        expect { wait(comparison, 0.01) }.to raise_error(/ERROR: Unable to parse operand/)
+        expect { wait_check(comparison, 0.01) }.to raise_error(/ERROR: Unable to parse operand/)
+      end
+
+      it "requires a list operand for the in operator" do
+        error = /ERROR: The 'in' operator requires a list operand/
+        expect { check("INST HEALTH_STATUS TEMP1 in 'abc'") }.to raise_error(error)
+        expect { wait("INST HEALTH_STATUS TEMP1 in 'abc'", 0.01) }.to raise_error(error)
+        expect { wait_check("INST HEALTH_STATUS TEMP1 in 'abc'", 0.01) }.to raise_error(error)
+
+        capture_io do |stdout|
+          check("INST HEALTH_STATUS TEMP1 in [1, 10]") # TEMP1 is 10
+          expect(stdout.string).to include('CHECK: INST HEALTH_STATUS TEMP1 in [1, 10] success with value == 10')
+          expect(wait("INST HEALTH_STATUS TEMP1 in [1, 10]", 0.01)).to be true
+          expect(wait_check("INST HEALTH_STATUS TEMP1 in [1, 10]", 0.01)).to be_a Float
+        end
+      end
+
+      it "ignores the comparison when wait_check is given a block" do
+        # The block is the condition so the text after the item name is never parsed
+        capture_io do |stdout|
+          result = wait_check("INST HEALTH_STATUS TEMP1 & 0x1", 0.01) do |value|
+            value == 10
+          end
+          expect(result).to be_a Float
+          expect(stdout.string).to include('CHECK: INST HEALTH_STATUS TEMP1 & 0x1 success with value == 10')
+        end
+      end
+
+      it "still rejects non-ascii comparison text when wait_check is given a block" do
+        # The comparison text is logged even when a block is the condition
+        data = "\xFF" * 10
+        expect {
+          wait_check("INST HEALTH_STATUS BLOCKTEST == '#{data}'", 0.01) { |_value| true }
+        }.to raise_error(RuntimeError, "ERROR: Invalid comparison to non-ascii value")
+      end
+    end
+
     describe "wait_check_tolerance" do
       it "raises with :FORMATTED or :WITH_UNITS" do
         expect { wait_check_tolerance("INST HEALTH_STATUS TEMP2 == 10.5", 0.1, 0.01, type: :FORMATTED) }.to raise_error("Invalid type 'FORMATTED' for wait_check_tolerance")

--- a/openc3/spec/script/extract_spec.rb
+++ b/openc3/spec/script/extract_spec.rb
@@ -334,6 +334,38 @@ module OpenC3
         expect { extract_operator_and_operand_from_comparison(%q(== "\x")) }.to raise_error(/Invalid escape sequence/)
       end
 
+      it "should accept the same unicode codepoints as Ruby" do
+        # Ruby allows an empty codepoint list and it produces an empty string
+        expect(extract_operator_and_operand_from_comparison(%q(== "\u{}"))).to eql(["==", ""])
+        expect(extract_operator_and_operand_from_comparison(%q(== "\u{ }"))).to eql(["==", ""])
+        # Up to six hex digits per codepoint, so leading zeros are allowed
+        expect(extract_operator_and_operand_from_comparison(%q(== "\u{000048}"))).to eql(["==", "H"])
+        expect(extract_operator_and_operand_from_comparison(%q(== "\u{48 000049}"))).to eql(["==", "HI"])
+        # The largest character Unicode defines
+        expect(extract_operator_and_operand_from_comparison(%q(== "\u{10FFFF}"))).to eql(["==", "\u{10FFFF}"])
+      end
+
+      it "should reject unicode codepoints which are not valid characters" do
+        # Ruby rejects all of these at parse time. Packing them would silently produce an
+        # invalid UTF-8 string which could never match a telemetry value.
+        # Above the largest character Unicode defines
+        expect { extract_operator_and_operand_from_comparison(%q(== "\u{110000}")) }.to \
+          raise_error(/Invalid Unicode codepoint/)
+        # The UTF-16 surrogate range is not a character on its own
+        expect { extract_operator_and_operand_from_comparison(%q(== "\u{D800}")) }.to \
+          raise_error(/Invalid Unicode codepoint/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "\uD800")) }.to \
+          raise_error(/Invalid Unicode codepoint/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "\uDFFF")) }.to \
+          raise_error(/Invalid Unicode codepoint/)
+        # More than six hex digits
+        expect { extract_operator_and_operand_from_comparison(%q(== "\u{0000048}")) }.to \
+          raise_error(/Invalid Unicode codepoint/)
+        # A bad codepoint anywhere in the list is an error, not a partial string
+        expect { extract_operator_and_operand_from_comparison(%q(== "\u{48 110000}")) }.to \
+          raise_error(/Invalid Unicode codepoint/)
+      end
+
       it "should reject unescaped string interpolation" do
         # The eval based implementation interpolated this. Interpolating is code execution so
         # it is now an error rather than a silent comparison against the uninterpolated text.

--- a/openc3/spec/script/extract_spec.rb
+++ b/openc3/spec/script/extract_spec.rb
@@ -253,8 +253,161 @@ module OpenC3
         expect { extract_operator_and_operand_from_comparison("^ 'foo'") }.to raise_error(/ERROR: Invalid/)
       end
 
+      it "should parse hex, octal and binary operands" do
+        expect(extract_operator_and_operand_from_comparison("== 0x0001")).to eql(["==", 1])
+        expect(extract_operator_and_operand_from_comparison("== 0o17")).to eql(["==", 15])
+        expect(extract_operator_and_operand_from_comparison("== 0b1010")).to eql(["==", 10])
+      end
+
+      it "should parse float operands" do
+        expect(extract_operator_and_operand_from_comparison("> 1.5")).to eql([">", 1.5])
+        expect(extract_operator_and_operand_from_comparison("> 1e5")).to eql([">", 100000.0])
+      end
+
       it "should complain about unparsable operands" do
-        expect { extract_operator_and_operand_from_comparison("== foo") }.to raise_error(/ERROR: Unable/)
+        expect { extract_operator_and_operand_from_comparison("== 1.2.3") }.to raise_error(/ERROR: Unable/)
+      end
+
+      it "should suggest a string for bare word operands" do
+        expect { extract_operator_and_operand_from_comparison("== foo") }.to \
+          raise_error(NameError, "Uninitialized constant foo. Did you mean 'foo' as a string?")
+      end
+
+      it "should process escape sequences using Ruby string literal rules" do
+        # Double quoted strings process the full escape set
+        expect(extract_operator_and_operand_from_comparison(%q(== "line\nnext"))).to eql(["==", "line\nnext"])
+        expect(extract_operator_and_operand_from_comparison(%q(== "tab\there"))).to eql(["==", "tab\there"])
+        expect(extract_operator_and_operand_from_comparison(%q(== "quote\"inside"))).to eql(["==", 'quote"inside'])
+        # Single quoted strings only escape the backslash and the single quote
+        expect(extract_operator_and_operand_from_comparison(%q(== 'line\nnext'))).to eql(["==", 'line\nnext'])
+        expect(extract_operator_and_operand_from_comparison(%q(== 'it\'s'))).to eql(["==", "it's"])
+      end
+
+      it "should preserve the encoding of a double quoted operand" do
+        comparison = %q(== "plain").dup.force_encoding(Encoding::UTF_8)
+        expect(extract_operator_and_operand_from_comparison(comparison)[1].encoding).to eql(Encoding::UTF_8)
+        # A \xHH escape can produce a byte which is not valid UTF-8
+        comparison = %q(== "\xff\xfe").dup.force_encoding(Encoding::UTF_8)
+        operand = extract_operator_and_operand_from_comparison(comparison)[1]
+        expect(operand.encoding).to eql(Encoding::ASCII_8BIT)
+        expect(operand.bytes).to eql([0xFF, 0xFE])
+      end
+
+      it "should require a single complete quoted literal" do
+        expect { extract_operator_and_operand_from_comparison(%q(== 'a' garbage 'b')) }.to raise_error(/ERROR: Unable to parse operand/)
+        expect { extract_operator_and_operand_from_comparison(%q(== 'unterminated)) }.to raise_error(/ERROR: Unable to parse operand/)
+      end
+
+      it "should reject ambiguous leading zero integers" do
+        # Ruby reads 010 as octal 8 while Python rejects it outright so require 0o10 or 10
+        expect { extract_operator_and_operand_from_comparison("== 010") }.to raise_error(/ERROR: Unable to parse operand: 010/)
+        expect(extract_operator_and_operand_from_comparison("== 0o10")).to eql(["==", 8])
+        expect(extract_operator_and_operand_from_comparison("== 10")).to eql(["==", 10])
+        # A leading zero is not ambiguous for a float
+        expect(extract_operator_and_operand_from_comparison("== 010.5")).to eql(["==", 10.5])
+      end
+
+      it "should parse numbers with underscore separators" do
+        expect(extract_operator_and_operand_from_comparison("== 1_000")).to eql(["==", 1000])
+        expect(extract_operator_and_operand_from_comparison("== 1_000.5")).to eql(["==", 1000.5])
+      end
+
+      it "should support the full set of double quoted escape sequences" do
+        expect(extract_operator_and_operand_from_comparison(%q(== "\u{1F600}"))).to eql(["==", "\u{1F600}"])
+        expect(extract_operator_and_operand_from_comparison(%q(== "\u{48 49}"))).to eql(["==", "HI"])
+        expect(extract_operator_and_operand_from_comparison(%q(== "é"))).to eql(["==", "é"])
+        # Octal escapes, e.g. \101 is 'A' and \012 is a newline
+        expect(extract_operator_and_operand_from_comparison(%q(== "\101"))).to eql(["==", "A"])
+        expect(extract_operator_and_operand_from_comparison(%q(== "\012"))).to eql(["==", "\n"])
+        expect(extract_operator_and_operand_from_comparison(%q(== "\0"))[1].bytes).to eql([0])
+        # Ruby drops the backslash of an escape which has no special meaning
+        expect(extract_operator_and_operand_from_comparison(%q(== "\q"))).to eql(["==", "q"])
+      end
+
+      it "should reject escape sequences it does not implement" do
+        # Silently dropping the backslash would change the value so these are errors
+        expect { extract_operator_and_operand_from_comparison(%q(== "\cA")) }.to raise_error(/Unsupported escape sequence/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "\C-A")) }.to raise_error(/Unsupported escape sequence/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "\M-A")) }.to raise_error(/Unsupported escape sequence/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "\M-\C-A")) }.to raise_error(/Unsupported escape sequence/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "\u")) }.to raise_error(/Invalid escape sequence/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "\x")) }.to raise_error(/Invalid escape sequence/)
+      end
+
+      it "should reject unescaped string interpolation" do
+        # The eval based implementation interpolated this. Interpolating is code execution so
+        # it is now an error rather than a silent comparison against the uninterpolated text.
+        expect { extract_operator_and_operand_from_comparison(%q(== "Temp #{1 + 1}")) }.to \
+          raise_error(/String interpolation is not supported in an operand/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "#@ivar")) }.to \
+          raise_error(/String interpolation is not supported in an operand/)
+        expect { extract_operator_and_operand_from_comparison(%q(== "#$global")) }.to \
+          raise_error(/String interpolation is not supported in an operand/)
+      end
+
+      it "should keep escaped interpolation and a bare hash as literal text" do
+        expect(extract_operator_and_operand_from_comparison(%q(== "\#{1 + 1}"))).to eql(["==", '#{1 + 1}'])
+        # Ruby single quoted strings never interpolate
+        expect(extract_operator_and_operand_from_comparison(%q(== '#{1 + 1}'))).to eql(["==", '#{1 + 1}'])
+        expect(extract_operator_and_operand_from_comparison(%q(== "cost #5"))).to eql(["==", "cost #5"])
+      end
+
+      it "should parse list elements with the same rules as a bare operand" do
+        expect(extract_operator_and_operand_from_comparison(%q(in ['ON', 'OFF']))).to eql(["in", ["ON", "OFF"]])
+        expect(extract_operator_and_operand_from_comparison("in [0xA, 0o17, 1_000]")).to eql(["in", [10, 15, 1000]])
+        expect(extract_operator_and_operand_from_comparison("in [true, nil]")).to eql(["in", [true, nil]])
+        expect(extract_operator_and_operand_from_comparison("in []")).to eql(["in", []])
+        expect(extract_operator_and_operand_from_comparison("in [[1, 2], [3]]")).to eql(["in", [[1, 2], [3]]])
+        # Commas and brackets inside a quoted element do not split it
+        expect(extract_operator_and_operand_from_comparison(%q(in ['a,b', '[c]']))).to eql(["in", ["a,b", "[c]"]])
+      end
+
+      it "should allow a trailing comma like a Ruby or Python list literal" do
+        expect(extract_operator_and_operand_from_comparison("in [1,]")).to eql(["in", [1]])
+      end
+
+      it "should reject malformed lists" do
+        expect { extract_operator_and_operand_from_comparison("in [1,,2]") }.to raise_error(/ERROR: Unable to parse operand/)
+        expect { extract_operator_and_operand_from_comparison("in [,1]") }.to raise_error(/ERROR: Unable to parse operand/)
+        expect { extract_operator_and_operand_from_comparison("in [1, 2]]") }.to raise_error(/ERROR: Unable to parse operand/)
+        expect { extract_operator_and_operand_from_comparison(%q(in ['unterminated])) }.to raise_error(/ERROR: Unable to parse operand/)
+      end
+
+      it "should allow underscore separators in an exponent" do
+        expect(extract_operator_and_operand_from_comparison("== 1e1_0")).to eql(["==", 1e10])
+      end
+
+      it "should require a list operand for the in operator" do
+        expect { extract_operator_and_operand_from_comparison("in 'abc'") }.to \
+          raise_error(/ERROR: The 'in' operator requires a list operand/)
+        expect { extract_operator_and_operand_from_comparison("in 5") }.to \
+          raise_error(/ERROR: The 'in' operator requires a list operand/)
+      end
+    end
+
+    describe "compare_values" do
+      it "should compare with all the supported operators" do
+        expect(compare_values(1, "==", 1)).to be true
+        expect(compare_values(1, "!=", 1)).to be false
+        expect(compare_values(2, ">", 1)).to be true
+        expect(compare_values(1, ">=", 1)).to be true
+        expect(compare_values(1, "<", 2)).to be true
+        expect(compare_values(1, "<=", 1)).to be true
+        expect(compare_values(2, "in", [1, 2, 3])).to be true
+        expect(compare_values(4, "in", [1, 2, 3])).to be false
+      end
+
+      it "should return false when the types can not be compared" do
+        expect(compare_values(nil, ">", 1)).to be false
+        expect(compare_values(1, ">", nil)).to be false
+        expect(compare_values("STRING", ">", 1)).to be false
+        # 'in' is containment against a list, matching Python, so a String operand is not a match
+        expect(compare_values(1, "in", 1)).to be false
+        expect(compare_values("a", "in", "abc")).to be false
+      end
+
+      it "should complain about invalid operators" do
+        expect { compare_values(1, "&", 1) }.to raise_error(/ERROR: Invalid operator: '&'/)
       end
     end
   end


### PR DESCRIPTION
### What changed

check validated the comparison operator while wait and wait_check passed the text straight to eval, so compound expressions such as "TIMEUS & 0x0001 == 0x0000" silently worked in two of the three APIs. All three now share one parser and comparator, and eval is gone from the comparison path entirely (check_expression and friends still use it by design). Operands are parsed as literals, which adds hex, octal, binary, underscore separators and recursive list elements, and rejects ambiguous or unparsable forms up front instead of after a timeout.

### Why it changed

Closes #3802 which was the different behavior between wait and wait_check. This also closes potential security escapes by not using eval. 

### Testing strategy

Added a bunch new unit tests. Ran various script code in COSMOS 7.3 and compared output to this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)