### PR TITLE
fix flaky file menu tests

### DIFF
--- a/playwright/tests/script-runner/file-menu.p.spec.ts
+++ b/playwright/tests/script-runner/file-menu.p.spec.ts
@@ -151,13 +151,14 @@ test('handles File->Save new file', async ({ page, utils }) => {
 })
 
 test('handles File Save overwrite', async ({ page, utils }) => {
+  const file = 'INST/procedures/save_overwrite.rb'
+
   await page.locator('textarea').fill('puts "File Save overwrite"')
   await page.locator('[data-test=script-runner-file]').click()
   await page.locator('text=Save File').click()
   await expect(page.locator('text=File Save As')).toBeVisible()
-  await page
-    .locator('[data-test=file-open-save-filename] input')
-    .fill('INST/procedures/save_overwrite.rb')
+  await page.locator('[data-test=file-open-save-filename] input').fill(file)
+  const saved = utils.saveComplete(file)
   await page.locator('[data-test=file-open-save-submit-btn]').click()
 
   // If the file already exists from a previous parallel run, handle the overwrite dialog
@@ -173,35 +174,46 @@ test('handles File Save overwrite', async ({ page, utils }) => {
     page.getByRole('dialog').filter({ hasText: 'File Save As...' }),
   ).not.toBeVisible()
   // Wait for save to complete before continuing
-  await expect(page.getByText('Saving...')).not.toBeVisible()
-  await expect(page.locator('#sr-controls')).toContainText(
-    'INST/procedures/save_overwrite.rb',
-  )
+  await saved
+  await expect(page.locator('#sr-controls')).toContainText(file)
 
   await page.locator('textarea').fill('# comment1')
+  // The ' *' is fileModified: proof the editor registered the edit before we
+  // ask it to save.
+  await expect(page.locator('#sr-controls')).toContainText(`${file} *`)
+  const savedFromMenu = utils.saveComplete(file)
   await page.locator('[data-test=script-runner-file]').click()
   await page.locator('text=Save File').click()
   // Wait for save to complete before continuing
-  await expect(page.getByText('Saving...')).not.toBeVisible()
+  await savedFromMenu
+
   await page.locator('textarea').fill('# comment2')
-  if (process.platform === 'darwin') {
-    await page.locator('textarea').press('Meta+S') // Ctrl-S save
-  } else {
-    await page.locator('textarea').press('Control+S') // Ctrl-S save
-  }
-  // Wait for save to complete before continuing
-  await expect(page.getByText('Saving...')).not.toBeVisible()
+  await expect(page.locator('#sr-controls')).toContainText(`${file} *`)
+  const savedFromCtrlS = utils.saveComplete(file)
+  await utils.ctrlS()
+  await savedFromCtrlS
 
   // File->Save As
   await page.locator('[data-test=script-runner-file]').click()
   await page.locator('text=Save As...').click()
+  // The dialog builds its tree from the listing once in created(). The submit
+  // button is enabled exactly when every target has finished loading
+  // (disableButtons === false), and until then success() silently no-ops, so
+  // this is the gate for clicking SAVE.
+  await expect(
+    page.locator('[data-test=file-open-save-submit-btn]'),
+  ).toBeEnabled()
   await expect(
     page.locator('[data-test=file-open-save-filename] input'),
-  ).toHaveValue('INST/procedures/save_overwrite.rb')
+  ).toHaveValue(file)
+  const resaved = utils.saveComplete(file)
   await page.locator('[data-test=file-open-save-submit-btn]').click()
   // Confirmation dialog
   await page.locator('text=Are you sure you want to overwrite').click()
   await page.locator('button:has-text("Overwrite")').click()
+  // Wait for the save itself, not the snackbar, so the delete below cannot
+  // race the POST that rewrites the file.
+  await resaved
 
   // Delete the file
   await page.locator('[data-test=script-runner-file]').click()
@@ -219,29 +231,51 @@ test('handles File Save overwrite', async ({ page, utils }) => {
 test('strips the modified marker on Save As', async ({ page, utils }) => {
   const original = 'INST/procedures/throughput_test.rb'
 
+  // reloadFile() issues this on mount. Registered before the goto so the
+  // response can't land before we're listening.
+  const bodyLoaded = utils.fileLoaded(original)
+
   // throughput_test.rb is used by no other spec, and deleting it at the end
   // removes only the targets_modified copy, restoring the plugin's original.
   await page.goto(`/tools/scriptrunner?file=${original}`, {
     waitUntil: 'domcontentloaded',
   })
   await expect(page.locator('.v-app-bar')).toContainText('Script Runner')
-  await expect(page.locator('#sr-controls')).toContainText(original)
+  // #sr-controls shows the filename as soon as it is read off the route query,
+  // before reloadFile() has awaited the body -- and saveFile() refuses to run
+  // at all while that load is in flight (saveAllowed === false). Asserting on
+  // the editor contents is not an option: a targets_modified copy left behind
+  // by an earlier run makes them unpredictable. So wait for the response, then
+  // for the Start button, which setFile() re-enables in the same tick it
+  // installs the contents. The response wait is what makes the button check
+  // meaningful -- startOrGoDisabled defaults to false, so on its own it could
+  // pass before reloadFile() had set it.
+  await bodyLoaded
+  await expect(page.locator('[data-test=start-button]')).toBeEnabled()
 
   // Write a comment to mark the file as modified, then save it so the marker appears in the listing.
   await page.locator('textarea').fill('# comment2')
-  if (process.platform === 'darwin') {
-    await page.locator('textarea').press('Meta+S') // Ctrl-S save
-  } else {
-    await page.locator('textarea').press('Control+S') // Ctrl-S save
-  }
-  // Wait for save to complete before continuing
-  await expect(page.getByText('Saving...')).not.toBeVisible()
+  // The ' *' is fileModified: proof the editor registered the edit before we
+  // ask it to save.
+  await expect(page.locator('#sr-controls')).toContainText(`${original} *`)
+  const saved = utils.saveComplete(original)
+  await utils.ctrlS()
+  // The targets_modified copy -- and so the '*' in the listing the dialog is
+  // about to fetch -- does not exist until this response lands. The dialog
+  // builds its tree once in created() and never refreshes, so opening it early
+  // means the marker never shows up at all.
+  await saved
 
   await page.locator('[data-test=script-runner-file]').click()
   await page.locator('text=Save As...').click()
-  // The dialog builds its tree from the listing on created(), so wait for every
-  // target to finish loading before reading the field or the tree.
-  await expect(page.getByRole('progressbar')).not.toBeVisible()
+  // The dialog builds its tree from the listing on created(), and the submit
+  // button is enabled exactly when every target has finished loading
+  // (disableButtons === false). That gates reading the tree, reading the
+  // field (each loadFiles() completion re-assigns it from inputFilename) and
+  // clicking SAVE (success() no-ops while the buttons are disabled).
+  await expect(
+    page.locator('[data-test=file-open-save-submit-btn]'),
+  ).toBeEnabled()
   await expect(
     page.locator('[data-test=file-open-save-filename] input'),
   ).toHaveValue(original)
@@ -251,7 +285,9 @@ test('strips the modified marker on Save As', async ({ page, utils }) => {
     .fill('throughput_test.rb')
   // Precondition: without the marker actually present in the tree this test
   // would pass no matter what the dialog does with it.
-  const marked = page.getByText('throughput_test.rb*', { exact: true })
+  const marked = page
+    .locator('.tree-container')
+    .getByText('throughput_test.rb*', { exact: true })
   await expect(marked).toBeVisible()
 
   // Selecting the marked file must fill in the clean path. toHaveValue is an
@@ -262,6 +298,7 @@ test('strips the modified marker on Save As', async ({ page, utils }) => {
   ).toHaveValue(original)
 
   // And the overwrite confirmation quotes the clean path, not the marked one
+  const resaved = utils.saveComplete(original)
   await page.locator('[data-test=file-open-save-submit-btn]').click()
   await expect(page.getByText(`overwrite: ${original}`)).toBeVisible()
   await page.locator('button:has-text("Overwrite")').click()
@@ -269,7 +306,9 @@ test('strips the modified marker on Save As', async ({ page, utils }) => {
   await expect(
     page.getByRole('dialog').filter({ hasText: 'File Save As...' }),
   ).not.toBeVisible()
-  await expect(page.getByText('Saving...')).not.toBeVisible()
+  // Wait for the save itself, not the snackbar, so the delete below cannot
+  // race the POST that rewrites the file.
+  await resaved
   await expect(page.locator('#sr-controls')).toContainText(original)
 
   // Delete the targets_modified copy so the plugin's original is restored
@@ -277,6 +316,9 @@ test('strips the modified marker on Save As', async ({ page, utils }) => {
   await page.locator('text=Delete File').click()
   await expect(page.locator('text=Permanently delete file')).toBeVisible()
   await page.locator('button:has-text("Delete")').click()
+  // newFile() only runs once the delete POST resolves, so this confirms the
+  // cleanup actually happened rather than leaving the copy behind.
+  await expect(page.locator('#sr-controls')).toContainText('<Untitled>')
 })
 
 test('handles Download', async ({ page, utils }) => {

--- a/playwright/utilities.ts
+++ b/playwright/utilities.ts
@@ -12,7 +12,7 @@
 # All Rights Reserved
 */
 
-import { type Page, expect } from '@playwright/test'
+import { type Page, type Response, expect } from '@playwright/test'
 import * as fs from 'node:fs'
 export class Utilities {
   readonly page: Page
@@ -157,5 +157,55 @@ export class Utilities {
           .innerText()
       })
       .toMatch(regex)
+  }
+
+  // Press the editor's save shortcut (Cmd-S on macOS, Ctrl-S elsewhere).
+  // Pair with saveComplete() -- the keypress only fires the request.
+  async ctrlS() {
+    await this.page
+      .locator('textarea')
+      .press(process.platform === 'darwin' ? 'Meta+S' : 'Control+S')
+  }
+
+  // Resolves once the server has accepted the save of `filename`.
+  //
+  // Register it BEFORE the action that triggers the save and await it after,
+  // so the listener exists before the response can land:
+  //
+  //   const saved = utils.saveComplete(file)
+  //   await utils.ctrlS()
+  //   await saved
+  //
+  // The "Saving..." snackbar cannot serve as this gate: ScriptRunner sets
+  // showSave *after* issuing the POST and leaves it up for 2s after success,
+  // so `expect(getByText('Saving...')).not.toBeVisible()` passes vacuously on
+  // a starved runner and lets the next step race the in-flight save. That
+  // matters most before opening a file dialog, which builds its tree from a
+  // one-shot listing fetch and never refreshes it.
+  saveComplete(filename: string): Promise<Response> {
+    return this.scriptApiResponse(filename, 'POST')
+  }
+
+  // Resolves once ScriptRunner's reloadFile() fetch of `filename` has
+  // returned, i.e. the contents are about to be installed in the editor.
+  fileLoaded(filename: string): Promise<Response> {
+    return this.scriptApiResponse(filename, 'GET')
+  }
+
+  // Match the pathname exactly rather than by substring: the '/delete',
+  // '/lock' and '/syntax' endpoints all sit under the script's own path and
+  // would otherwise resolve the wrong wait. Requiring 200 means a missing
+  // file fails the wait instead of quietly letting the test continue.
+  private scriptApiResponse(
+    filename: string,
+    method: 'GET' | 'POST',
+  ): Promise<Response> {
+    return this.page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname ===
+          `/script-api/scripts/${filename}` &&
+        response.request().method() === method &&
+        response.status() === 200,
+    )
   }
 }


### PR DESCRIPTION
### What changed

Improved `strips the modified marker on Save As` and `handles File Save overwrite` tests to avoid race conditions from vacuous waits

### Why it changed

Based on flaky report from [this enterprise build](https://github.com/OpenC3/cosmos-enterprise/actions/runs/34281347621/job/102246578429)

### Testing strategy

Ran updated tests 20 times each locally against enterprise and core to ensure they passed