### PR TITLE
fix: add missing requires so spec files run standalone

### DIFF
--- a/openc3/lib/openc3/interfaces/interface.rb
+++ b/openc3/lib/openc3/interfaces/interface.rb
@@ -15,6 +15,7 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
+require 'openc3/packets/packet'
 require 'openc3/api/api'
 require 'openc3/logs/stream_log_pair'
 require 'openc3/utilities/secrets'

--- a/openc3/lib/openc3/io/win32_serial_driver.rb
+++ b/openc3/lib/openc3/io/win32_serial_driver.rb
@@ -16,6 +16,7 @@
 # if purchased from OpenC3, Inc.
 
 require 'openc3/win32/win32'
+require 'openc3/io/serial_driver'
 require 'timeout' # For Timeout::Error
 
 module OpenC3

--- a/openc3/lib/openc3/processors/processor.rb
+++ b/openc3/lib/openc3/processors/processor.rb
@@ -15,6 +15,8 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
+require 'openc3/packets/packet'
+
 module OpenC3
   class Processor
     # @return [Symbol] The value type for the processor

--- a/openc3/spec/conversions/packet_time_formatted_conversion_spec.rb
+++ b/openc3/spec/conversions/packet_time_formatted_conversion_spec.rb
@@ -18,6 +18,7 @@
 require 'spec_helper'
 require 'openc3/conversions/packet_time_formatted_conversion'
 require 'openc3/packets/packet'
+require 'openc3/conversions/generic_conversion'
 
 module OpenC3
   describe PacketTimeFormattedConversion do

--- a/openc3/spec/conversions/packet_time_seconds_conversion_spec.rb
+++ b/openc3/spec/conversions/packet_time_seconds_conversion_spec.rb
@@ -18,6 +18,7 @@
 require 'spec_helper'
 require 'openc3/conversions/packet_time_seconds_conversion'
 require 'openc3/packets/packet'
+require 'openc3/conversions/generic_conversion'
 
 module OpenC3
   describe PacketTimeSecondsConversion do

--- a/openc3/spec/interfaces/protocols/cobs_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/cobs_protocol_spec.rb
@@ -14,6 +14,7 @@
 require 'spec_helper'
 require 'openc3/interfaces/protocols/cobs_protocol'
 require 'openc3/interfaces/interface'
+require 'openc3/interfaces/stream_interface'
 require 'openc3/streams/stream'
 
 module OpenC3

--- a/openc3/spec/interfaces/protocols/crc_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/crc_protocol_spec.rb
@@ -17,7 +17,9 @@
 
 require 'spec_helper'
 require 'openc3/interfaces/protocols/crc_protocol'
+require 'openc3/interfaces/protocols/burst_protocol'
 require 'openc3/interfaces/interface'
+require 'openc3/interfaces/stream_interface'
 require 'openc3/streams/stream'
 
 module OpenC3

--- a/openc3/spec/interfaces/protocols/length_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/length_protocol_spec.rb
@@ -18,6 +18,7 @@
 require 'spec_helper'
 require 'openc3/interfaces/protocols/length_protocol'
 require 'openc3/interfaces/interface'
+require 'openc3/interfaces/stream_interface'
 require 'openc3/streams/stream'
 
 module OpenC3

--- a/openc3/spec/interfaces/protocols/preidentified_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/preidentified_protocol_spec.rb
@@ -18,6 +18,7 @@
 require 'spec_helper'
 require 'openc3/interfaces/protocols/preidentified_protocol'
 require 'openc3/interfaces/interface'
+require 'openc3/interfaces/stream_interface'
 require 'openc3/streams/stream'
 
 module OpenC3

--- a/openc3/spec/interfaces/protocols/slip_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/slip_protocol_spec.rb
@@ -14,6 +14,7 @@
 require 'spec_helper'
 require 'openc3/interfaces/protocols/slip_protocol'
 require 'openc3/interfaces/interface'
+require 'openc3/interfaces/stream_interface'
 require 'openc3/streams/stream'
 
 module OpenC3

--- a/openc3/spec/interfaces/protocols/terminated_protocol_spec.rb
+++ b/openc3/spec/interfaces/protocols/terminated_protocol_spec.rb
@@ -18,6 +18,7 @@
 require 'spec_helper'
 require 'openc3/interfaces/protocols/terminated_protocol'
 require 'openc3/interfaces/interface'
+require 'openc3/interfaces/stream_interface'
 require 'openc3/streams/stream'
 
 module OpenC3

--- a/openc3/spec/interfaces/tcpip_server_interface_spec.rb
+++ b/openc3/spec/interfaces/tcpip_server_interface_spec.rb
@@ -16,6 +16,7 @@
 # if purchased from OpenC3, Inc.
 
 require 'spec_helper'
+require 'openc3/interfaces'
 require 'openc3/interfaces/tcpip_server_interface'
 
 module OpenC3

--- a/openc3/spec/utilities/bucket_utilities_spec.rb
+++ b/openc3/spec/utilities/bucket_utilities_spec.rb
@@ -12,6 +12,7 @@
 # if purchased from OpenC3, Inc.
 
 require "spec_helper"
+require "ostruct"
 require "openc3/utilities/bucket_utilities"
 
 module OpenC3


### PR DESCRIPTION
### What changed

- Require openc3/packets/packet in interface.rb and processor.rb: the C extension defines a partial OpenC3::Packet that satisfies defined? and so blocks the full Ruby class from ever loading
- Require openc3/io/serial_driver in win32_serial_driver, which uses SerialDriver::VALID_PARITY and the parity constants
- Require stream_interface in six protocol specs, plus burst_protocol in crc_protocol_spec, which use them as test harnesses
- Require openc3/interfaces in tcpip_server_interface_spec so StreamInterface can resolve protocol classes via require_class
- Require generic_conversion in two conversion specs and ostruct in bucket_utilities_spec

### Why it changed

These files resolved constants through full-suite load order rather than their own requires, so running a spec file alone raised NameError or LoadError.

### Testing strategy

Ran the unit tests individually