### PR TITLE
fix(scripts): resolve shellcheck findings and handle arguments safely

### DIFF
--- a/docs.openc3.com/build.sh
+++ b/docs.openc3.com/build.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 pnpm install --frozen-lockfile --ignore-scripts
 cd scripts && ruby generate_docs_from_yaml.rb && cd ..
 pnpm build

--- a/openc3-cosmos-cmd-tlm-api/spec/run_tests.sh
+++ b/openc3-cosmos-cmd-tlm-api/spec/run_tests.sh
@@ -1,16 +1,18 @@
+#!/bin/bash
+
 export RUBYGEMS_URL=https://rubygems.org
-openc3_path=$(dirname $(dirname $(pwd)))
+openc3_path=$(dirname "$(dirname "$PWD")")
 openc3_path+="/openc3"
 export OPENC3_DEVEL=$openc3_path
 echo "OPENC3_DEVEL set to $OPENC3_DEVEL"
 
 bundle config set --local with :DEVELOPMENT
 
-cd ../..
+cd ../.. || exit 1
 bundle install
-cd openc3
+cd openc3 || exit 1
 bundle install
 bundle exec rake build
-cd ../openc3-cosmos-cmd-tlm-api
+cd ../openc3-cosmos-cmd-tlm-api || exit 1
 bundle install
 bundle exec rspec

--- a/openc3-cosmos-init/init.sh
+++ b/openc3-cosmos-init/init.sh
@@ -8,8 +8,7 @@
 # Only OPENC3_DEMO uses this so far - the OPENC3_NO_* flags below are still
 # presence-only, where "VAR=0" and "VAR=false" mean ON.
 flag_enabled() {
-    local value="$1"
-    case "$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')" in
+    case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
         '' | 0 | false) return 1 ;;
         *) return 0 ;;
     esac
@@ -144,7 +143,7 @@ if [ "${OPENC3_CLOUD}" = "local" ]; then
                 probe_conn "${bhost}" "${bport}"
             fi
         fi
-        if [ $(date +%s) -ge $deadline ]; then
+        if [ "$(date +%s)" -ge "$deadline" ]; then
             echo "${T} ERROR: timed out after ${OPENC3_INIT_WAIT_TIMEOUT}s waiting for buckets ${OPENC3_BUCKET_URL}; exiting to restart init"
             exit 1
         fi
@@ -168,7 +167,7 @@ while [ $RC -gt 0 ]; do
             probe_conn "${hostname}" "${OPENC3_REDIS_PORT}"
         fi
     fi
-    if [ $(date +%s) -ge $deadline ]; then
+    if [ "$(date +%s)" -ge "$deadline" ]; then
         echo "${T} ERROR: timed out after ${OPENC3_INIT_WAIT_TIMEOUT}s waiting for Redis ${hostname}:${OPENC3_REDIS_PORT}; exiting to restart init"
         exit 1
     fi
@@ -190,7 +189,7 @@ while [ $RC -gt 0 ]; do
             probe_conn "${hostname}" "${OPENC3_REDIS_EPHEMERAL_PORT}"
         fi
     fi
-    if [ $(date +%s) -ge $deadline ]; then
+    if [ "$(date +%s)" -ge "$deadline" ]; then
         echo "${T} ERROR: timed out after ${OPENC3_INIT_WAIT_TIMEOUT}s waiting for Redis Ephemeral ${hostname}:${OPENC3_REDIS_EPHEMERAL_PORT}; exiting to restart init"
         exit 1
     fi

--- a/openc3-cosmos-init/init.sh
+++ b/openc3-cosmos-init/init.sh
@@ -7,12 +7,14 @@
 # who writes it. An unrecognized value stays on, matching the old behavior.
 # Only OPENC3_DEMO uses this so far - the OPENC3_NO_* flags below are still
 # presence-only, where "VAR=0" and "VAR=false" mean ON.
-flag_enabled() {
-    case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+# Use a subshell to keep value local without the non-POSIX local keyword.
+flag_enabled() (
+    value="$1"
+    case "$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')" in
         '' | 0 | false) return 1 ;;
         *) return 0 ;;
     esac
-}
+)
 
 # Seed the UV wheel cache from the Docker image into the runtime volume
 # so plugins can reuse system wheels without re-downloading (critical for airgapped environments)

--- a/openc3-cosmos-init/verify-uv-cache.sh
+++ b/openc3-cosmos-init/verify-uv-cache.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Copyright 2026 OpenC3, Inc.
 # All Rights Reserved.
 #
@@ -9,7 +10,6 @@
 # This file may also be used under the terms of a commercial license
 # if purchased from OpenC3, Inc.
 
-#!/bin/sh
 # Build-time assertion: every plugin gem shipped in this image that declares
 # BOTH uv.lock and pyproject.toml must be able to install its Python
 # dependencies from the baked UV cache with NO network.

--- a/openc3-ruby/shoreman.sh
+++ b/openc3-ruby/shoreman.sh
@@ -65,7 +65,10 @@ load_env_file() {
   export PORT=${PORT:-5000}
 
   if [[ -f "$env_file" ]]; then
-    export $(grep "^[^#]*=.*" "$env_file" | xargs)
+    local assignment
+    while IFS= read -r -d '' assignment; do
+      [[ -n "$assignment" ]] && export "${assignment?}"
+    done < <(grep "^[^#]*=.*" "$env_file" | xargs printf '%s\0')
   fi
 }
 
@@ -109,7 +112,6 @@ main() {
 
   trap onexit INT TERM
 
-  exitcode=0
   while true; do
     for pid in $pids; do
       # Wait for the children to finish executing before exiting.

--- a/openc3-tsdb/docker-entrypoint.sh
+++ b/openc3-tsdb/docker-entrypoint.sh
@@ -10,11 +10,6 @@ QUESTDB_UID="${QUESTDB_UID:-"$(id -u questdb)"}"
 QUESTDB_GID="${QUESTDB_GID:-"$(id -g questdb)"}"
 JAVA_COMMAND="/app/bin/java"
 
-# directories inside QUESTDB_DATA_DIR that we will chown
-DEFAULT_LOCAL_DIRS=${DEFAULT_LOCAL_DIRS:-"/conf /public /db /.checkpoint /snapshot"}
-array=( ${DEFAULT_LOCAL_DIRS} )
-read -ra LOCALDIRS < <( echo -n "( "; printf -- "-ipath ${QUESTDB_DATA_DIR}%s* -o " "${array[@]:0:$((${#array[@]} - 1))}"; echo -n "-ipath ${QUESTDB_DATA_DIR}${array[@]: -1}*"; echo " )";)
-
 # backwards compatibility with previous versions
 # if [ ${IGNORE_FIND_AND_OWN_DIR+x} ]
 # then
@@ -48,7 +43,7 @@ if [[ $# -eq 0 ]]; then
     set -- $JAVA_COMMAND -ea -Dnoebug -XX:+UseParallelGC -XX:ErrorFile=${QUESTDB_DATA_DIR}/db/hs_err_pid+%p.log -Dout=${QUESTDB_DATA_DIR}/conf/log.conf -m io.questdb/io.questdb.ServerMain -d ${QUESTDB_DATA_DIR} -f
 else
     if [[ "${1:0:1}" == '-' ]]; then
-        echo "Found config arguments $@"
+        echo "Found config arguments $*"
         set -- $JAVA_COMMAND "$@"
     elif [[ "$1" == "/app/bin/java" ]]; then
         echo "Java binary argument found in command, ignoring on-demand JVM arguments, start with fully-customized arguments"

--- a/openc3.sh
+++ b/openc3.sh
@@ -88,7 +88,8 @@ run_with_registry_check() {
 # alone would clobber them, so their values are saved first and restored
 # afterwards.
 source_env_files() {
-  local dir="$(dirname -- "$0")"
+  local dir
+  dir="$(dirname -- "$0")"
   local -a env_files=()
   local file key
   if [[ -f "$dir/${ENV_FILE:-.env}" ]]; then
@@ -109,10 +110,12 @@ source_env_files() {
 
   set -a
   for file in "${env_files[@]}"; do
+    # Env files are selected at runtime and may be outside the repository.
+    # shellcheck source=/dev/null
     . "$file"
   done
   for key in "${preset[@]}"; do
-    export "$key"
+    export "${key?}"
   done
   set +a
 }
@@ -160,8 +163,9 @@ fi
 $CONTAINER_CMD info | grep -e "rootless$" -e "rootless: true"
 if [[ "$?" -ne 0 ]]; then
   export OPENC3_ROOTFUL=1
-  export OPENC3_USER_ID=`id -u`
-  export OPENC3_GROUP_ID=`id -g`
+  OPENC3_USER_ID=$(id -u)
+  OPENC3_GROUP_ID=$(id -g)
+  export OPENC3_USER_ID OPENC3_GROUP_ID
 else
   export OPENC3_ROOTLESS=1
   export OPENC3_USER_ID=0
@@ -376,7 +380,8 @@ resolve_openc3_tag() {
   if [[ -n "$OPENC3_TAG" ]]; then
     return
   fi
-  local dir="$(dirname -- "$0")"
+  local dir
+  dir="$(dirname -- "$0")"
   local env_file
   for env_file in "$dir/.env.local" "$dir/${ENV_FILE:-.env}"; do
     if [[ -f "$env_file" ]]; then
@@ -399,7 +404,8 @@ build_core_images() {
   if [[ "$OPENC3_TAG" != "latest" ]]; then
     return
   fi
-  local core_dir="$(dirname -- "$0")/../cosmos"
+  local core_dir
+  core_dir="$(dirname -- "$0")/../cosmos"
   if [[ -f "$core_dir/compose-build.yaml" ]]; then
     echo "Building core images from $core_dir ..."
     ${DOCKER_COMPOSE_COMMAND} --project-directory "$core_dir" \
@@ -467,9 +473,9 @@ case $1 in
       * ) CLI_SERVICE=openc3-cosmos-cmd-tlm-api ;;
     esac
     if [[ "$OPENC3_ENTERPRISE" -eq 1 ]]; then
-      ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm -v $(pwd):/openc3/local:z -w /openc3/local -e OPENC3_API_USER=$OPENC3_API_USER -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps $CLI_SERVICE ruby /openc3/bin/openc3cli "$@"
+      ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm -v "$PWD:/openc3/local:z" -w /openc3/local -e OPENC3_API_USER=$OPENC3_API_USER -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps $CLI_SERVICE ruby /openc3/bin/openc3cli "$@"
     else
-      ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm -v $(pwd):/openc3/local:z -w /openc3/local -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps $CLI_SERVICE ruby /openc3/bin/openc3cli "$@"
+      ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm -v "$PWD:/openc3/local:z" -w /openc3/local -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps $CLI_SERVICE ruby /openc3/bin/openc3cli "$@"
     fi
     ;;
   cliroot )
@@ -516,9 +522,9 @@ case $1 in
     # Shift off the first argument (script name) to get CLI args
     shift
     if [[ "$OPENC3_ENTERPRISE" -eq 1 ]]; then
-      ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm --user=root -v $(pwd):/openc3/local:z -w /openc3/local -e OPENC3_API_USER=$OPENC3_API_USER -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli "$@"
+      ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm --user=root -v "$PWD:/openc3/local:z" -w /openc3/local -e OPENC3_API_USER=$OPENC3_API_USER -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli "$@"
     else
-      ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm --user=root -v $(pwd):/openc3/local:z -w /openc3/local -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli "$@"
+      ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" run -it --rm --user=root -v "$PWD:/openc3/local:z" -w /openc3/local -e OPENC3_API_PASSWORD=$OPENC3_API_PASSWORD --no-deps openc3-cosmos-cmd-tlm-api ruby /openc3/bin/openc3cli "$@"
     fi
     ;;
   start )
@@ -658,9 +664,14 @@ case $1 in
     fi
     if [[ "$2" == "local" ]]
     then
-      cd "$(dirname -- "$0")/plugins/DEFAULT"
-      ls | grep -xv "README.md" | xargs rm -r
-      cd ../..
+      (
+        cd "$(dirname -- "$0")/plugins/DEFAULT" || exit 1
+        for entry in *; do
+          [[ "$entry" == "README.md" ]] && continue
+          [[ -e "$entry" || -L "$entry" ]] || continue
+          rm -r -- "$entry"
+        done
+      )
     fi
     ;;
   list )
@@ -831,16 +842,16 @@ case $1 in
     umask 0022
     chmod -R +r "$(dirname -- "$0")"
     # Collect any additional build flags from arguments (skip first arg which is "build")
-    BUILD_FLAGS="${@:2}"
+    BUILD_FLAGS=("${@:2}")
     if [[ "$OPENC3_ENTERPRISE" -eq 1 ]]; then
-      build_core_images $BUILD_FLAGS
-      run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build $BUILD_FLAGS openc3-enterprise-gem
+      build_core_images "${BUILD_FLAGS[@]}"
+      run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build "${BUILD_FLAGS[@]}" openc3-enterprise-gem
     else
-      run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build $BUILD_FLAGS openc3-ruby
-      run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build $BUILD_FLAGS openc3-base
-      run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build $BUILD_FLAGS openc3-node
+      run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build "${BUILD_FLAGS[@]}" openc3-ruby
+      run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build "${BUILD_FLAGS[@]}" openc3-base
+      run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build "${BUILD_FLAGS[@]}" openc3-node
     fi
-    run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build $BUILD_FLAGS
+    run_with_registry_check ${CONTAINER_COMPOSE_CMD} "${COMPOSE_FILE_ARGS[@]}" -f "$(dirname -- "$0")/compose-build.yaml" build "${BUILD_FLAGS[@]}"
     ;;
   build-ubi )
     if [[ "$OPENC3_DEVEL" -eq 0 ]]; then

--- a/playwright/playwright.sh
+++ b/playwright/playwright.sh
@@ -77,7 +77,7 @@ case $1 in
         fi
         rm -rf openc3-cosmos-pw-test
         ../openc3.sh cli generate plugin PW_TEST --ruby
-        cd openc3-cosmos-pw-test
+        cd openc3-cosmos-pw-test || exit 1
         ../../openc3.sh cli generate target PW_TEST --ruby
         # Give the plugin Python dependencies so PluginModel runs uvinstall and
         # creates a per-plugin venv. Without one, Script Runner's Python venv
@@ -96,7 +96,7 @@ case $1 in
         ../../openc3.sh cli rake build VERSION=1.0.0
         cp openc3-cosmos-pw-test-1.0.0.gem openc3-cosmos-pw-test-1.0.1.gem
         ../../openc3.sh cli validate openc3-cosmos-pw-test-1.0.0.gem
-        cd -
+        cd - || exit 1
         ;;
 
     reset-storage-state )
@@ -185,7 +185,7 @@ case $1 in
             exit 0
         fi
         sed -i.bak 's#http://localhost:2900#https://aws.openc3.com#' playwright.config.ts && rm -f playwright.config.ts.bak
-        KEYCLOAK_URL=https://aws.openc3.com/auth/admin/master/console REDIRECT_URL=https://aws.openc3.com/* pnpm test:keycloak
+        KEYCLOAK_URL=https://aws.openc3.com/auth/admin/master/console REDIRECT_URL="https://aws.openc3.com/*" pnpm test:keycloak
         pnpm test:enterprise
         ;;
 esac

--- a/scripts/linux/benchmark_s3_migration.sh
+++ b/scripts/linux/benchmark_s3_migration.sh
@@ -13,8 +13,6 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 # Colors for output (using $'...' syntax for portability)
 RED=$'\033[0;31m'
 GREEN=$'\033[0;32m'
@@ -123,12 +121,15 @@ run_migration_benchmark() {
     run_mc mb "openc3s3/${BENCHMARK_BUCKET}" >/dev/null 2>&1 || true
 
     # Time the mirror operation
-    local start_time=$(get_time)
+    local start_time
+    start_time=$(get_time)
 
     run_mc mirror --preserve --overwrite "openc3minio/${BENCHMARK_BUCKET}" "openc3s3/${BENCHMARK_BUCKET}" >&2
 
-    local end_time=$(get_time)
-    local duration=$(echo "$end_time - $start_time" | bc)
+    local end_time
+    end_time=$(get_time)
+    local duration
+    duration=$(echo "$end_time - $start_time" | bc)
 
     # Only the duration goes to stdout (for capture)
     echo "$duration"
@@ -151,7 +152,8 @@ calc_rate() {
         return
     fi
 
-    local rate=$(echo "scale=2; $size_mb / $duration" | bc 2>/dev/null)
+    local rate
+    rate=$(echo "scale=2; $size_mb / $duration" | bc 2>/dev/null) || rate=""
     if [[ -z "$rate" ]]; then
         echo "N/A"
     else
@@ -172,13 +174,18 @@ format_duration() {
     if (( $(echo "$seconds < 60" | bc -l) )); then
         printf "%.2f seconds" "$seconds"
     elif (( $(echo "$seconds < 3600" | bc -l) )); then
-        local mins=$(echo "scale=0; $seconds / 60" | bc)
-        local secs=$(echo "scale=2; $seconds - ($mins * 60)" | bc)
+        local mins
+        mins=$(echo "scale=0; $seconds / 60" | bc)
+        local secs
+        secs=$(echo "scale=2; $seconds - ($mins * 60)" | bc)
         printf "%d min %.2f sec" "$mins" "$secs"
     else
-        local hours=$(echo "scale=0; $seconds / 3600" | bc)
-        local mins=$(echo "scale=0; ($seconds - $hours * 3600) / 60" | bc)
-        local secs=$(echo "scale=2; $seconds - ($hours * 3600) - ($mins * 60)" | bc)
+        local hours
+        hours=$(echo "scale=0; $seconds / 3600" | bc)
+        local mins
+        mins=$(echo "scale=0; ($seconds - $hours * 3600) / 60" | bc)
+        local secs
+        secs=$(echo "scale=2; $seconds - ($hours * 3600) - ($mins * 60)" | bc)
         printf "%d hr %d min %.2f sec" "$hours" "$mins" "$secs"
     fi
 }
@@ -199,11 +206,14 @@ run_benchmark() {
     generate_test_data "$size_mb"
 
     # Run migration and capture duration
-    local duration=$(run_migration_benchmark)
+    local duration
+    duration=$(run_migration_benchmark)
 
     # Calculate rate
-    local rate=$(calc_rate "$size_mb" "$duration")
-    local formatted_duration=$(format_duration "$duration")
+    local rate
+    rate=$(calc_rate "$size_mb" "$duration")
+    local formatted_duration
+    formatted_duration=$(format_duration "$duration")
 
     # Clean up
     cleanup_test_data
@@ -276,8 +286,10 @@ print_summary() {
         echo "${CYAN}Estimated times based on measured rate (${rate} MB/s):${NC}"
         for estimate_gb in 50 100 500 1000; do
             local estimate_mb=$((estimate_gb * 1024))
-            local est_seconds=$(echo "scale=2; $estimate_mb / $rate" | bc)
-            local est_formatted=$(format_duration "$est_seconds")
+            local est_seconds
+            est_seconds=$(echo "scale=2; $estimate_mb / $rate" | bc)
+            local est_formatted
+            est_formatted=$(format_duration "$est_seconds")
             printf "  %4d GB: %s\n" "$estimate_gb" "$est_formatted"
         done
         echo ""

--- a/scripts/linux/openc3_build_ubi.sh
+++ b/scripts/linux/openc3_build_ubi.sh
@@ -58,8 +58,16 @@ fi
 
 set -e
 
-# Save the script's starting directory for use in helper functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Match individual array entries exactly, including arguments containing spaces.
+contains_image() {
+  local requested="$1"
+  local image
+  shift
+  for image in "$@"; do
+    [[ "$image" == "$requested" ]] && return 0
+  done
+  return 1
+}
 
 # Parse command line arguments to separate build flags from image names
 BUILD_FLAGS=()
@@ -81,7 +89,7 @@ else
   # Validate provided image names
   for arg in "${REMAINING_ARGS[@]}"; do
     # Check if the image is in the available list
-    if [[ " ${AVAILABLE_IMAGES[@]} " =~ " ${arg} " ]]; then
+    if contains_image "$arg" "${AVAILABLE_IMAGES[@]}"; then
       IMAGES_TO_BUILD+=("$arg")
     else
       echo "Error: Unknown image '${arg}'" >&2
@@ -92,7 +100,7 @@ else
       exit 1
     fi
   done
-  echo "Building specified images: ${IMAGES_TO_BUILD[@]}"
+  echo "Building specified images: ${IMAGES_TO_BUILD[*]}"
 fi
 
 # Detect container runtime
@@ -101,7 +109,7 @@ then
   if command -v podman &> /dev/null
   then
     function docker() {
-      podman $@
+      podman "$@"
     }
   else
     echo "Neither docker nor podman found!!!"
@@ -164,8 +172,7 @@ chmod -R +r . 2>/dev/null || echo "Warning: Could not set all files readable (th
 # Helper function to check if an image should be built
 should_build() {
   local image_name="$1"
-  [[ " ${IMAGES_TO_BUILD[@]} " =~ " ${image_name} " ]]
-  return $?
+  contains_image "$image_name" "${IMAGES_TO_BUILD[@]}"
 }
 
 # Helper function to format duration in human-readable format

--- a/scripts/linux/openc3_migrate_s3.sh
+++ b/scripts/linux/openc3_migrate_s3.sh
@@ -70,8 +70,6 @@ NC='\033[0m' # No Color
 # State variables
 MINIO_SOURCE=""        # Where to read MINIO data from (live or temp container)
 VERSITY_DEST=""        # Where to write versitygw data to (live or temp container)
-USING_TEMP_MINIO=false
-USING_TEMP_VERSITY=false
 DOCKER_NETWORK=""
 
 usage() {
@@ -235,16 +233,13 @@ detect_environment() {
     live_minio=$(find_container "openc3-minio")
     if [[ -n "$live_minio" ]] && [[ "$live_minio" != "$MINIO_MIGRATION_CONTAINER" ]]; then
         MINIO_SOURCE="$live_minio"
-        USING_TEMP_MINIO=false
         log_info "Found live MINIO (COSMOS 6): $MINIO_SOURCE"
         DOCKER_NETWORK=$(get_container_network "$MINIO_SOURCE")
     elif container_running "$MINIO_MIGRATION_CONTAINER"; then
         MINIO_SOURCE="$MINIO_MIGRATION_CONTAINER"
-        USING_TEMP_MINIO=true
         log_info "Using temp MINIO container: $MINIO_SOURCE"
     else
         MINIO_SOURCE=""
-        USING_TEMP_MINIO=true
         log_info "No MINIO running - will start temp container"
     fi
 
@@ -253,18 +248,15 @@ detect_environment() {
     live_versity=$(find_container "openc3-buckets")
     if [[ -n "$live_versity" ]] && [[ "$live_versity" != "$VERSITY_MIGRATION_CONTAINER" ]]; then
         VERSITY_DEST="$live_versity"
-        USING_TEMP_VERSITY=false
         log_info "Found live versitygw (COSMOS 7): $VERSITY_DEST"
         if [[ -z "$DOCKER_NETWORK" ]]; then
             DOCKER_NETWORK=$(get_container_network "$VERSITY_DEST")
         fi
     elif container_running "$VERSITY_MIGRATION_CONTAINER"; then
         VERSITY_DEST="$VERSITY_MIGRATION_CONTAINER"
-        USING_TEMP_VERSITY=true
         log_info "Using temp versitygw container: $VERSITY_DEST"
     else
         VERSITY_DEST=""
-        USING_TEMP_VERSITY=true
         log_info "No versitygw running - will start temp container"
     fi
 

--- a/scripts/linux/openc3_setup.sh
+++ b/scripts/linux/openc3_setup.sh
@@ -31,7 +31,7 @@ then
   if command -v podman &> /dev/null
   then
     function docker() {
-      podman $@
+      podman "$@"
     }
   else
     echo "Neither docker nor podman found!!!"

--- a/scripts/linux/openc3_util.sh
+++ b/scripts/linux/openc3_util.sh
@@ -183,8 +183,8 @@ push() {
 }
 
 clean_files() {
-  find . -type d -name "node_modules" -exec sh -c 'echo "Removing {}"; rm -rf "{}"' \;
-  find . -type d -name "coverage" -exec sh -c 'echo "Removing {}"; rm -rf "{}"' \;
+  find . -type d -name "node_modules" -exec sh -c 'echo "Removing $1"; rm -rf -- "$1"' sh {} \;
+  find . -type d -name "coverage" -exec sh -c 'echo "Removing $1"; rm -rf -- "$1"' sh {} \;
   # Prompt for removing pnpm-lock.yaml files
   find . -type f -name "pnpm-lock.yaml" -exec rm -i {} \;
   # Prompt for removing Gemfile.lock files

--- a/scripts/release/build_multi_arch.sh
+++ b/scripts/release/build_multi_arch.sh
@@ -27,7 +27,7 @@ cd ../..
 while IFS='=' read -r key value; do
   [[ -z "$key" || "$key" == \#* ]] && continue
   printf -v "$key" '%s' "${!key:-$value}"
-  export "$key"
+  export "${key?}"
 done < .env
 # OPENC3_REGISTRY=localhost:5000 # Uncomment for local builds
 # OPENC3_ENTERPRISE_REGISTRY=localhost:5000 # Uncomment for local builds


### PR DESCRIPTION
Preserve argument boundaries, guard directory changes, and handle cleanup filenames safely. Correct shebangs, separate declarations from command assignments, and remove unused variables.

### What changed

Fixed shell lint findings across 14 scripts, including quoting, arrays, shebangs, unused variables, and safer file cleanup.

### Why it changed

Resolves #3796 and prevents argument splitting, unsafe filename handling, and cleanup in the wrong directory when `cd` fails.

### Testing strategy

ShellCheck reported zero warnings or errors in affected scripts. Shell syntax checks and smoke checks passed for environment parsing, argument preservation, image matching, and unusual filenames.

### Review notes

Focus on cleanup handling in `openc3.sh`, environment parsing in `shoreman.sh`, and build argument forwarding. Full container builds and migrations were not run.
