### PR TITLE
fix(logs): flag and read CBOR extra on RAW_PACKET entries

### DIFF
--- a/openc3/lib/openc3/logs/packet_log_reader.rb
+++ b/openc3/lib/openc3/logs/packet_log_reader.rb
@@ -142,7 +142,7 @@ module OpenC3
         end
       elsif flags & OPENC3_ENTRY_TYPE_MASK == OPENC3_RAW_PACKET_ENTRY_TYPE_MASK
         packet_index, time_nsec_since_epoch = entry[2..11].unpack('nQ>')
-        received_time_nsec_since_epoch, _extra, packet_data = handle_received_time_extra_and_data(entry, time_nsec_since_epoch, includes_received_time, includes_extra, cbor)
+        received_time_nsec_since_epoch, extra, packet_data = handle_received_time_extra_and_data(entry, time_nsec_since_epoch, includes_received_time, includes_extra, cbor)
         lookup_cmd_or_tlm, target_name, packet_name, _id = @packets[packet_index]
         if cmd_or_tlm != lookup_cmd_or_tlm
           raise "Packet type mismatch, packet:#{cmd_or_tlm}, lookup:#{lookup_cmd_or_tlm}"
@@ -159,6 +159,10 @@ module OpenC3
         packet.set_received_time_fast(received_time)
         packet.cmd_or_tlm = cmd_or_tlm
         packet.stored = stored
+        # Assigned unconditionally because identify_and_define_packet_data
+        # returns the shared System packet, so a nil extra here must clear
+        # the extra left over from a previous read of the same packet
+        packet.extra = extra
         packet.received_count += 1
         return packet
       elsif flags & OPENC3_ENTRY_TYPE_MASK == OPENC3_TARGET_DECLARATION_ENTRY_TYPE_MASK
@@ -304,7 +308,24 @@ module OpenC3
         if cbor
           extra = CBOR.decode(extra_encoded)
         else
-          extra = JSON.parse(extra_encoded, allow_nan: true, create_additions: true)
+          begin
+            extra = JSON.parse(extra_encoded, allow_nan: true, create_additions: true)
+          rescue JSON::ParserError => e
+            # PacketLogWriter up to version 7.3.0 CBOR encoded the extra on
+            # RAW_PACKET entries without setting OPENC3_CBOR_FLAG_MASK, so the
+            # flag claims JSON while the bytes are CBOR. Retry as CBOR so those
+            # existing files can still be read. extra is always a Hash, so a
+            # decode to anything else means these bytes aren't the legacy
+            # encoding either and the original JSON error is the useful one.
+            decoded = begin
+              CBOR.decode(extra_encoded)
+            rescue StandardError
+              raise e
+            end
+            raise e unless Hash === decoded
+
+            extra = decoded
+          end
         end
       end
       data = entry[next_offset..-1]

--- a/openc3/lib/openc3/logs/packet_log_writer.rb
+++ b/openc3/lib/openc3/logs/packet_log_writer.rb
@@ -311,6 +311,11 @@ module OpenC3
           extra = JSON.parse(extra, allow_nan: true, create_additions: true) if String === extra
           length += OPENC3_EXTRA_LENGTH_FIXED_SIZE
           if @data_format == :CBOR
+            # The reader uses this same flag to pick the extra decoder, so it
+            # must be set here as well as in the JSON_PACKET data branch above.
+            # RAW_PACKET entries never reach that branch and would otherwise
+            # write CBOR extra that the reader tries to JSON.parse.
+            flags |= OPENC3_CBOR_FLAG_MASK
             extra_encoded = extra.as_json.to_cbor
           else
             extra_encoded = JSON.generate(extra.as_json, allow_nan: true)

--- a/openc3/spec/logs/packet_log_writer_spec.rb
+++ b/openc3/spec/logs/packet_log_writer_spec.rb
@@ -219,6 +219,117 @@ module OpenC3
         FileUtils.rm_f 'test_log.bin'
       end
 
+      %i[CBOR JSON].each do |data_format|
+        it "round trips RAW_PACKET extra using #{data_format}" do
+          time = Time.now.to_nsec_from_epoch
+          timestamp = Time.from_nsec_from_epoch(time).to_timestamp
+          label = 'extra'
+          plw = PacketLogWriter.new(@log_dir, label)
+          plw.data_format = data_format
+          extra = { 'username' => 'test', 'count' => 5 }
+          plw.write(:RAW_PACKET, :TLM, 'TGT1', 'PKT1', time, false, "\x01\x02", nil, '0-0', extra: extra)
+          # A second packet without extra to prove a stale extra isn't carried over
+          plw.write(:RAW_PACKET, :TLM, 'TGT1', 'PKT1', time, false, "\x03\x04", nil, '0-0')
+          threads = plw.shutdown
+          threads.each { |t| t.join }
+
+          bin = @files["#{timestamp}__#{timestamp}__#{label}.bin.gz"]
+          gz = Zlib::GzipReader.new(StringIO.new(bin))
+          File.open('test_log.bin', 'wb') { |file| file.write gz.read }
+          reader = PacketLogReader.new
+          reader.open('test_log.bin')
+          # The extra must decode without raising regardless of data_format,
+          # which requires the writer to flag CBOR encoded extra
+          pkt = reader.read
+          expect(pkt.target_name).to eq 'TGT1'
+          expect(pkt.packet_name).to eq 'PKT1'
+          expect(pkt.buffer).to eq "\x01\x02"
+          expect(pkt.extra).to eq extra
+          pkt = reader.read
+          expect(pkt.buffer).to eq "\x03\x04"
+          expect(pkt.extra).to be_nil
+          reader.close()
+          FileUtils.rm_f 'test_log.bin'
+        end
+
+        it "clears a stale RAW_PACKET extra on a defined packet using #{data_format}" do
+          time = Time.now.to_nsec_from_epoch
+          timestamp = Time.from_nsec_from_epoch(time).to_timestamp
+          label = 'stale'
+          # INST HEALTH_STATUS is defined, so the reader identifies and defines
+          # it and hands back the shared System packet on every read
+          buffer = System.telemetry.packet('INST', 'HEALTH_STATUS').buffer
+          plw = PacketLogWriter.new(@log_dir, label)
+          plw.data_format = data_format
+          extra = { 'username' => 'test' }
+          plw.write(:RAW_PACKET, :TLM, 'INST', 'HEALTH_STATUS', time, false, buffer, nil, '0-0', extra: extra)
+          plw.write(:RAW_PACKET, :TLM, 'INST', 'HEALTH_STATUS', time, false, buffer, nil, '0-0')
+          threads = plw.shutdown
+          threads.each { |t| t.join }
+
+          bin = @files["#{timestamp}__#{timestamp}__#{label}.bin.gz"]
+          gz = Zlib::GzipReader.new(StringIO.new(bin))
+          File.open('test_log.bin', 'wb') { |file| file.write gz.read }
+          reader = PacketLogReader.new
+          reader.open('test_log.bin')
+          pkt = reader.read
+          expect(pkt.extra).to eq extra
+          pkt = reader.read
+          expect(pkt.extra).to be_nil
+          reader.close()
+          FileUtils.rm_f 'test_log.bin'
+        end
+      end
+
+      it "reads a pre-7.3.1 RAW_PACKET extra written as CBOR without the CBOR flag" do
+        time = Time.now.to_nsec_from_epoch
+        timestamp = Time.from_nsec_from_epoch(time).to_timestamp
+        label = 'legacy'
+        extra = { 'username' => 'test', 'count' => 5 }
+        plw = PacketLogWriter.new(@log_dir, label)
+        plw.write(:RAW_PACKET, :TLM, 'TGT1', 'PKT1', time, false, "\x01\x02", nil, '0-0', extra: extra)
+        threads = plw.shutdown
+        threads.each { |t| t.join }
+
+        bin = @files["#{timestamp}__#{timestamp}__#{label}.bin.gz"]
+        gz = Zlib::GzipReader.new(StringIO.new(bin))
+        bin = gz.read
+        # Turn the file into what the pre-7.3.1 writer produced by clearing
+        # PacketLogConstants::OPENC3_CBOR_FLAG_MASK on the RAW_PACKET entries, leaving the extra
+        # CBOR encoded while the flag claims JSON
+        offset = PacketLogConstants::OPENC3_HEADER_LENGTH
+        cleared = 0
+        while offset < bin.length
+          length = bin[offset, 4].unpack1('N')
+          flags = bin[(offset + 4), 2].unpack1('n')
+          if flags & PacketLogConstants::OPENC3_ENTRY_TYPE_MASK == PacketLogConstants::OPENC3_RAW_PACKET_ENTRY_TYPE_MASK
+            expect(flags & PacketLogConstants::OPENC3_CBOR_FLAG_MASK).to eq PacketLogConstants::OPENC3_CBOR_FLAG_MASK
+            bin[(offset + 4), 2] = [flags & ~PacketLogConstants::OPENC3_CBOR_FLAG_MASK].pack('n')
+            cleared += 1
+          end
+          offset += 4 + length
+        end
+        expect(cleared).to eq 1
+
+        File.open('test_log.bin', 'wb') { |file| file.write bin }
+        reader = PacketLogReader.new
+        reader.open('test_log.bin')
+        pkt = reader.read
+        expect(pkt.buffer).to eq "\x01\x02"
+        expect(pkt.extra).to eq extra
+        reader.close()
+        FileUtils.rm_f 'test_log.bin'
+      end
+
+      it "raises the JSON error when a JSON flagged extra is neither JSON nor CBOR" do
+        reader = PacketLogReader.new
+        garbage = "\xff\xfe\xfd"
+        entry = "\x00" * 12 + [garbage.length].pack('N') + garbage
+        expect {
+          reader.send(:handle_received_time_extra_and_data, entry, 0, false, true, false)
+        }.to raise_error(JSON::ParserError)
+      end
+
       it "correctly writes multiple files in a row" do
         first_time = Time.now.to_nsec_from_epoch
         last_time = first_time += 1_000_000_000


### PR DESCRIPTION
### What changed

- Set OPENC3_CBOR_FLAG_MASK when CBOR encoding extra in PacketLogWriter#write_entry, matching packet_log_writer.py
- Assign packet.extra on RAW_PACKET reads, which PacketLogReader discarded, dropping extra through DecomCommon on reingest
- Retry CBOR.decode on JSON::ParserError so raw logs written before this fix stay readable

### Why it changed

PacketLogWriter CBOR encoded the extra on RAW_PACKET entries without setting OPENC3_CBOR_FLAG_MASK, so PacketLogReader picked JSON.parse for CBOR bytes and raised JSON::ParserError. Any interface that sets packet.extra made its raw logs unreadable, failing reingest jobs and raw streaming reads.

### Testing strategy

Unit tests