### PR TITLE
fix(bucket-file-cache): make unreserve release the reservation

### DIFF
--- a/openc3-cosmos-cmd-tlm-api/app/models/message_file_reader.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/message_file_reader.rb
@@ -49,6 +49,21 @@ class MessageFileReader
       end
     end
     return false
+  ensure
+    close()
+  end
+
+  # Release every file still open. next_log_entry only unreserves a file once
+  # its reader runs out of entries, so returning early -- reaching @end_time, or
+  # the caller breaking out of each to cancel -- would otherwise leak those
+  # reservations for the life of the process, keeping the files on disk and out
+  # of reach of BucketFileCache's age out sweep.
+  def close
+    @open_readers.each do |reader|
+      reader.close
+      BucketFileCache.unreserve(reader.bucket_file)
+    end
+    @open_readers = []
   end
 
   def read

--- a/openc3-cosmos-cmd-tlm-api/app/models/streaming_object_file_reader.rb
+++ b/openc3-cosmos-cmd-tlm-api/app/models/streaming_object_file_reader.rb
@@ -48,6 +48,23 @@ class StreamingObjectFileReader
       end
     end
     return false
+  ensure
+    close()
+  end
+
+  # Release every file still open. next_packet_and_topic only unreserves a file
+  # once its reader runs out of packets, so returning early -- reaching
+  # @end_time, or the caller breaking out of each to cancel -- would otherwise
+  # leak those reservations for the life of the process, keeping the files on
+  # disk and out of reach of BucketFileCache's age out sweep.
+  # Offsets are deliberately not applied here: the stream is over in both cases,
+  # and the handoff to realtime only uses offsets from readers that finished.
+  def close
+    @open_readers.each do |reader|
+      reader.close
+      BucketFileCache.unreserve(reader.bucket_file)
+    end
+    @open_readers = []
   end
 
   def read

--- a/openc3-cosmos-cmd-tlm-api/spec/models/message_file_reader_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/models/message_file_reader_spec.rb
@@ -242,6 +242,72 @@ RSpec.describe MessageFileReader, type: :model do
     end
   end
 
+  describe "#close" do
+    let(:reader) { MessageFileReader.new(start_time: start_time, end_time: end_time, scope: scope) }
+
+    # next_log_entry only unreserves a file once its reader runs out of entries.
+    # Anything that ends the read early leaves the rest reserved, and a
+    # reservation that is never released also blocks BucketFileCache from
+    # aging the file out, so it stays on disk for the life of the process.
+    it "releases files that are still open" do
+      reader1 = double("reader1")
+      reader2 = double("reader2")
+      bucket_file1 = double("bucket_file1")
+      bucket_file2 = double("bucket_file2")
+      allow(reader1).to receive(:bucket_file).and_return(bucket_file1)
+      allow(reader2).to receive(:bucket_file).and_return(bucket_file2)
+      reader.instance_variable_set(:@open_readers, [reader1, reader2])
+
+      expect(reader1).to receive(:close)
+      expect(reader2).to receive(:close)
+      expect(@bucket_file_cache).to receive(:unreserve).with(bucket_file1)
+      expect(@bucket_file_cache).to receive(:unreserve).with(bucket_file2)
+
+      reader.close
+
+      expect(reader.instance_variable_get(:@open_readers)).to be_empty
+    end
+
+    it "does nothing when no files are open" do
+      reader.instance_variable_set(:@open_readers, [])
+      expect(@bucket_file_cache).to_not receive(:unreserve)
+      expect { reader.close }.to_not raise_error
+    end
+
+    it "releases open files when each stops at the end time" do
+      reader1 = double("reader1", close: nil)
+      bucket_file1 = double("bucket_file1")
+      allow(reader1).to receive(:bucket_file).and_return(bucket_file1)
+      # Sits past @end_time so each returns on the first entry, before this
+      # reader ever runs out and gets unreserved the normal way
+      allow(reader1).to receive(:next_entry_time).and_return(end_time + 1)
+      allow(reader1).to receive(:read).and_return({"time" => (end_time + 1).to_s})
+      allow(reader).to receive(:open_current_files)
+      reader.instance_variable_set(:@open_readers, [reader1])
+
+      expect(@bucket_file_cache).to receive(:unreserve).with(bucket_file1)
+
+      expect(reader.each { |_entry| }).to be true
+      expect(reader.instance_variable_get(:@open_readers)).to be_empty
+    end
+
+    it "releases open files when the caller breaks out of each" do
+      reader1 = double("reader1", close: nil)
+      bucket_file1 = double("bucket_file1")
+      allow(reader1).to receive(:bucket_file).and_return(bucket_file1)
+      allow(reader1).to receive(:next_entry_time).and_return(start_time + 1)
+      allow(reader1).to receive(:read).and_return({"time" => (start_time + 1).to_s})
+      allow(reader).to receive(:open_current_files)
+      reader.instance_variable_set(:@open_readers, [reader1])
+
+      expect(@bucket_file_cache).to receive(:unreserve).with(bucket_file1)
+
+      reader.each { |_entry| break } # How a cancelled stream unwinds
+
+      expect(reader.instance_variable_get(:@open_readers)).to be_empty
+    end
+  end
+
   describe "#build_file_list" do
     let(:reader) { MessageFileReader.new(start_time: start_time, end_time: end_time, scope: scope) }
 

--- a/openc3-cosmos-cmd-tlm-api/spec/models/streaming_object_file_reader_spec.rb
+++ b/openc3-cosmos-cmd-tlm-api/spec/models/streaming_object_file_reader_spec.rb
@@ -1,0 +1,123 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require "rails_helper"
+
+RSpec.describe StreamingObjectFileReader, type: :model do
+  let(:start_time) { Time.at(1748151200) }
+  let(:end_time) { Time.at(1748152200) }
+  let(:scope) { "DEFAULT" }
+  let(:collection) do
+    double(
+      "StreamingObjectCollection",
+      target_info: [["INST__TLM__RAW"], start_time, end_time, {}],
+      apply_last_offsets: nil,
+    )
+  end
+  let(:reader) { StreamingObjectFileReader.new(collection, scope: scope) }
+
+  before(:each) do
+    @bucket_file_cache = class_double("BucketFileCache")
+    stub_const("BucketFileCache", @bucket_file_cache)
+    allow(@bucket_file_cache).to receive(:hint)
+    allow(@bucket_file_cache).to receive(:unreserve)
+
+    @bucket_utilities = class_double("OpenC3::BucketUtilities")
+    stub_const("OpenC3::BucketUtilities", @bucket_utilities)
+    allow(@bucket_utilities).to receive(:files_between_time).and_return([])
+  end
+
+  # Builds a reader double sitting on a single packet at the given time
+  def log_reader(time, bucket_file)
+    packet = double("packet", packet_time: time, packet_name: "HEALTH_STATUS")
+    double(
+      "BufferedPacketLogReader",
+      next_packet_time: time,
+      buffered_read: packet,
+      bucket_file: bucket_file,
+      last_offsets: {},
+      close: nil,
+    )
+  end
+
+  def bucket_file(name)
+    double(name, topic_prefix: "DEFAULT__TELEMETRY__{INST}")
+  end
+
+  describe "#close" do
+    # next_packet_and_topic only unreserves a file once its reader runs out of
+    # packets. Anything that ends the read early leaves the rest reserved, and
+    # a reservation that is never released also blocks BucketFileCache from
+    # aging the file out, so it stays on disk for the life of the process.
+    it "releases files that are still open" do
+      file1 = bucket_file("bucket_file1")
+      file2 = bucket_file("bucket_file2")
+      reader1 = log_reader(start_time, file1)
+      reader2 = log_reader(start_time, file2)
+      reader.instance_variable_set(:@open_readers, [reader1, reader2])
+
+      expect(reader1).to receive(:close)
+      expect(reader2).to receive(:close)
+      expect(@bucket_file_cache).to receive(:unreserve).with(file1)
+      expect(@bucket_file_cache).to receive(:unreserve).with(file2)
+
+      reader.close
+
+      expect(reader.instance_variable_get(:@open_readers)).to be_empty
+    end
+
+    it "does nothing when no files are open" do
+      reader.instance_variable_set(:@open_readers, [])
+      expect(@bucket_file_cache).to_not receive(:unreserve)
+      expect { reader.close }.to_not raise_error
+    end
+
+    it "releases open files when each stops at the end time" do
+      file1 = bucket_file("bucket_file1")
+      # Sits past @end_time so each returns on the first packet, before this
+      # reader ever runs out and gets unreserved the normal way
+      reader.instance_variable_set(:@open_readers, [log_reader(end_time + 1, file1)])
+      allow(reader).to receive(:open_current_files)
+
+      expect(@bucket_file_cache).to receive(:unreserve).with(file1)
+
+      expect(reader.each { |_packet, _topic| }).to be true
+      expect(reader.instance_variable_get(:@open_readers)).to be_empty
+    end
+
+    it "releases open files when the caller breaks out of each" do
+      file1 = bucket_file("bucket_file1")
+      reader.instance_variable_set(:@open_readers, [log_reader(start_time + 1, file1)])
+      allow(reader).to receive(:open_current_files)
+
+      expect(@bucket_file_cache).to receive(:unreserve).with(file1)
+
+      reader.each { |_packet, _topic| break } # How a cancelled stream unwinds
+
+      expect(reader.instance_variable_get(:@open_readers)).to be_empty
+    end
+
+    it "leaves nothing reserved when every reader runs out normally" do
+      file1 = bucket_file("bucket_file1")
+      exhausted = double("BufferedPacketLogReader", next_packet_time: nil, bucket_file: file1,
+                                                    last_offsets: {}, close: nil)
+      reader.instance_variable_set(:@open_readers, [exhausted])
+      allow(reader).to receive(:open_current_files)
+
+      # Unreserved once by next_packet_and_topic, and not again by close
+      expect(@bucket_file_cache).to receive(:unreserve).with(file1).once
+
+      expect(reader.each { |_packet, _topic| }).to be false
+    end
+  end
+end

--- a/openc3/lib/openc3/utilities/bucket_file_cache.rb
+++ b/openc3/lib/openc3/utilities/bucket_file_cache.rb
@@ -244,18 +244,26 @@ class BucketFileCache
   # @param bucket_file_or_path [BucketFile|String] BucketFile or its bucket path
   def unreserve(bucket_file_or_path)
     if bucket_file_or_path.is_a?(BucketFile)
-      bucket_path = bucket_file_or_path.bucket_path
+      released = bucket_file_or_path
+      bucket_path = released.bucket_path
     else
+      released = nil
       bucket_path = bucket_file_or_path
     end
     @@mutex.synchronize do
       bucket_file = @bucket_file_hash[bucket_path]
-      if bucket_file
-        bucket_file.unreserve
-        if bucket_file.reservation_count <= 0 and !@queued_path_hash[bucket_path]
-          @current_disk_usage -= bucket_file.size
-          @bucket_file_hash.delete(bucket_path)
-        end
+      return if bucket_file.nil?
+      # Releasing to zero drops the entry, so the next reserve of the same path
+      # builds a new BucketFile. A BucketFile that is no longer the entry for
+      # its path was therefore already released, and releasing it again would
+      # decrement its replacement and delete a local file another reader still
+      # has open. Only the current owner of the path may release it.
+      return unless released.nil? or released.equal?(bucket_file)
+
+      bucket_file.unreserve
+      if bucket_file.reservation_count <= 0 and !@queued_path_hash[bucket_path]
+        @current_disk_usage -= bucket_file.size
+        @bucket_file_hash.delete(bucket_path)
       end
     end
   end

--- a/openc3/lib/openc3/utilities/bucket_file_cache.rb
+++ b/openc3/lib/openc3/utilities/bucket_file_cache.rb
@@ -163,6 +163,10 @@ class BucketFileCache
 
     @current_disk_usage = 0
     @queued_bucket_files = []
+    # Mirrors @queued_bucket_files as bucket_path => true. Membership is checked
+    # once per file close in unreserve() and once per entry in age_out_files(),
+    # both of which are O(cache size) linear scans against the bare Array.
+    @queued_path_hash = {}
     @bucket_file_hash = {}
     bucket_file = nil
 
@@ -176,6 +180,7 @@ class BucketFileCache
         if @queued_bucket_files.length > 0 and @current_disk_usage < MAX_DISK_USAGE
           @@mutex.synchronize do
             bucket_file = @queued_bucket_files.shift
+            @queued_path_hash.delete(bucket_file.bucket_path) if bucket_file
           end
           begin
             retrieved = bucket_file.retrieve(client)
@@ -229,6 +234,7 @@ class BucketFileCache
       retrieved = bucket_file.reserve
       @current_disk_usage += bucket_file.size if retrieved
       @queued_bucket_files.delete(bucket_file)
+      @queued_path_hash.delete(bucket_path)
       return bucket_file
     end
   end
@@ -246,7 +252,7 @@ class BucketFileCache
       bucket_file = @bucket_file_hash[bucket_path]
       if bucket_file
         bucket_file.unreserve
-        if bucket_file.reservation_count <= 0 and !@queued_bucket_files.include?(bucket_file)
+        if bucket_file.reservation_count <= 0 and !@queued_path_hash[bucket_path]
           @current_disk_usage -= bucket_file.size
           @bucket_file_hash.delete(bucket_path)
         end
@@ -261,8 +267,8 @@ class BucketFileCache
   # thread would re-add their size to @current_disk_usage after removal.
   def age_out_files
     @@mutex.synchronize do
-      @bucket_file_hash.delete_if do |_bucket_path, bucket_file|
-        next false if @queued_bucket_files.include?(bucket_file)
+      @bucket_file_hash.delete_if do |bucket_path, bucket_file|
+        next false if @queued_path_hash[bucket_path]
         if bucket_file.age_check
           @current_disk_usage -= bucket_file.size
           true
@@ -278,6 +284,7 @@ class BucketFileCache
     unless bucket_file
       bucket_file = BucketFile.new(bucket_path)
       @queued_bucket_files << bucket_file
+      @queued_path_hash[bucket_path] = true
       @bucket_file_hash[bucket_path] = bucket_file
     end
     return bucket_file

--- a/openc3/lib/openc3/utilities/bucket_file_cache.rb
+++ b/openc3/lib/openc3/utilities/bucket_file_cache.rb
@@ -166,10 +166,13 @@ class BucketFileCache
     @bucket_file_hash = {}
     bucket_file = nil
 
+    # NOTE: check_time must be initialized outside the loop or it is pushed
+    # forward on every iteration and the age out check below never fires
+    check_time = Time.now + CHECK_TIME_SECONDS # Check for aged out files periodically
+
     @thread = Thread.new do
       client = OpenC3::Bucket.getClient()
       while true
-        check_time = Time.now + CHECK_TIME_SECONDS # Check for aged out files periodically
         if @queued_bucket_files.length > 0 and @current_disk_usage < MAX_DISK_USAGE
           @@mutex.synchronize do
             bucket_file = @queued_bucket_files.shift
@@ -187,18 +190,7 @@ class BucketFileCache
           # Nothing to do or disk full
           if Time.now > check_time
             check_time = Time.now + CHECK_TIME_SECONDS
-            # Delete any files that aren't reserved and are old
-            removed_files = []
-            @bucket_file_hash.each do |bucket_path, bucket_file|
-              deleted = bucket_file.age_check
-              if deleted
-                removed_files << bucket_path
-                @current_disk_usage -= bucket_file.size
-              end
-            end
-            removed_files.each do |bucket_path|
-              @bucket_file_hash.delete(bucket_path)
-            end
+            age_out_files()
           end
           sleep(1)
         end
@@ -216,8 +208,9 @@ class BucketFileCache
     return instance().reserve(bucket_path)
   end
 
-  def self.unreserve(bucket_path)
-    return instance().unreserve(bucket_path)
+  # @param bucket_file_or_path [BucketFile|String] BucketFile or its bucket path
+  def self.unreserve(bucket_file_or_path)
+    return instance().unreserve(bucket_file_or_path)
   end
 
   def hint(bucket_paths)
@@ -240,20 +233,45 @@ class BucketFileCache
     end
   end
 
-  def unreserve(bucket_path)
+  # Callers hold the BucketFile returned by reserve() but the cache is keyed by
+  # bucket path, so accept either and normalize to the path.
+  # @param bucket_file_or_path [BucketFile|String] BucketFile or its bucket path
+  def unreserve(bucket_file_or_path)
+    if bucket_file_or_path.is_a?(BucketFile)
+      bucket_path = bucket_file_or_path.bucket_path
+    else
+      bucket_path = bucket_file_or_path
+    end
     @@mutex.synchronize do
       bucket_file = @bucket_file_hash[bucket_path]
       if bucket_file
         bucket_file.unreserve
         if bucket_file.reservation_count <= 0 and !@queued_bucket_files.include?(bucket_file)
           @current_disk_usage -= bucket_file.size
-          @bucket_file_hash.delete(bucket_file)
+          @bucket_file_hash.delete(bucket_path)
         end
       end
     end
   end
 
   # Private
+
+  # Delete the local copy of any file that is old and no longer reserved.
+  # Files still waiting in the download queue are skipped because the download
+  # thread would re-add their size to @current_disk_usage after removal.
+  def age_out_files
+    @@mutex.synchronize do
+      @bucket_file_hash.delete_if do |_bucket_path, bucket_file|
+        next false if @queued_bucket_files.include?(bucket_file)
+        if bucket_file.age_check
+          @current_disk_usage -= bucket_file.size
+          true
+        else
+          false
+        end
+      end
+    end
+  end
 
   def create_bucket_file(bucket_path)
     bucket_file = @bucket_file_hash[bucket_path]

--- a/openc3/spec/utilities/bucket_file_cache_spec.rb
+++ b/openc3/spec/utilities/bucket_file_cache_spec.rb
@@ -26,8 +26,10 @@ describe BucketFileCache do
 
   before(:each) do
     @downloads = []
+    @download_buckets = []
     @client = double("getClient").as_null_object
     allow(@client).to receive(:get_object) do |bucket:, key:, path:|
+      @download_buckets << bucket
       @downloads << key
       FileUtils.mkdir_p(File.dirname(path))
       if File.extname(key) == '.gz'
@@ -137,6 +139,7 @@ describe BucketFileCache do
         expect(File.read(bucket_file.local_path)).to eql contents
         expect(bucket_file.size).to eql file_size
         expect(@downloads).to eql [bucket_path]
+        expect(@download_buckets).to eql [ENV['OPENC3_LOGS_BUCKET']]
       end
 
       it "returns false and doesn't re-download an existing local file" do

--- a/openc3/spec/utilities/bucket_file_cache_spec.rb
+++ b/openc3/spec/utilities/bucket_file_cache_spec.rb
@@ -1,0 +1,415 @@
+# encoding: ascii-8bit
+
+# Copyright 2026 OpenC3, Inc.
+# All Rights Reserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE.md for more details.
+#
+# This file may also be used under the terms of a commercial license
+# if purchased from OpenC3, Inc.
+
+require "spec_helper"
+require "ostruct"
+require "zlib"
+require "openc3/utilities/bucket_file_cache"
+
+describe BucketFileCache do
+  let(:prefix) { "DEFAULT/decom_logs/tlm/INST/20200101" }
+  let(:bucket_path) { "#{prefix}/20200101000000000000000__20200101001000000000000__DEFAULT__INST__HEALTH_STATUS__rt__decom.bin" }
+  let(:bucket_path2) { "#{prefix}/20200101001000000000000__20200101002000000000000__DEFAULT__INST__HEALTH_STATUS__rt__decom.bin" }
+  let(:bucket_path3) { "#{prefix}/20200101002000000000000__20200101003000000000000__DEFAULT__INST__HEALTH_STATUS__rt__decom.bin" }
+  let(:contents) { 'x' * 100 }
+  let(:file_size) { contents.length }
+
+  before(:each) do
+    @downloads = []
+    @client = double("getClient").as_null_object
+    allow(@client).to receive(:get_object) do |bucket:, key:, path:|
+      @downloads << key
+      FileUtils.mkdir_p(File.dirname(path))
+      if File.extname(key) == '.gz'
+        Zlib::GzipWriter.open(path) { |gz| gz.write(contents) }
+      else
+        File.write(path, contents)
+      end
+      OpenStruct.new
+    end
+    allow(OpenC3::Bucket).to receive(:getClient).and_return(@client)
+    # Don't pay the retry backoff in tests
+    allow_any_instance_of(BucketFile).to receive(:sleep)
+    BucketFileCache.class_variable_set(:@@instance, nil)
+    @caches = []
+  end
+
+  after(:each) do
+    @caches.each do |cache|
+      thread = cache.instance_variable_get(:@thread)
+      if thread
+        thread.kill
+        thread.join
+      end
+      FileUtils.remove_dir(cache.cache_dir, true)
+    end
+    BucketFileCache.class_variable_set(:@@instance, nil)
+  end
+
+  # Build a cache and install it as the singleton. BucketFile#retrieve reaches
+  # back through BucketFileCache.instance for cache_dir so the singleton has to
+  # be set before anything downloads. The background thread is killed by
+  # default so tests drive the cache deterministically.
+  def build_cache(run_thread: false)
+    cache = BucketFileCache.new
+    @caches << cache
+    BucketFileCache.class_variable_set(:@@instance, cache)
+    unless run_thread
+      thread = cache.instance_variable_get(:@thread)
+      thread.kill
+      thread.join
+      cache.instance_variable_set(:@thread, nil)
+    end
+    cache
+  end
+
+  def hash(cache)
+    cache.instance_variable_get(:@bucket_file_hash)
+  end
+
+  def queue(cache)
+    cache.instance_variable_get(:@queued_bucket_files)
+  end
+
+  def disk_usage(cache)
+    cache.instance_variable_get(:@current_disk_usage)
+  end
+
+  # Poll rather than sleep a fixed amount so thread tests aren't slower than
+  # they need to be. Returns whether the block came true before timing out.
+  def wait_until(timeout = 5)
+    start = Time.now
+    while (Time.now - start) < timeout
+      return true if yield
+      sleep(0.05)
+    end
+    false
+  end
+
+  describe BucketFile do
+    describe "initialize" do
+      it "builds the topic prefix from the bucket path" do
+        expect(BucketFile.new("DEFAULT/decom_logs/tlm/INST/x.bin").topic_prefix).to eql "DEFAULT__DECOM__{INST}"
+        expect(BucketFile.new("DEFAULT/decom_logs/cmd/INST/x.bin").topic_prefix).to eql "DEFAULT__DECOMCMD__{INST}"
+        expect(BucketFile.new("OTHER/raw_logs/tlm/INST2/x.bin").topic_prefix).to eql "OTHER__TELEMETRY__{INST2}"
+        expect(BucketFile.new("OTHER/raw_logs/cmd/INST2/x.bin").topic_prefix).to eql "OTHER__COMMAND__{INST2}"
+      end
+
+      it "starts unreserved with no local file" do
+        bucket_file = BucketFile.new(bucket_path)
+        expect(bucket_file.bucket_path).to eql bucket_path
+        expect(bucket_file.reservation_count).to eql 0
+        expect(bucket_file.local_path).to be_nil
+        expect(bucket_file.size).to eql 0
+        expect(bucket_file.error).to be_nil
+      end
+    end
+
+    describe "retrieve" do
+      it "downloads the file and records its size" do
+        build_cache()
+        bucket_file = BucketFile.new(bucket_path)
+        expect(bucket_file.retrieve(@client)).to be true
+        expect(File.read(bucket_file.local_path)).to eql contents
+        expect(bucket_file.size).to eql file_size
+        expect(@downloads).to eql [bucket_path]
+      end
+
+      it "returns false and doesn't re-download an existing local file" do
+        build_cache()
+        bucket_file = BucketFile.new(bucket_path)
+        expect(bucket_file.retrieve(@client)).to be true
+        expect(bucket_file.retrieve(@client)).to be false
+        expect(@downloads.length).to eql 1
+      end
+
+      it "uncompresses gzipped files and drops the .gz" do
+        build_cache()
+        bucket_file = BucketFile.new("#{bucket_path}.gz")
+        expect(bucket_file.retrieve(@client)).to be true
+        expect(File.extname(bucket_file.local_path)).to eql ".bin"
+        expect(File.read(bucket_file.local_path)).to eql contents
+        expect(bucket_file.size).to eql file_size
+      end
+
+      it "retries three times then raises and records the error" do
+        build_cache()
+        allow(@client).to receive(:get_object).and_raise("bucket down")
+        bucket_file = BucketFile.new(bucket_path)
+        expect { bucket_file.retrieve(@client) }.to raise_error(/bucket down/)
+        expect(bucket_file.error.message).to match(/bucket down/)
+        expect(bucket_file.local_path).to be_nil
+      end
+    end
+
+    describe "reserve / unreserve" do
+      it "counts reservations and deletes the local file at zero" do
+        build_cache()
+        bucket_file = BucketFile.new(bucket_path)
+        expect(bucket_file.reserve).to be true
+        expect(bucket_file.reservation_count).to eql 1
+        local_path = bucket_file.local_path
+
+        expect(bucket_file.reserve).to be false # already local
+        expect(bucket_file.reservation_count).to eql 2
+
+        expect(bucket_file.unreserve).to eql 1
+        expect(File.exist?(local_path)).to be true
+
+        expect(bucket_file.unreserve).to eql 0
+        expect(File.exist?(local_path)).to be false
+        expect(bucket_file.local_path).to be_nil
+      end
+    end
+
+    describe "age_check" do
+      it "keeps files that are young" do
+        build_cache()
+        bucket_file = BucketFile.new(bucket_path)
+        bucket_file.retrieve(@client)
+        expect(bucket_file.age_check).to be false
+        expect(bucket_file.local_path).to_not be_nil
+      end
+
+      it "keeps old files that are still reserved" do
+        stub_const("BucketFile::MAX_AGE_SECONDS", 0)
+        build_cache()
+        bucket_file = BucketFile.new(bucket_path)
+        bucket_file.reserve
+        expect(bucket_file.age_check).to be false
+        expect(File.exist?(bucket_file.local_path)).to be true
+      end
+
+      it "deletes old files that are unreserved" do
+        stub_const("BucketFile::MAX_AGE_SECONDS", 0)
+        build_cache()
+        bucket_file = BucketFile.new(bucket_path)
+        bucket_file.retrieve(@client)
+        local_path = bucket_file.local_path
+        expect(bucket_file.age_check).to be true
+        expect(File.exist?(local_path)).to be false
+      end
+    end
+  end
+
+  describe "instance" do
+    it "returns the same singleton" do
+      cache = BucketFileCache.instance
+      @caches << cache
+      expect(BucketFileCache.instance).to be cache
+    end
+  end
+
+  describe "hint" do
+    it "queues files in priority order without downloading them" do
+      cache = build_cache()
+      BucketFileCache.hint([bucket_path, bucket_path2, bucket_path3])
+      expect(queue(cache).map(&:bucket_path)).to eql [bucket_path, bucket_path2, bucket_path3]
+      expect(hash(cache).keys).to match_array [bucket_path, bucket_path2, bucket_path3]
+      expect(@downloads).to be_empty
+      expect(disk_usage(cache)).to eql 0
+    end
+
+    it "reuses files already in the cache" do
+      cache = build_cache()
+      BucketFileCache.hint([bucket_path])
+      existing = hash(cache)[bucket_path]
+      BucketFileCache.hint([bucket_path])
+      expect(hash(cache).length).to eql 1
+      expect(hash(cache)[bucket_path]).to be existing
+      expect(queue(cache).length).to eql 1
+    end
+  end
+
+  describe "reserve" do
+    it "downloads the file, tracks disk usage, and dequeues it" do
+      cache = build_cache()
+      BucketFileCache.hint([bucket_path])
+      bucket_file = BucketFileCache.reserve(bucket_path)
+      expect(bucket_file.bucket_path).to eql bucket_path
+      expect(bucket_file.reservation_count).to eql 1
+      expect(File.exist?(bucket_file.local_path)).to be true
+      expect(queue(cache)).to be_empty
+      expect(disk_usage(cache)).to eql file_size
+    end
+
+    it "counts a second reservation of the same path only once against disk usage" do
+      cache = build_cache()
+      first = BucketFileCache.reserve(bucket_path)
+      second = BucketFileCache.reserve(bucket_path)
+      expect(second).to be first
+      expect(first.reservation_count).to eql 2
+      expect(@downloads.length).to eql 1
+      expect(disk_usage(cache)).to eql file_size
+    end
+  end
+
+  describe "unreserve" do
+    # streaming_object_file_reader.rb and message_file_reader.rb both hand back
+    # the BucketFile they got from reserve(), not its bucket path. Looking that
+    # up in the path-keyed hash returned nil and the whole call did nothing.
+    it "releases the reservation when given a BucketFile" do
+      cache = build_cache()
+      bucket_file = BucketFileCache.reserve(bucket_path)
+      local_path = bucket_file.local_path
+
+      BucketFileCache.unreserve(bucket_file)
+
+      expect(bucket_file.reservation_count).to eql 0
+      expect(File.exist?(local_path)).to be false
+      expect(hash(cache)).to be_empty
+      expect(disk_usage(cache)).to eql 0
+    end
+
+    it "releases the reservation when given a bucket path" do
+      cache = build_cache()
+      bucket_file = BucketFileCache.reserve(bucket_path)
+      local_path = bucket_file.local_path
+
+      BucketFileCache.unreserve(bucket_path)
+
+      expect(bucket_file.reservation_count).to eql 0
+      expect(File.exist?(local_path)).to be false
+      expect(hash(cache)).to be_empty
+      expect(disk_usage(cache)).to eql 0
+    end
+
+    it "keeps the file until every reservation is released" do
+      cache = build_cache()
+      bucket_file = BucketFileCache.reserve(bucket_path)
+      BucketFileCache.reserve(bucket_path)
+
+      BucketFileCache.unreserve(bucket_file)
+      expect(File.exist?(bucket_file.local_path)).to be true
+      expect(hash(cache).length).to eql 1
+      expect(disk_usage(cache)).to eql file_size
+
+      BucketFileCache.unreserve(bucket_file)
+      expect(hash(cache)).to be_empty
+      expect(disk_usage(cache)).to eql 0
+    end
+
+    it "ignores paths that aren't cached" do
+      cache = build_cache()
+      expect { BucketFileCache.unreserve("#{prefix}/not_cached.bin") }.to_not raise_error
+      expect(disk_usage(cache)).to eql 0
+    end
+
+    it "leaves still-queued files in the cache" do
+      cache = build_cache()
+      # hint() queues the file; reserve() dequeues it, so re-queue by hand to
+      # model the window where the download thread hasn't picked it up yet
+      bucket_file = BucketFileCache.reserve(bucket_path)
+      queue(cache) << bucket_file
+
+      BucketFileCache.unreserve(bucket_file)
+
+      expect(hash(cache).length).to eql 1
+      expect(disk_usage(cache)).to eql file_size
+    end
+
+    # The headline symptom: @current_disk_usage ratchets up until it passes
+    # MAX_DISK_USAGE and the download thread stops fetching anything at all.
+    it "does not leak disk usage or hash entries across many cycles" do
+      cache = build_cache()
+      20.times do |i|
+        path = "#{prefix}/cycle_#{i}__DEFAULT__INST__HEALTH_STATUS__rt__decom.bin"
+        bucket_file = BucketFileCache.reserve(path)
+        BucketFileCache.unreserve(bucket_file)
+      end
+      expect(hash(cache)).to be_empty
+      expect(disk_usage(cache)).to eql 0
+      expect(Dir.children(cache.cache_dir)).to be_empty
+    end
+  end
+
+  describe "age out" do
+    it "deletes old unreserved files and reclaims their disk usage" do
+      stub_const("BucketFile::MAX_AGE_SECONDS", 0)
+      cache = build_cache()
+      bucket_file = BucketFileCache.reserve(bucket_path)
+      local_path = bucket_file.local_path
+      # Release the reservation without going through the cache so the entry
+      # is left behind for the sweep to find
+      bucket_file.instance_variable_set(:@reservation_count, 0)
+
+      cache.age_out_files
+
+      expect(hash(cache)).to be_empty
+      expect(disk_usage(cache)).to eql 0
+      expect(File.exist?(local_path)).to be false
+    end
+
+    it "keeps reserved files no matter how old" do
+      stub_const("BucketFile::MAX_AGE_SECONDS", 0)
+      cache = build_cache()
+      bucket_file = BucketFileCache.reserve(bucket_path)
+
+      cache.age_out_files
+
+      expect(hash(cache).length).to eql 1
+      expect(File.exist?(bucket_file.local_path)).to be true
+      expect(disk_usage(cache)).to eql file_size
+    end
+
+    # A queued file's size is added by the download thread after the fact, so
+    # dropping its hash entry here would orphan those bytes in @current_disk_usage
+    it "skips files still waiting in the download queue" do
+      stub_const("BucketFile::MAX_AGE_SECONDS", 0)
+      cache = build_cache()
+      BucketFileCache.hint([bucket_path])
+
+      cache.age_out_files
+
+      expect(hash(cache).length).to eql 1
+      expect(queue(cache).length).to eql 1
+    end
+  end
+
+  describe "background thread" do
+    it "downloads hinted files and tracks their disk usage" do
+      cache = build_cache(run_thread: true)
+      BucketFileCache.hint([bucket_path, bucket_path2])
+
+      expect(wait_until { queue(cache).empty? and disk_usage(cache) == file_size * 2 }).to be true
+      expect(@downloads).to match_array [bucket_path, bucket_path2]
+    end
+
+    # check_time was recomputed at the top of every loop iteration, so
+    # Time.now > check_time was never true and the sweep never ran
+    it "runs the age out sweep on the check interval" do
+      stub_const("BucketFileCache::CHECK_TIME_SECONDS", 1)
+      stub_const("BucketFile::MAX_AGE_SECONDS", 0)
+      cache = build_cache(run_thread: true)
+      BucketFileCache.hint([bucket_path])
+      expect(wait_until { queue(cache).empty? and disk_usage(cache) == file_size }).to be true
+      bucket_file = hash(cache)[bucket_path]
+      expect(File.exist?(bucket_file.local_path)).to be true
+
+      expect(wait_until { hash(cache).empty? }).to be true
+      expect(disk_usage(cache)).to eql 0
+      expect(bucket_file.local_path).to be_nil
+    end
+
+    it "stops downloading once disk usage passes MAX_DISK_USAGE" do
+      stub_const("BucketFileCache::MAX_DISK_USAGE", file_size)
+      cache = build_cache(run_thread: true)
+      BucketFileCache.hint([bucket_path, bucket_path2, bucket_path3])
+
+      expect(wait_until { disk_usage(cache) >= file_size }).to be true
+      sleep(0.5) # Give the thread a chance to (wrongly) keep going
+      expect(@downloads).to eql [bucket_path]
+      expect(queue(cache).length).to eql 2
+    end
+  end
+end

--- a/openc3/spec/utilities/bucket_file_cache_spec.rb
+++ b/openc3/spec/utilities/bucket_file_cache_spec.rb
@@ -316,6 +316,24 @@ describe BucketFileCache do
       expect(disk_usage(cache)).to eql 0
     end
 
+    # Releasing to zero drops the entry, so a later reserve of the same path
+    # builds a different BucketFile. A duplicate close of the old object must
+    # not reach through the path to that replacement.
+    it "ignores a stale BucketFile that no longer owns its path" do
+      cache = build_cache()
+      stale = BucketFileCache.reserve(bucket_path)
+      BucketFileCache.unreserve(stale)
+      current = BucketFileCache.reserve(bucket_path)
+      expect(current).to_not be stale
+
+      BucketFileCache.unreserve(stale)
+
+      expect(current.reservation_count).to eql 1
+      expect(File.exist?(current.local_path)).to be true
+      expect(hash(cache)[bucket_path]).to be current
+      expect(disk_usage(cache)).to eql file_size
+    end
+
     it "ignores paths that aren't cached" do
       cache = build_cache()
       expect { BucketFileCache.unreserve("#{prefix}/not_cached.bin") }.to_not raise_error

--- a/openc3/spec/utilities/bucket_file_cache_spec.rb
+++ b/openc3/spec/utilities/bucket_file_cache_spec.rb
@@ -85,6 +85,20 @@ describe BucketFileCache do
     cache.instance_variable_get(:@current_disk_usage)
   end
 
+  # Count linear scans of the download queue Array performed by the block.
+  # Queue membership is checked once per file close in unreserve() and once per
+  # cache entry in age_out_files(), so an Array#include? there is O(cache size)
+  # on a hot path -- it has to be an O(1) lookup instead.
+  def count_queue_scans(cache)
+    scans = 0
+    queue(cache).define_singleton_method(:include?) do |item|
+      scans += 1
+      super(item)
+    end
+    yield
+    scans
+  end
+
   # Poll rather than sleep a fixed amount so thread tests aren't slower than
   # they need to be. Returns whether the block came true before timing out.
   def wait_until(timeout = 5)
@@ -307,15 +321,17 @@ describe BucketFileCache do
 
     it "leaves still-queued files in the cache" do
       cache = build_cache()
-      # hint() queues the file; reserve() dequeues it, so re-queue by hand to
-      # model the window where the download thread hasn't picked it up yet
-      bucket_file = BucketFileCache.reserve(bucket_path)
-      queue(cache) << bucket_file
+      # hint() queues both; reserving the first dequeues only that one, so the
+      # second is still waiting on the download thread
+      BucketFileCache.hint([bucket_path, bucket_path2])
+      BucketFileCache.reserve(bucket_path)
+      queued = hash(cache)[bucket_path2]
 
-      BucketFileCache.unreserve(bucket_file)
+      BucketFileCache.unreserve(queued)
 
-      expect(hash(cache).length).to eql 1
-      expect(disk_usage(cache)).to eql file_size
+      # Dropping it here would orphan the size the download thread is about to add
+      expect(hash(cache)).to have_key bucket_path2
+      expect(queue(cache)).to eql [queued]
     end
 
     # The headline symptom: @current_disk_usage ratchets up until it passes
@@ -373,6 +389,48 @@ describe BucketFileCache do
 
       expect(hash(cache).length).to eql 1
       expect(queue(cache).length).to eql 1
+    end
+  end
+
+  describe "queue membership cost" do
+    # A historical query hints its whole file list, so both the queue and the
+    # cache hold one entry per log file in the requested range
+    it "does not rescan the download queue for every cache entry when aging out" do
+      stub_const("BucketFile::MAX_AGE_SECONDS", 0)
+      cache = build_cache()
+      paths = (0...20).map { |i| "#{prefix}/scan_#{i}__DEFAULT__INST__HEALTH_STATUS__rt__decom.bin" }
+      BucketFileCache.hint(paths)
+      # Reserve the first half, which dequeues them, then drop the reservations
+      # so the sweep is free to take them
+      swept = paths[0...10]
+      swept.each do |path|
+        BucketFileCache.reserve(path).instance_variable_set(:@reservation_count, 0)
+      end
+
+      scans = count_queue_scans(cache) { cache.age_out_files }
+
+      expect(scans).to eql 0
+      expect(hash(cache).keys).to match_array paths[10..]
+      expect(queue(cache).length).to eql 10
+    end
+
+    it "does not scan the download queue on unreserve" do
+      cache = build_cache()
+      BucketFileCache.hint((0...20).map { |i| "#{prefix}/queued_#{i}__DEFAULT__INST__HEALTH_STATUS__rt__decom.bin" })
+      bucket_file = BucketFileCache.reserve(bucket_path)
+
+      scans = count_queue_scans(cache) { BucketFileCache.unreserve(bucket_file) }
+
+      expect(scans).to eql 0
+      expect(hash(cache)).to_not have_key bucket_path
+    end
+
+    it "keeps the queue index in step with the queue itself" do
+      cache = build_cache(run_thread: true)
+      BucketFileCache.hint([bucket_path, bucket_path2])
+      expect(wait_until { queue(cache).empty? }).to be true
+      # The download thread dequeued both, so neither is queued any longer
+      expect(cache.instance_variable_get(:@queued_path_hash)).to be_empty
     end
   end
 


### PR DESCRIPTION
### What changed

- Accept a BucketFile or a bucket path in BucketFileCache#unreserve; both call sites (streaming_object_file_reader, message_file_reader) pass the object, which missed the path-keyed hash and made the call a no-op
- Delete the hash entry by bucket_path rather than by BucketFile, so the entry is dropped even when a path was passed
- Initialize check_time outside the download thread loop; it was reset every iteration so the age out sweep never fired
- Extract the sweep into age_out_files, holding @@mutex while it mutates @bucket_file_hash and skipping files still queued for download
- Add specs covering unreserve, age out, retrieve, hint and the MAX_DISK_USAGE cutoff; 8 fail without the fixes above

### Why it changed

BucketFileCache leaked temp files and ratcheted @current_disk_usage up until it passed MAX_DISK_USAGE, at which point the thread stopped downloading historical data entirely.

### Testing strategy

Unit test