### PR TITLE
skip build scripts during uv sync

### DIFF
--- a/openc3/Dockerfile
+++ b/openc3/Dockerfile
@@ -50,13 +50,13 @@ COPY --chown=${IMAGE_USER}:${IMAGE_GROUP} python/pyproject.toml python/uv.lock p
 # UV_CACHE_DIR). Routing the sync through a mount and copying it into the seed
 # afterwards would bake wheels from unrelated past builds into the image, which
 # is exactly what verify-uv-cache.sh exists to prevent.
-RUN UV_CACHE_DIR=/openc3/uv_cache uv sync --frozen --no-dev --no-install-project
+RUN UV_CACHE_DIR=/openc3/uv_cache uv sync --no-build --frozen --no-dev --no-install-project
 
 # Copy application code (excluding .venv from source)
 COPY --chown=${IMAGE_USER}:${IMAGE_GROUP} python/ .
 
 # Install the application itself with dependencies already present
-RUN UV_CACHE_DIR=/openc3/uv_cache uv sync --frozen --no-dev
+RUN UV_CACHE_DIR=/openc3/uv_cache uv sync --no-build --frozen --no-dev
 
 WORKDIR /openc3/
 


### PR DESCRIPTION
### What changed

Add `--no-build` to `uv sync` in `openc3/Dockerfile`

### Why it changed

SonarQube major warning about running installation scripts

### Testing strategy

`openc3.sh build` and CI

### Review notes

[SonarQube issues](https://sonarcloud.io/project/issues?id=OpenC3_cosmos&cleanCodeAttributeCategories=RESPONSIBLE&languages=docker&s=IMPACT_RANK&issueStatuses=OPEN%2CCONFIRMED)